### PR TITLE
Add headless dev server script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ For more details on project structure and IPC patterns, see `docs/developer-hand
 
 - **Install deps:** `npm i`
 - **Dev server:** `npm run dev` (Electron Forge with reload)
-  - Requires a graphical environment; headless systems fail with an EPIPE error.
+  - Requires a graphical environment. Use `npm run dev:headless` on headless systems to avoid EPIPE errors. This variant also passes `--no-sandbox` so Electron can run as root in CI.
 - **Lint:** `npm run lint`
 - **Unit tests:** `npm test` (Vitest)
 - **Package:** `npm run make`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Install dependencies and launch the development build:
 ```bash
 npm i
 npm run dev
+# Use this variant on servers without a display (runs xvfb and adds --no-sandbox)
+npm run dev:headless
 ```
 
 Run unit tests and lint the codebase with:

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -8,15 +8,15 @@ declare global {
       listProjects: () => Promise<{ name: string; version: string }[]>;
       listVersions: () => Promise<string[]>;
       createProject: (name: string, version: string) => Promise<void>;
-      openProject: (name: string) => void;
+      openProject: (name: string) => Promise<void>;
       onOpenProject: (listener: (event: unknown, path: string) => void) => void;
-      exportProject: (path: string) => void;
-      addTexture: (project: string, name: string) => void;
+      exportProject: (path: string) => Promise<void>;
+      addTexture: (project: string, name: string) => Promise<void>;
       listTextures: (project: string) => Promise<string[]>;
       getTexturePath: (project: string, texture: string) => Promise<string>;
       getTextureUrl: (project: string, texture: string) => Promise<string>;
-      openInFolder: (file: string) => void;
-      openFile: (file: string) => void;
+      openInFolder: (file: string) => Promise<void>;
+      openFile: (file: string) => Promise<void>;
     };
   }
 }

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -15,21 +15,23 @@ const api = {
 
   // Create a new project
   createProject: (name: string, version: string) =>
-    ipcRenderer.invoke('create-project', name, version),
+    ipcRenderer.invoke('create-project', name, version) as Promise<void>,
 
   // Request the main process to open an existing project
-  openProject: (name: string) => ipcRenderer.invoke('open-project', name),
+  openProject: (name: string) =>
+    ipcRenderer.invoke('open-project', name) as Promise<void>,
 
   // Listen for the main window reporting that a project has been opened
   onOpenProject: (listener: (event: unknown, path: string) => void) =>
     ipcRenderer.on('project-opened', listener),
 
   // Ask the main process to export the current project as a zip
-  exportProject: (path: string) => ipcRenderer.invoke('export-project', path),
+  exportProject: (path: string) =>
+    ipcRenderer.invoke('export-project', path) as Promise<void>,
 
   // Download and copy a texture from the cached client jar
   addTexture: (project: string, name: string) =>
-    ipcRenderer.invoke('add-texture', project, name),
+    ipcRenderer.invoke('add-texture', project, name) as Promise<void>,
 
   // Retrieve the list of texture paths for this project
   listTextures: (project: string) =>
@@ -44,15 +46,17 @@ const api = {
     ipcRenderer.invoke('get-texture-url', project, name),
 
   // Reveal a file in the OS file manager
-  openInFolder: (file: string) => ipcRenderer.invoke('open-in-folder', file),
+  openInFolder: (file: string) =>
+    ipcRenderer.invoke('open-in-folder', file) as Promise<void>,
 
   // Open a file with the default application
-  openFile: (file: string) => ipcRenderer.invoke('open-file', file),
+  openFile: (file: string) =>
+    ipcRenderer.invoke('open-file', file) as Promise<void>,
 };
 
 declare global {
   interface Window {
-    electronAPI: typeof api;
+    electronAPI?: typeof api;
   }
 }
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -7,6 +7,12 @@ npm i
 npm run dev
 ```
 
+On servers without a display you can run the headless variant which starts via `xvfb` and passes `--no-sandbox` so Electron can run as root:
+
+```bash
+npm run dev:headless
+```
+
 Run tests:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "dev": "npm --workspace apps/mc-pack-tool run start",
+    "dev:headless": "xvfb-run -a npm --workspace apps/mc-pack-tool run start -- -- --no-sandbox",
     "lint": "npm --workspace apps/mc-pack-tool run lint",
     "test": "npm --workspace apps/mc-pack-tool run test",
     "make": "npm --workspace apps/mc-pack-tool run make",


### PR DESCRIPTION
## Summary
- support `--no-sandbox` in `dev:headless` npm script
- fix type mismatch for `electronAPI`
- document using headless mode with xvfb in README, setup docs, and AGENTS instructions

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684afb652cd88331b910ae3c4a7ea054