### PR TITLE
Fix texture protocol and show textures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Electron-based tool for creating Minecraft resource packs. The interface is d
 
 - **Project Manager** – integrated into the main window, it keeps a list of projects with their name, Minecraft version and chosen assets. You can create new packs or open and edit existing ones without switching windows.
 - **Asset Selection** – textures are pulled from Mojang's version manifest and cached locally for quick searching.
-- **Secure Previews** – images load through a custom `texture://` protocol so `file://` access is never required.
+- **Secure Previews** – images load through custom `texture://` and `ptex://` protocols so `file://` access is never required.
 - **Asset Editing** – when an asset is added it is copied into the correct folder structure inside the project. Files can be opened in Explorer/Finder or with the default program for that type. Any changes on disk instantly appear in the UI.
 - **Live Asset Browser** – the editor window lists all files in the project directory and automatically reloads when something changes.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -13,7 +13,10 @@ vi.mock('chokidar', () => ({
 
 vi.mock('fs', () => ({
   default: {
-    readdirSync: vi.fn(() => ['a.txt', 'b.png']),
+    readdirSync: vi.fn(() => [
+      { name: 'a.txt', isDirectory: () => false },
+      { name: 'b.png', isDirectory: () => false },
+    ]),
   },
 }));
 

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -29,5 +29,7 @@ describe('AssetBrowser', () => {
     render(<AssetBrowser path="/proj" />);
     expect(screen.getByText('a.txt')).toBeInTheDocument();
     expect(screen.getByText('b.png')).toBeInTheDocument();
+    const img = screen.getByAltText('b.png') as HTMLImageElement;
+    expect(img.src).toContain('ptex://b.png');
   });
 });

--- a/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
@@ -21,7 +21,7 @@ describe('AssetSelector', () => {
       getTextureUrl,
     };
     listTextures.mockResolvedValue(['grass.png', 'stone.png']);
-    getTextureUrl.mockResolvedValue('texture:///img/grass.png');
+    getTextureUrl.mockResolvedValue('texture://img/grass.png');
     vi.clearAllMocks();
   });
 
@@ -33,7 +33,7 @@ describe('AssetSelector', () => {
     const item = await screen.findByText('grass.png');
     const img = (await screen.findByAltText('grass.png')) as HTMLImageElement;
     expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'grass.png');
-    expect(img.src).toContain('texture:///img/grass.png');
+    expect(img.src).toContain('texture://img/grass.png');
     fireEvent.click(item);
     expect(addTexture).toHaveBeenCalledWith('/proj', 'grass.png');
   });

--- a/apps/mc-pack-tool/forge.config.ts
+++ b/apps/mc-pack-tool/forge.config.ts
@@ -26,6 +26,9 @@ const config: ForgeConfig = {
     new AutoUnpackNativesPlugin({}),
     new WebpackPlugin({
       mainConfig,
+      // Allow images from our custom texture:// protocol in development.
+      devContentSecurityPolicy:
+        "default-src 'self' 'unsafe-inline' data: texture:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
       renderer: {
         config: rendererConfig,
         entryPoints: [

--- a/apps/mc-pack-tool/forge.config.ts
+++ b/apps/mc-pack-tool/forge.config.ts
@@ -28,7 +28,7 @@ const config: ForgeConfig = {
       mainConfig,
       // Allow images from our custom texture:// protocol in development.
       devContentSecurityPolicy:
-        "default-src 'self' 'unsafe-inline' data: texture:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
+        "default-src 'self' 'unsafe-inline' data: texture: ptex:; script-src 'self' 'unsafe-eval' 'unsafe-inline' data:",
       renderer: {
         config: rendererConfig,
         entryPoints: [

--- a/apps/mc-pack-tool/src/index.ts
+++ b/apps/mc-pack-tool/src/index.ts
@@ -15,12 +15,14 @@ import {
   getTexturePath,
   getTextureURL,
   registerTextureProtocol,
+  registerProjectTextureProtocol,
   setActiveProject,
 } from './main/assets';
 import { ProjectMetadataSchema } from './minecraft/project';
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'texture', privileges: { standard: true, secure: true } },
+  { scheme: 'ptex', privileges: { standard: true, secure: true } },
 ]);
 
 // Webpack's DefinePlugin in Electron Forge exposes entry point URLs as
@@ -139,6 +141,7 @@ registerFileHandlers();
 // Once Electron is ready register protocols and show the main window.
 app.whenReady().then(() => {
   registerTextureProtocol(protocol);
+  registerProjectTextureProtocol(protocol);
   createMainWindow();
 });
 

--- a/apps/mc-pack-tool/src/index.ts
+++ b/apps/mc-pack-tool/src/index.ts
@@ -15,6 +15,7 @@ import {
   getTexturePath,
   getTextureURL,
   registerTextureProtocol,
+  setActiveProject,
 } from './main/assets';
 import { ProjectMetadataSchema } from './minecraft/project';
 
@@ -86,6 +87,7 @@ ipcMain.handle('open-project', (_e, name: string) => {
   const projectPath = path.join(projectsDir, name);
   if (!fs.existsSync(projectPath))
     fs.mkdirSync(projectPath, { recursive: true });
+  void setActiveProject(projectPath);
   mainWindow?.webContents.send('project-opened', projectPath);
 });
 

--- a/apps/mc-pack-tool/src/main/assets.ts
+++ b/apps/mc-pack-tool/src/main/assets.ts
@@ -21,6 +21,9 @@ const cacheDir = path.join(basePath, 'assets-cache');
 // is opened so the protocol can resolve relative texture URLs.
 let projectTexturesDir = '';
 let cacheTexturesDir = '';
+// Base path for the currently active project used by the project texture
+// protocol.
+let activeProjectDir = '';
 
 /**
  * Fetch a JSON document from the given URL.
@@ -201,6 +204,15 @@ export function registerTextureProtocol(protocol: Protocol) {
   });
 }
 
+/** Register the `ptex` protocol to serve files from the active project. */
+export function registerProjectTextureProtocol(protocol: Protocol) {
+  protocol.registerFileProtocol('ptex', (request, callback) => {
+    const rel = decodeURI(request.url.replace('ptex://', ''));
+    const file = activeProjectDir ? path.join(activeProjectDir, rel) : '';
+    callback(file);
+  });
+}
+
 /** Update the directories used by the texture protocol for the active project. */
 export async function setActiveProject(projectPath: string): Promise<void> {
   const metaPath = path.join(projectPath, 'project.json');
@@ -214,4 +226,5 @@ export async function setActiveProject(projectPath: string): Promise<void> {
     'minecraft',
     'textures'
   );
+  activeProjectDir = projectPath;
 }

--- a/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
@@ -45,14 +45,10 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
       {files.map((f) => {
         const full = path.join(projectPath, f);
         const name = path.basename(f);
-        const texPrefix = path.join('assets', 'minecraft', 'textures');
         let thumb: string | null = null;
-        if (f.startsWith(texPrefix) && f.endsWith('.png')) {
-          const rel = f
-            .slice(texPrefix.length + 1)
-            .split(path.sep)
-            .join('/');
-          thumb = `texture://${rel}`;
+        if (f.endsWith('.png')) {
+          const rel = f.split(path.sep).join('/');
+          thumb = `ptex://${rel}`;
         }
         const openFile = () => window.electronAPI?.openFile(full);
         const openFolder = () => window.electronAPI?.openInFolder(full);

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -50,3 +50,14 @@ Use spaces for indentation in `.ts` and `.tsx` files and keep React components f
 Tailwind CSS is configured with the `daisyUI` plugin. The `tailwind.config.js`
 file defines a custom **minecraft** theme with matching light and dark modes.
 You can switch themes using the `data-theme` attribute on any element.
+
+## Custom Protocols
+
+Two custom protocols simplify image previews:
+
+- `texture://` serves textures from the Minecraft client cache or the active
+  project. URLs use the form `texture://<relative-path>`.
+- `ptex://` serves files directly from the project directory and is used by the
+  asset browser to preview modified assets.
+
+Both protocols are registered in `src/index.ts` when Electron starts.


### PR DESCRIPTION
## Summary
- update texture protocol to use relative URLs
- recursively display project files in AssetBrowser with thumbnails
- hook up setActiveProject when opening a project
- update tests for new texture URL format

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684adc166ebc83319318aec8314c600a