### PR TITLE
Add Navbar theme toggle

### DIFF
--- a/apps/mc-pack-tool/__tests__/Navbar.test.tsx
+++ b/apps/mc-pack-tool/__tests__/Navbar.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import Navbar from '../src/renderer/components/Navbar';
+
+// Ensure consistent DOM for each test
+beforeEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.setAttribute('data-theme', 'minecraft');
+  localStorage.clear();
+});
+
+describe('Navbar', () => {
+  it('displays app title', () => {
+    render(<Navbar />);
+    expect(screen.getByTestId('app-title')).toHaveTextContent(
+      'Minecraft Resource Packer'
+    );
+  });
+
+  it('toggles theme and saves preference', () => {
+    render(<Navbar />);
+    const button = screen.getByLabelText('Toggle theme');
+    fireEvent.click(button);
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+    expect(localStorage.getItem('theme')).toBe('light');
+  });
+});

--- a/apps/mc-pack-tool/src/renderer/components/Navbar.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/Navbar.tsx
@@ -4,7 +4,7 @@ import { toggleTheme } from '../utils/theme';
 export default function Navbar() {
   return (
     <header className="navbar bg-primary text-primary-content">
-      <div className="flex-1 px-2 font-display text-lg">
+      <div className="flex-1 px-2 font-display text-lg" data-testid="app-title">
         <span className="hidden sm:inline">Minecraft Resource Packer</span>
         <span className="sm:hidden">MRP</span>
       </div>
@@ -21,7 +21,7 @@ export default function Navbar() {
         onClick={toggleTheme}
         aria-label="Toggle theme"
       >
-        🌙
+        🌓
       </button>
     </header>
   );

--- a/apps/mc-pack-tool/src/renderer/index.tsx
+++ b/apps/mc-pack-tool/src/renderer/index.tsx
@@ -4,8 +4,8 @@ import App from './components/App';
 import '../index.css';
 
 const saved = localStorage.getItem('theme');
-if (saved === 'dark') {
-  document.documentElement.classList.add('dark');
+if (saved) {
+  document.documentElement.setAttribute('data-theme', saved);
 }
 
 // Bootstraps the main renderer process. This simply mounts the React

--- a/apps/mc-pack-tool/src/renderer/utils/theme.ts
+++ b/apps/mc-pack-tool/src/renderer/utils/theme.ts
@@ -1,6 +1,7 @@
 export const toggleTheme = () => {
   const root = document.documentElement;
-  const next = root.classList.contains('dark') ? 'light' : 'dark';
-  root.classList.toggle('dark');
+  const current = root.getAttribute('data-theme') ?? 'minecraft';
+  const next = current === 'minecraft' ? 'light' : 'minecraft';
+  root.setAttribute('data-theme', next);
   localStorage.setItem('theme', next);
 };


### PR DESCRIPTION
## Summary
- display app title in Navbar
- add daisyUI theme toggle with localStorage support
- test Navbar behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bbc440530833185499522b4dd62b0