### PR TITLE
Implement project metadata creation

### DIFF
--- a/apps/mc-pack-tool/__tests__/createProject.test.ts
+++ b/apps/mc-pack-tool/__tests__/createProject.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+import { createProject } from '../src/main/projects';
+import { ProjectMetadataSchema } from '../src/minecraft/project';
+
+const baseDir = path.join(os.tmpdir(), `projtest-${uuid()}`);
+
+beforeAll(() => {
+	fs.mkdirSync(baseDir, { recursive: true });
+});
+
+afterAll(() => {
+	fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe('createProject', () => {
+	it('writes valid project.json', () => {
+		createProject(baseDir, 'Test', '1.20');
+		const data = JSON.parse(fs.readFileSync(path.join(baseDir, 'Test', 'project.json'), 'utf-8'));
+		const meta = ProjectMetadataSchema.parse(data);
+		expect(meta.name).toBe('Test');
+		expect(meta.version).toBe('1.20');
+	});
+});

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -5,7 +5,8 @@ declare global {
   interface Window {
     /** API provided by the preload script for communicating with the main process */
     electronAPI?: {
-      listProjects: () => Promise<string[]>;
+      listProjects: () => Promise<{ name: string; version: string }[]>;
+      createProject: (name: string, version: string) => void;
       openProject: (name: string) => void;
       onOpenProject: (listener: (event: unknown, path: string) => void) => void;
       exportProject: (path: string, out: string) => void;

--- a/apps/mc-pack-tool/src/main/projects.ts
+++ b/apps/mc-pack-tool/src/main/projects.ts
@@ -1,0 +1,10 @@
+import fs from 'fs';
+import path from 'path';
+import { ProjectMetadata } from "../minecraft/project";
+
+export function createProject(baseDir: string, name: string, version: string): void {
+  const dir = path.join(baseDir, name);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const meta: ProjectMetadata = { name, version, assets: [] };
+  fs.writeFileSync(path.join(dir, "project.json"), JSON.stringify(meta, null, 2));
+}

--- a/apps/mc-pack-tool/src/minecraft/project.ts
+++ b/apps/mc-pack-tool/src/minecraft/project.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const ProjectMetadataSchema = z.object({
+  name: z.string(),
+  version: z.string(),
+  assets: z.array(z.string()).default([]),
+});
+
+export type ProjectMetadata = z.infer<typeof ProjectMetadataSchema>;

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -5,16 +5,21 @@ import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
   // Retrieve a list of saved projects
-  listProjects: () => ipcRenderer.invoke('list-projects') as Promise<string[]>,
-
-  // Request the main process to open or create a project
+  listProjects: () =>
+  ipcRenderer.invoke('list-projects') as Promise<{ name: string; version: string }[]>,
+  
+  // Create a new project
+  createProject: (name: string, version: string) =>
+  ipcRenderer.invoke('create-project', name, version),
+  
+  // Request the main process to open an existing project
   openProject: (name: string) => ipcRenderer.invoke('open-project', name),
-
+  
   // Listen for the main window reporting that a project has been opened
   onOpenProject: (listener: (event: unknown, path: string) => void) =>
-    ipcRenderer.on('project-opened', listener),
-
+  ipcRenderer.on('project-opened', listener),
+  
   // Ask the main process to export the current project as a zip
   exportProject: (path: string, out: string) =>
-    ipcRenderer.invoke('export-project', path, out),
+  ipcRenderer.invoke('export-project', path, out),
 });

--- a/apps/mc-pack-tool/src/renderer/manager/ProjectManager.tsx
+++ b/apps/mc-pack-tool/src/renderer/manager/ProjectManager.tsx
@@ -4,29 +4,60 @@ import React, { useEffect, useState } from 'react';
 // project selection dialog used in game engines like Godot.
 
 const ProjectManager: React.FC = () => {
-  const [projects, setProjects] = useState<string[]>([]);
+  interface ProjectInfo { name: string; version: string }
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [name, setName] = useState('');
+  const [version, setVersion] = useState('');
+
+  const refresh = () => {
+    window.electronAPI?.listProjects().then(setProjects);
+  };
 
   useEffect(() => {
     // Fetch the list of projects from the main process when the component loads
-    window.electronAPI?.listProjects().then(setProjects);
+    refresh();
   }, []);
 
-  const handleOpen = (name: string) => {
-    window.electronAPI?.openProject(name);
+  const handleOpen = (n: string) => {
+    window.electronAPI?.openProject(n);
+  };
+
+  const handleCreate = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !version) return;
+    window.electronAPI?.createProject(name, version).then(refresh);
+    setName('');
+    setVersion('');
   };
 
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Projects</h1>
+      <form onSubmit={handleCreate} className="space-x-2 mb-4">
+        <input
+          className="border px-1"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Name"
+        />
+        <input
+          className="border px-1"
+          value={version}
+          onChange={e => setVersion(e.target.value)}
+          placeholder="Version"
+        />
+        <button className="border px-2" type="submit">
+          Create
+        </button>
+      </form>
       <ul className="space-y-1">
         {projects.map(p => (
-          <li key={p}>
-            {/* Each project name opens the corresponding folder */}
+          <li key={p.name}>
             <button
               className="underline text-blue-600"
-              onClick={() => handleOpen(p)}
-            >
-              {p}
+              onClick={() => handleOpen(p.name)}
+>
+              {p.name} ({p.version})
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Summary
- add zod schema for project metadata
- write project.json when creating a project
- preload/list/create projects with version info
- extend project manager UI with creation form
- test project creation

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a9141b6c88331a5728079255d8d3c