### PR TITLE
Fix Windows path separator in listTextures

### DIFF
--- a/apps/mc-pack-tool/__tests__/assets.test.ts
+++ b/apps/mc-pack-tool/__tests__/assets.test.ts
@@ -143,6 +143,13 @@ describe('listTextures', () => {
     const list = await listTextures(projDir);
     expect(list).toContain('block/foo.png');
   });
+
+  it('uses forward slashes', async () => {
+    const list = await listTextures(projDir);
+    for (const item of list) {
+      expect(item).not.toContain('\\');
+    }
+  });
 });
 
 describe('listVersions', () => {

--- a/apps/mc-pack-tool/src/main/assets.ts
+++ b/apps/mc-pack-tool/src/main/assets.ts
@@ -97,7 +97,8 @@ export async function listTextures(projectPath: string): Promise<string[]> {
       if (entry.isDirectory()) {
         walk(p);
       } else if (entry.name.endsWith('.png')) {
-        out.push(path.relative(texRoot, p));
+        const rel = path.relative(texRoot, p);
+        out.push(rel.split(path.sep).join('/'));
       }
     }
   };


### PR DESCRIPTION
## Summary
- normalize texture path separators in `listTextures`
- test that path separators are forward slashes

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ac9251c6c83318841ea5d1feb58dc