### PR TITLE
Fetch and cache client assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An Electron-based tool for creating Minecraft resource packs. The interface is d
 ## Features
 
 - **Project Manager** – similar to Godot's launcher, it keeps a list of projects with their name, Minecraft version and chosen assets. You can create new packs or open and edit existing ones.
-- **Asset Selection** – search for vanilla textures by name using the `minecraft-data` and `minecraft-assets` libraries. Add assets to your project with a click.
+- **Asset Selection** – textures are pulled from Mojang's version manifest and cached locally for quick searching.
 - **Asset Editing** – when an asset is added it is copied into the correct folder structure inside the project. Files can be opened in Explorer/Finder or with the default program for that type. Any changes on disk instantly appear in the UI.
 - **Live Asset Browser** – the editor window lists all files in the project directory and automatically reloads when something changes.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.

--- a/apps/mc-pack-tool/__tests__/addTexture.test.ts
+++ b/apps/mc-pack-tool/__tests__/addTexture.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+import { createProject } from '../src/main/projects';
+import { addTexture } from '../src/main/assets';
+
+const tmpDir = path.join(os.tmpdir(), `texturetest-${uuid()}`);
+
+beforeAll(() => {
+		fs.mkdirSync(tmpDir, { recursive: true });
+});
+
+afterAll(() => {
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('addTexture', () => {
+it('copies texture into project folder', async () => {
+createProject(tmpDir, 'Pack', '1.21.1');
+const proj = path.join(tmpDir, 'Pack');
+await addTexture(proj, 'block/stone.png');
+const dest = path.join(proj, 'assets', 'minecraft', 'textures', 'block', 'stone.png');
+expect(fs.existsSync(dest)).toBe(true);
+});
+});

--- a/apps/mc-pack-tool/package.json
+++ b/apps/mc-pack-tool/package.json
@@ -58,7 +58,6 @@
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
     "electron-squirrel-startup": "^1.0.1",
-    "minecraft-assets": "^1.15.0",
     "minecraft-data": "^3.89.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -2,14 +2,16 @@
 export {};
 
 declare global {
-  interface Window {
-    /** API provided by the preload script for communicating with the main process */
-    electronAPI?: {
-      listProjects: () => Promise<{ name: string; version: string }[]>;
-      createProject: (name: string, version: string) => void;
-      openProject: (name: string) => void;
-      onOpenProject: (listener: (event: unknown, path: string) => void) => void;
-      exportProject: (path: string, out: string) => void;
-    };
-  }
+	interface Window {
+		/** API provided by the preload script for communicating with the main process */
+		electronAPI?: {
+			listProjects: () => Promise<{ name: string; version: string }[]>;
+			createProject: (name: string, version: string) => void;
+			openProject: (name: string) => void;
+			onOpenProject: (listener: (event: unknown, path: string) => void) => void;
+			exportProject: (path: string, out: string) => void;
+			addTexture: (project: string, name: string) => void;
+			listTextures: (project: string) => Promise<string[]>;
+		};
+	}
 }

--- a/apps/mc-pack-tool/src/index.ts
+++ b/apps/mc-pack-tool/src/index.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import fs from 'fs';
 import { exportPack } from './main/exporter';
 import { createProject } from './main/projects';
+import { addTexture, listTextures } from './main/assets';
 import { ProjectMetadataSchema } from './minecraft/project';
 
 declare const MANAGER_WEBPACK_ENTRY: string;
@@ -17,79 +18,87 @@ declare const MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 let managerWindow: BrowserWindow | null = null;
 let mainWindow: BrowserWindow | null = null;
 
-// Directory that stores the local projects on disk.  Under Electron's
+// Directory that stores the local projects on disk.	Under Electron's
 // userData path to keep everything self contained.
 const projectsDir = path.join(app.getPath('userData'), 'projects');
 
-// Create the initial project manager window.  This lists available projects
+// Create the initial project manager window.	 This lists available projects
 // and lets the user open one or create a new one.
 const createManagerWindow = () => {
-  managerWindow = new BrowserWindow({
-    width: 600,
-    height: 400,
-    webPreferences: {
-      nodeIntegration: true,
-      preload: MANAGER_PRELOAD_WEBPACK_ENTRY,
-    },
-  });
-  managerWindow.loadURL(MANAGER_WEBPACK_ENTRY);
+	managerWindow = new BrowserWindow({
+		width: 600,
+		height: 400,
+		webPreferences: {
+			nodeIntegration: true,
+			preload: MANAGER_PRELOAD_WEBPACK_ENTRY,
+		},
+	});
+	managerWindow.loadURL(MANAGER_WEBPACK_ENTRY);
 };
 
 // Create the main application window for a specific project.
 // Once the window loads we emit the selected project path so the renderer can
 // display its contents.
 const createMainWindow = (projectPath: string) => {
-  mainWindow = new BrowserWindow({
-    width: 800,
-    height: 600,
-    webPreferences: {
-      nodeIntegration: true,
-      preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
-    },
-  });
-  mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
-  mainWindow.webContents.on('did-finish-load', () => {
-    mainWindow?.webContents.send('project-opened', projectPath);
-  });
+	mainWindow = new BrowserWindow({
+		width: 800,
+		height: 600,
+		webPreferences: {
+			nodeIntegration: true,
+			preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+		},
+	});
+	mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+	mainWindow.webContents.on('did-finish-load', () => {
+		mainWindow?.webContents.send('project-opened', projectPath);
+	});
 };
 
 // Return the names of sub directories within the projects folder.
 ipcMain.handle('list-projects', async () => {
-    if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
-    return fs
-      .readdirSync(projectsDir)
-      .filter(f => fs.statSync(path.join(projectsDir, f)).isDirectory())
-      .map(name => {
-        const metaPath = path.join(projectsDir, name, 'project.json');
-        if (fs.existsSync(metaPath)) {
-          try {
-            const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-            const meta = ProjectMetadataSchema.parse(data);
-            return { name: meta.name, version: meta.version };
-          } catch {
-            return { name, version: 'unknown' };
-          }
-        }
-        return { name, version: 'unknown' };
-      });
+		if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
+		return fs
+			.readdirSync(projectsDir)
+			.filter(f => fs.statSync(path.join(projectsDir, f)).isDirectory())
+			.map(name => {
+				const metaPath = path.join(projectsDir, name, 'project.json');
+				if (fs.existsSync(metaPath)) {
+					try {
+						const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+						const meta = ProjectMetadataSchema.parse(data);
+						return { name: meta.name, version: meta.version };
+					} catch {
+						return { name, version: 'unknown' };
+					}
+				}
+				return { name, version: 'unknown' };
+			});
 });
 
 // Create or open an existing project and show it in the main window.
 ipcMain.handle('open-project', (_e, name: string) => {
-  const projectPath = path.join(projectsDir, name);
-  if (!fs.existsSync(projectPath)) fs.mkdirSync(projectPath, { recursive: true });
-  if (managerWindow) managerWindow.close();
-  createMainWindow(projectPath);
-  });
+	const projectPath = path.join(projectsDir, name);
+	if (!fs.existsSync(projectPath)) fs.mkdirSync(projectPath, { recursive: true });
+	if (managerWindow) managerWindow.close();
+	createMainWindow(projectPath);
+	});
 
-  ipcMain.handle('create-project', (_e, name: string, version: string) => {
-  if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
-  createProject(projectsDir, name, version);
-  });
+ipcMain.handle('create-project', (_e, name: string, version: string) => {
+	if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
+	createProject(projectsDir, name, version);
+});
+
+ipcMain.handle('add-texture', (_e, projectPath: string, texture: string) => {
+void addTexture(projectPath, texture);
+});
+
+ipcMain.handle('list-textures', (_e, projectPath: string) => {
+return listTextures(projectPath);
+});
 
 // Trigger pack export for the given project directory.
 ipcMain.handle('export-project', (_e, projectPath: string, out: string) => {
-  exportPack(projectPath, out);
+	exportPack(projectPath, out);
 });
 
 // Once Electron is ready show the manager window.
@@ -99,15 +108,15 @@ app.whenReady().then(createManagerWindow);
 // and Linux, but keep it alive on macOS so the user can re-open it from the
 // dock.
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+	if (process.platform !== 'darwin') {
+		app.quit();
+	}
 });
 
 // macOS re-creates the window when the dock icon is clicked and there are no
 // other windows open.
 app.on('activate', () => {
-  if (BrowserWindow.getAllWindows().length === 0) {
-    createManagerWindow();
-  }
+	if (BrowserWindow.getAllWindows().length === 0) {
+		createManagerWindow();
+	}
 });

--- a/apps/mc-pack-tool/src/main/assets.ts
+++ b/apps/mc-pack-tool/src/main/assets.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import path from 'path';
+import { app as electronApp } from 'electron';
+import os from 'os';
+import unzipper from 'unzipper';
+import { ProjectMetadataSchema } from '../minecraft/project';
+
+/** URL pointing to Mojang's version manifest which lists all official releases. */
+const VERSION_MANIFEST =
+        'https://launchermeta.mojang.com/mc/game/version_manifest.json';
+
+/** Base directory used to store cached client JARs and extracted assets. */
+const basePath = electronApp?.getPath
+        ? electronApp.getPath('userData')
+        : os.tmpdir();
+/** Directory that contains one sub folder per Minecraft version. */
+const cacheDir = path.join(basePath, 'assets-cache');
+
+/**
+ * Fetch a JSON document from the given URL.
+ * @throws if the request fails.
+ */
+async function fetchJson(url: string): Promise<any> {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Failed to fetch ${url}`);
+        return res.json();
+}
+
+/**
+ * Download a file from the given URL and write it to disk.
+ */
+async function downloadFile(url: string, dest: string): Promise<void> {
+        const res = await fetch(url);
+        if (!res.ok) throw new Error(`Failed to download ${url}`);
+        await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+        const array = new Uint8Array(await res.arrayBuffer());
+        await fs.promises.writeFile(dest, array);
+}
+
+/**
+ * Ensure that the assets for the given Minecraft version are downloaded and
+ * extracted. Returns the path to the extracted client folder.
+ */
+async function ensureAssets(version: string): Promise<string> {
+        const base = path.join(cacheDir, version);
+        const assetsPath = path.join(base, 'client');
+        const texDir = path.join(assetsPath, 'assets', 'minecraft', 'textures');
+        if (fs.existsSync(texDir)) return assetsPath;
+
+	await fs.promises.mkdir(base, { recursive: true });
+        const manifest = await fetchJson(VERSION_MANIFEST);
+        const entry = manifest.versions.find((v: any) => v.id === version);
+        if (!entry) throw new Error(`Version ${version} not found`);
+        const ver = await fetchJson(entry.url);
+        const jarUrl = ver.downloads.client.url;
+        const jarPath = path.join(base, 'client.jar');
+        if (!fs.existsSync(jarPath)) await downloadFile(jarUrl, jarPath);
+	await new Promise((resolve, reject) => {
+	fs.createReadStream(jarPath)
+		.pipe(unzipper.Extract({ path: assetsPath }))
+		.on('close', resolve)
+		.on('error', reject);
+	});
+	return assetsPath;
+}
+
+/**
+ * Recursively list all texture paths available for the given project version.
+ */
+export async function listTextures(projectPath: string): Promise<string[]> {
+        const metaPath = path.join(projectPath, 'project.json');
+        const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+        const meta = ProjectMetadataSchema.parse(data);
+        const root = await ensureAssets(meta.version);
+        const texRoot = path.join(root, 'assets', 'minecraft', 'textures');
+        const out: string[] = [];
+        const walk = (dir: string) => {
+                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                        const p = path.join(dir, entry.name);
+                        if (entry.isDirectory()) {
+                                walk(p);
+                        } else if (entry.name.endsWith('.png')) {
+                                out.push(path.relative(texRoot, p));
+                        }
+                }
+        };
+        walk(texRoot);
+        return out;
+}
+
+/**
+ * Copy the given texture from the cached client into the project directory and
+ * update the project's metadata so it will be packaged.
+ */
+export async function addTexture(projectPath: string, texture: string): Promise<void> {
+        const metaPath = path.join(projectPath, 'project.json');
+        const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+        const meta = ProjectMetadataSchema.parse(data);
+        const root = await ensureAssets(meta.version);
+        const src = path.join(root, 'assets', 'minecraft', 'textures', texture);
+        const dest = path.join(projectPath, 'assets', 'minecraft', 'textures', texture);
+        await fs.promises.mkdir(path.dirname(dest), { recursive: true });
+        await fs.promises.copyFile(src, dest);
+        meta.assets.push(`assets/minecraft/textures/${texture}`);
+        fs.writeFileSync(metaPath, JSON.stringify(meta, null, 2));
+}

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -4,22 +4,30 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-  // Retrieve a list of saved projects
-  listProjects: () =>
-  ipcRenderer.invoke('list-projects') as Promise<{ name: string; version: string }[]>,
-  
-  // Create a new project
-  createProject: (name: string, version: string) =>
-  ipcRenderer.invoke('create-project', name, version),
-  
-  // Request the main process to open an existing project
-  openProject: (name: string) => ipcRenderer.invoke('open-project', name),
-  
-  // Listen for the main window reporting that a project has been opened
-  onOpenProject: (listener: (event: unknown, path: string) => void) =>
-  ipcRenderer.on('project-opened', listener),
-  
-  // Ask the main process to export the current project as a zip
-  exportProject: (path: string, out: string) =>
-  ipcRenderer.invoke('export-project', path, out),
+	// Retrieve a list of saved projects
+	listProjects: () =>
+	ipcRenderer.invoke('list-projects') as Promise<{ name: string; version: string }[]>,
+	
+	// Create a new project
+	createProject: (name: string, version: string) =>
+	ipcRenderer.invoke('create-project', name, version),
+	
+	// Request the main process to open an existing project
+	openProject: (name: string) => ipcRenderer.invoke('open-project', name),
+	
+	// Listen for the main window reporting that a project has been opened
+	onOpenProject: (listener: (event: unknown, path: string) => void) =>
+	ipcRenderer.on('project-opened', listener),
+	
+	// Ask the main process to export the current project as a zip
+	exportProject: (path: string, out: string) =>
+	ipcRenderer.invoke('export-project', path, out),
+
+	// Download and copy a texture from the cached client jar
+	addTexture: (project: string, name: string) =>
+	ipcRenderer.invoke('add-texture', project, name),
+
+	// Retrieve the list of texture paths for this project
+	listTextures: (project: string) =>
+	ipcRenderer.invoke('list-textures', project),
 });

--- a/apps/mc-pack-tool/src/renderer/main/App.tsx
+++ b/apps/mc-pack-tool/src/renderer/main/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import AssetBrowser from './AssetBrowser';
+import AssetSelector from './AssetSelector';
 
 // Main React component shown in the editor window.  It waits for the main
 // process to notify which project is open and then displays an AssetBrowser for
@@ -22,6 +23,7 @@ const App: React.FC = () => {
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Project: {projectPath}</h1>
+      <AssetSelector path={projectPath} />
       {/* Display the files inside the selected project */}
       <AssetBrowser path={projectPath} />
     </div>

--- a/apps/mc-pack-tool/src/renderer/main/AssetSelector.tsx
+++ b/apps/mc-pack-tool/src/renderer/main/AssetSelector.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+	path: string;
+}
+
+const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
+	const [all, setAll] = useState<string[]>([]);
+	const [query, setQuery] = useState('');
+
+	useEffect(() => {
+		window.electronAPI?.listTextures(projectPath).then(list => setAll(list));
+	}, [projectPath]);
+
+	const filtered = all.filter(n => n.includes(query));
+
+	const handleSelect = (name: string) => {
+		window.electronAPI?.addTexture(projectPath, name);
+	};
+
+	return (
+		<div className="mb-4">
+			<input
+				className="border px-1 mb-2"
+				placeholder="Search texture"
+				value={query}
+				onChange={e => setQuery(e.target.value)}
+			/>
+			<ul className="h-48 overflow-y-scroll border p-1">
+				{filtered.map(n => (
+					<li key={n}>
+						<button className="underline text-blue-600" onClick={() => handleSelect(n)}>
+							{n}
+						</button>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+};
+
+export default AssetSelector;

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
         "electron-squirrel-startup": "^1.0.1",
-        "minecraft-assets": "^1.15.0",
         "minecraft-data": "^3.89.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -9615,12 +9614,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/minecraft-assets": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/minecraft-assets/-/minecraft-assets-1.15.0.tgz",
-      "integrity": "sha512-hHHNyzrUUaCDEVdupvgnu8hM5y/6t6R8V2m9LgkFRlz0XENII2uDevO5pXkLlz80K0SazHWzd8+zcHitmt6c0Q==",
-      "license": "MIT"
     },
     "node_modules/minecraft-data": {
       "version": "3.89.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,9 @@
 {
   "name": "minecraft-resource-packer",
   "private": true,
-  "workspaces": ["apps/mc-pack-tool"],
+  "workspaces": [
+    "apps/mc-pack-tool"
+  ],
   "scripts": {
     "dev": "npm --workspace apps/mc-pack-tool run start",
     "lint": "npm --workspace apps/mc-pack-tool run lint",


### PR DESCRIPTION
## Summary
- pull textures from Mojang's version manifest instead of minecraft-assets
- cache each client.jar and list textures via IPC
- update preload and global types for new API
- adapt AssetSelector to use cached textures
- add inline docs for asset helpers
- adjust test for async asset copying

## Testing
- `npm run lint`
- `npm test` *(fails: ENETUNREACH)*


------
https://chatgpt.com/codex/tasks/task_e_684a94635c3c8331974f36750bfff8a6