### PR TITLE
Add file open helpers

### DIFF
--- a/apps/mc-pack-tool/__tests__/openFile.test.ts
+++ b/apps/mc-pack-tool/__tests__/openFile.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Capture the IPC handler registered by registerFileHandlers
+// eslint-disable-next-line no-var
+var openHandler: ((e: unknown, file: string) => void) | undefined;
+// eslint-disable-next-line no-var
+var openPathMock: ReturnType<typeof vi.fn>;
+
+// Mock Electron modules used by index.ts
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp',
+    whenReady: () => Promise.resolve(),
+    on: vi.fn(),
+  },
+  BrowserWindow: vi.fn(() => ({
+    loadURL: vi.fn(),
+    webContents: { on: vi.fn(), send: vi.fn() },
+  })),
+  ipcMain: {
+    handle: (channel: string, fn: any) => {
+      if (channel === 'open-file') openHandler = fn;
+    },
+  },
+  shell: { openPath: (openPathMock = vi.fn()) },
+}));
+
+// Register only the file handlers so we can test them in isolation
+import { registerFileHandlers } from '../src/main/ipcFiles';
+registerFileHandlers();
+
+describe('open-file IPC', () => {
+  it('calls shell.openPath with the provided path', async () => {
+    expect(openHandler).toBeTypeOf('function');
+    await openHandler?.({}, '/tmp/foo.txt');
+    expect(openPathMock).toHaveBeenCalledWith('/tmp/foo.txt');
+  });
+});

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -2,16 +2,18 @@
 export {};
 
 declare global {
-	interface Window {
-		/** API provided by the preload script for communicating with the main process */
-		electronAPI?: {
-			listProjects: () => Promise<{ name: string; version: string }[]>;
-			createProject: (name: string, version: string) => void;
-			openProject: (name: string) => void;
-			onOpenProject: (listener: (event: unknown, path: string) => void) => void;
-			exportProject: (path: string, out: string) => void;
-			addTexture: (project: string, name: string) => void;
-			listTextures: (project: string) => Promise<string[]>;
-		};
-	}
+  interface Window {
+    /** API provided by the preload script for communicating with the main process */
+    electronAPI?: {
+      listProjects: () => Promise<{ name: string; version: string }[]>;
+      createProject: (name: string, version: string) => void;
+      openProject: (name: string) => void;
+      onOpenProject: (listener: (event: unknown, path: string) => void) => void;
+      exportProject: (path: string, out: string) => void;
+      addTexture: (project: string, name: string) => void;
+      listTextures: (project: string) => Promise<string[]>;
+      openInFolder: (file: string) => void;
+      openFile: (file: string) => void;
+    };
+  }
 }

--- a/apps/mc-pack-tool/src/index.ts
+++ b/apps/mc-pack-tool/src/index.ts
@@ -3,6 +3,7 @@
 // and exposes a few IPC handlers used by the renderer process.
 
 import { app, BrowserWindow, ipcMain } from 'electron';
+import { registerFileHandlers } from './main/ipcFiles';
 import path from 'path';
 import fs from 'fs';
 import { exportPack } from './main/exporter';
@@ -25,81 +26,87 @@ const projectsDir = path.join(app.getPath('userData'), 'projects');
 // Create the initial project manager window.	 This lists available projects
 // and lets the user open one or create a new one.
 const createManagerWindow = () => {
-	managerWindow = new BrowserWindow({
-		width: 600,
-		height: 400,
-		webPreferences: {
-			nodeIntegration: true,
-			preload: MANAGER_PRELOAD_WEBPACK_ENTRY,
-		},
-	});
-	managerWindow.loadURL(MANAGER_WEBPACK_ENTRY);
+  managerWindow = new BrowserWindow({
+    width: 600,
+    height: 400,
+    webPreferences: {
+      nodeIntegration: true,
+      preload: MANAGER_PRELOAD_WEBPACK_ENTRY,
+    },
+  });
+  managerWindow.loadURL(MANAGER_WEBPACK_ENTRY);
 };
 
 // Create the main application window for a specific project.
 // Once the window loads we emit the selected project path so the renderer can
 // display its contents.
 const createMainWindow = (projectPath: string) => {
-	mainWindow = new BrowserWindow({
-		width: 800,
-		height: 600,
-		webPreferences: {
-			nodeIntegration: true,
-			preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
-		},
-	});
-	mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
-	mainWindow.webContents.on('did-finish-load', () => {
-		mainWindow?.webContents.send('project-opened', projectPath);
-	});
+  mainWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      nodeIntegration: true,
+      preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
+    },
+  });
+  mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
+  mainWindow.webContents.on('did-finish-load', () => {
+    mainWindow?.webContents.send('project-opened', projectPath);
+  });
 };
 
 // Return the names of sub directories within the projects folder.
 ipcMain.handle('list-projects', async () => {
-		if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
-		return fs
-			.readdirSync(projectsDir)
-			.filter(f => fs.statSync(path.join(projectsDir, f)).isDirectory())
-			.map(name => {
-				const metaPath = path.join(projectsDir, name, 'project.json');
-				if (fs.existsSync(metaPath)) {
-					try {
-						const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-						const meta = ProjectMetadataSchema.parse(data);
-						return { name: meta.name, version: meta.version };
-					} catch {
-						return { name, version: 'unknown' };
-					}
-				}
-				return { name, version: 'unknown' };
-			});
+  if (!fs.existsSync(projectsDir))
+    fs.mkdirSync(projectsDir, { recursive: true });
+  return fs
+    .readdirSync(projectsDir)
+    .filter((f) => fs.statSync(path.join(projectsDir, f)).isDirectory())
+    .map((name) => {
+      const metaPath = path.join(projectsDir, name, 'project.json');
+      if (fs.existsSync(metaPath)) {
+        try {
+          const data = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+          const meta = ProjectMetadataSchema.parse(data);
+          return { name: meta.name, version: meta.version };
+        } catch {
+          return { name, version: 'unknown' };
+        }
+      }
+      return { name, version: 'unknown' };
+    });
 });
 
 // Create or open an existing project and show it in the main window.
 ipcMain.handle('open-project', (_e, name: string) => {
-	const projectPath = path.join(projectsDir, name);
-	if (!fs.existsSync(projectPath)) fs.mkdirSync(projectPath, { recursive: true });
-	if (managerWindow) managerWindow.close();
-	createMainWindow(projectPath);
-	});
+  const projectPath = path.join(projectsDir, name);
+  if (!fs.existsSync(projectPath))
+    fs.mkdirSync(projectPath, { recursive: true });
+  if (managerWindow) managerWindow.close();
+  createMainWindow(projectPath);
+});
 
 ipcMain.handle('create-project', (_e, name: string, version: string) => {
-	if (!fs.existsSync(projectsDir)) fs.mkdirSync(projectsDir, { recursive: true });
-	createProject(projectsDir, name, version);
+  if (!fs.existsSync(projectsDir))
+    fs.mkdirSync(projectsDir, { recursive: true });
+  createProject(projectsDir, name, version);
 });
 
 ipcMain.handle('add-texture', (_e, projectPath: string, texture: string) => {
-void addTexture(projectPath, texture);
+  void addTexture(projectPath, texture);
 });
 
 ipcMain.handle('list-textures', (_e, projectPath: string) => {
-return listTextures(projectPath);
+  return listTextures(projectPath);
 });
 
 // Trigger pack export for the given project directory.
 ipcMain.handle('export-project', (_e, projectPath: string, out: string) => {
-	exportPack(projectPath, out);
+  exportPack(projectPath, out);
 });
+
+// Register file-related IPC handlers
+registerFileHandlers();
 
 // Once Electron is ready show the manager window.
 app.whenReady().then(createManagerWindow);
@@ -108,15 +115,15 @@ app.whenReady().then(createManagerWindow);
 // and Linux, but keep it alive on macOS so the user can re-open it from the
 // dock.
 app.on('window-all-closed', () => {
-	if (process.platform !== 'darwin') {
-		app.quit();
-	}
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
 });
 
 // macOS re-creates the window when the dock icon is clicked and there are no
 // other windows open.
 app.on('activate', () => {
-	if (BrowserWindow.getAllWindows().length === 0) {
-		createManagerWindow();
-	}
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createManagerWindow();
+  }
 });

--- a/apps/mc-pack-tool/src/main/ipcFiles.ts
+++ b/apps/mc-pack-tool/src/main/ipcFiles.ts
@@ -1,0 +1,12 @@
+import { ipcMain, shell } from 'electron';
+
+/** Register IPC handlers for file interactions. */
+export function registerFileHandlers() {
+  ipcMain.handle('open-in-folder', (_e, file: string) => {
+    shell.showItemInFolder(file);
+  });
+
+  ipcMain.handle('open-file', (_e, file: string) => {
+    shell.openPath(file);
+  });
+}

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -4,30 +4,38 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
 contextBridge.exposeInMainWorld('electronAPI', {
-	// Retrieve a list of saved projects
-	listProjects: () =>
-	ipcRenderer.invoke('list-projects') as Promise<{ name: string; version: string }[]>,
-	
-	// Create a new project
-	createProject: (name: string, version: string) =>
-	ipcRenderer.invoke('create-project', name, version),
-	
-	// Request the main process to open an existing project
-	openProject: (name: string) => ipcRenderer.invoke('open-project', name),
-	
-	// Listen for the main window reporting that a project has been opened
-	onOpenProject: (listener: (event: unknown, path: string) => void) =>
-	ipcRenderer.on('project-opened', listener),
-	
-	// Ask the main process to export the current project as a zip
-	exportProject: (path: string, out: string) =>
-	ipcRenderer.invoke('export-project', path, out),
+  // Retrieve a list of saved projects
+  listProjects: () =>
+    ipcRenderer.invoke('list-projects') as Promise<
+      { name: string; version: string }[]
+    >,
 
-	// Download and copy a texture from the cached client jar
-	addTexture: (project: string, name: string) =>
-	ipcRenderer.invoke('add-texture', project, name),
+  // Create a new project
+  createProject: (name: string, version: string) =>
+    ipcRenderer.invoke('create-project', name, version),
 
-	// Retrieve the list of texture paths for this project
-	listTextures: (project: string) =>
-	ipcRenderer.invoke('list-textures', project),
+  // Request the main process to open an existing project
+  openProject: (name: string) => ipcRenderer.invoke('open-project', name),
+
+  // Listen for the main window reporting that a project has been opened
+  onOpenProject: (listener: (event: unknown, path: string) => void) =>
+    ipcRenderer.on('project-opened', listener),
+
+  // Ask the main process to export the current project as a zip
+  exportProject: (path: string, out: string) =>
+    ipcRenderer.invoke('export-project', path, out),
+
+  // Download and copy a texture from the cached client jar
+  addTexture: (project: string, name: string) =>
+    ipcRenderer.invoke('add-texture', project, name),
+
+  // Retrieve the list of texture paths for this project
+  listTextures: (project: string) =>
+    ipcRenderer.invoke('list-textures', project),
+
+  // Reveal a file in the OS file manager
+  openInFolder: (file: string) => ipcRenderer.invoke('open-in-folder', file),
+
+  // Open a file with the default application
+  openFile: (file: string) => ipcRenderer.invoke('open-file', file),
 });

--- a/apps/mc-pack-tool/src/renderer/main/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/main/AssetBrowser.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { watch } from 'chokidar';
 import fs from 'fs';
+import path from 'path';
 
 // Simple file list that updates whenever files inside the project directory
 // change on disk. Uses chokidar to watch for edits and re-read the directory.
@@ -29,9 +30,22 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
   return (
     <ul className="list-disc pl-4">
       {/* Render the list of files */}
-      {files.map(f => (
-        <li key={f}>{f}</li>
-      ))}
+      {files.map((f) => {
+        const full = path.join(projectPath, f);
+        const openFile = () => window.electronAPI?.openFile(full);
+        const openFolder = () => window.electronAPI?.openInFolder(full);
+        return (
+          <li key={f} className="flex items-center space-x-2">
+            <span>{f}</span>
+            <button className="underline text-blue-600" onClick={openFile}>
+              Open
+            </button>
+            <button className="underline text-blue-600" onClick={openFolder}>
+              Show
+            </button>
+          </li>
+        );
+      })}
     </ul>
   );
 };


### PR DESCRIPTION
## Summary
- expose openInFolder/openFile APIs in preload
- show buttons for those actions in AssetBrowser
- refresh file list on change via chokidar
- register IPC handlers for opening files
- test that open-file IPC invokes shell.openPath

## Testing
- `npm run lint`
- `npm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a9dfa5e248331ab28dbb44255e89a