### PR TITLE
Add export pack button

### DIFF
--- a/apps/mc-pack-tool/__tests__/App.test.tsx
+++ b/apps/mc-pack-tool/__tests__/App.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 
 import App from '../src/renderer/components/App';
 
@@ -13,15 +13,18 @@ vi.mock('../src/renderer/components/AssetBrowser', () => ({
 
 describe('App', () => {
   let openHandler: ((e: unknown, path: string) => void) | undefined;
+  const exportProject = vi.fn();
 
   beforeEach(() => {
     interface ElectronAPI {
       onOpenProject: (cb: (e: unknown, path: string) => void) => void;
+      exportProject: (path: string) => void;
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       onOpenProject: (cb) => {
         openHandler = cb;
       },
+      exportProject,
     };
   });
 
@@ -32,5 +35,15 @@ describe('App', () => {
       openHandler?.({}, '/tmp/proj');
     });
     expect(screen.getByText(/Project: \/tmp\/proj/)).toBeInTheDocument();
+  });
+
+  it('invokes exportProject when button clicked', () => {
+    render(<App />);
+    act(() => {
+      openHandler?.({}, '/tmp/proj');
+    });
+    const btn = screen.getByText('Export Pack');
+    fireEvent.click(btn);
+    expect(exportProject).toHaveBeenCalledWith('/tmp/proj');
   });
 });

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -9,7 +9,7 @@ declare global {
       createProject: (name: string, version: string) => void;
       openProject: (name: string) => void;
       onOpenProject: (listener: (event: unknown, path: string) => void) => void;
-      exportProject: (path: string, out: string) => void;
+      exportProject: (path: string) => void;
       addTexture: (project: string, name: string) => void;
       listTextures: (project: string) => Promise<string[]>;
       openInFolder: (file: string) => void;

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -22,8 +22,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('project-opened', listener),
 
   // Ask the main process to export the current project as a zip
-  exportProject: (path: string, out: string) =>
-    ipcRenderer.invoke('export-project', path, out),
+  exportProject: (path: string) =>
+    ipcRenderer.invoke('export-project', path),
 
   // Download and copy a texture from the cached client jar
   addTexture: (project: string, name: string) =>

--- a/apps/mc-pack-tool/src/renderer/components/App.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/App.tsx
@@ -20,9 +20,21 @@ const App: React.FC = () => {
     return <div className="p-4">No project loaded</div>;
   }
 
+  const handleExport = () => {
+    if (projectPath) {
+      window.electronAPI?.exportProject(projectPath);
+    }
+  };
+
   return (
     <div className="p-4">
       <h1 className="text-xl font-bold mb-2">Project: {projectPath}</h1>
+      <button
+        className="bg-blue-500 text-white px-2 py-1 rounded mb-2"
+        onClick={handleExport}
+      >
+        Export Pack
+      </button>
       <AssetSelector path={projectPath} />
       {/* Display the files inside the selected project */}
       <AssetBrowser path={projectPath} />


### PR DESCRIPTION
## Summary
- expose an `exportProject` IPC handler that prompts for a zip file and exports
- expose the handler via the preload script and global types
- add Export Pack button to the main app UI
- test that clicking the button triggers the export API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ab8d4dbd883319c9870ce9caf1d84