### PR TITLE
Add responsive daisyUI drawer

### DIFF
--- a/apps/mc-pack-tool/__tests__/DrawerLayout.test.tsx
+++ b/apps/mc-pack-tool/__tests__/DrawerLayout.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import DrawerLayout from '../src/renderer/components/DrawerLayout';
 import Navbar from '../src/renderer/components/Navbar';
 
@@ -11,24 +11,43 @@ describe('DrawerLayout', () => {
     document.body.innerHTML = '';
   });
 
-  it('renders children and menu', () => {
+  it('collapses to icons on mobile and expands when toggled', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
     render(
       <DrawerLayout>
         <Navbar />
         <div>content</div>
       </DrawerLayout>
     );
+
     expect(screen.getByText('content')).toBeInTheDocument();
-    expect(screen.getByText('Projects')).toBeInTheDocument();
+    const label = screen.getByText('Projects');
+    expect(label.className).toContain('hidden');
+    fireEvent.click(screen.getByTestId('drawer-toggle'));
+    expect(label.className).not.toContain('hidden');
   });
 
-  it('contains drawer toggle checkbox', () => {
+  it('shows full drawer on desktop by default', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+
     render(
       <DrawerLayout>
         <Navbar />
         <div>content</div>
       </DrawerLayout>
     );
-    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+
+    const label = screen.getByText('Projects');
+    expect(label.className).not.toContain('hidden');
+    expect(screen.getByRole('checkbox')).toBeChecked();
   });
 });

--- a/apps/mc-pack-tool/setupTests.ts
+++ b/apps/mc-pack-tool/setupTests.ts
@@ -1,7 +1,15 @@
-import { afterEach } from 'vitest';
+import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
 afterEach(() => {
   cleanup();
 });
+
+if (!window.matchMedia) {
+  window.matchMedia = vi.fn().mockImplementation(() => ({
+    matches: false,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}

--- a/apps/mc-pack-tool/src/renderer/components/DrawerLayout.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/DrawerLayout.tsx
@@ -1,28 +1,50 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface DrawerLayoutProps {
   children: React.ReactNode;
 }
 
 export default function DrawerLayout({ children }: DrawerLayoutProps) {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 768px)');
+    const handler = (e: MediaQueryListEvent) => setOpen(e.matches);
+    setOpen(mq.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
   return (
-    <div className="drawer drawer-mobile min-h-screen bg-base-200">
-      <input id="nav-drawer" type="checkbox" className="drawer-toggle" />
+    <div
+      className={`drawer min-h-screen bg-base-200 ${open ? 'drawer-open' : ''}`}
+    >
+      <input
+        id="nav-drawer"
+        type="checkbox"
+        className="drawer-toggle"
+        checked={open}
+        onChange={(e) => setOpen(e.target.checked)}
+      />
       <div className="drawer-content flex flex-col">{children}</div>
       <div className="drawer-side">
-        <label htmlFor="nav-drawer" className="drawer-overlay" />
-        <aside className="menu p-4 w-20 md:w-60 bg-base-100">
+        {open && <label htmlFor="nav-drawer" className="drawer-overlay" />}
+        <aside className={`menu p-4 bg-base-100 ${open ? 'w-60' : 'w-20'}`}>
           <ul>
             <li>
               <a className="flex items-center">
                 <span className="text-xl">🏠</span>
-                <span className="hidden md:inline ml-2">Projects</span>
+                <span className={`ml-2 ${open ? '' : 'hidden md:inline'}`}>
+                  Projects
+                </span>
               </a>
             </li>
             <li>
               <a className="flex items-center">
                 <span className="text-xl">⚙️</span>
-                <span className="hidden md:inline ml-2">Settings</span>
+                <span className={`ml-2 ${open ? '' : 'hidden md:inline'}`}>
+                  Settings
+                </span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
## Summary
- add stateful DrawerLayout that expands to full menu over 768px
- toggle drawer with hamburger button
- update tests for DrawerLayout
- mock `matchMedia` in test setup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bb956556483319ae869c86e18f1c1