### PR TITLE
Add pronounceable project names

### DIFF
--- a/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
@@ -42,6 +42,17 @@ describe('ProjectManager', () => {
     expect(option).toBeInTheDocument();
   });
 
+  it('uses generated name when input left unchanged', async () => {
+    render(<ProjectManager />);
+    await screen.findByRole('button', { name: 'Open' });
+    const input = screen.getByPlaceholderText('Name') as HTMLInputElement;
+    const select = await screen.findByRole('combobox');
+    const generated = input.value;
+    fireEvent.change(select, { target: { value: '1.21' } });
+    fireEvent.click(screen.getByText('Create'));
+    expect(createProject).toHaveBeenCalledWith(generated, '1.21');
+  });
+
   it('creates project via form', async () => {
     render(<ProjectManager />);
     await screen.findByRole('button', { name: 'Open' });

--- a/apps/mc-pack-tool/__tests__/names.test.ts
+++ b/apps/mc-pack-tool/__tests__/names.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { generateProjectName } from '../src/renderer/utils/names';
+
+describe('generateProjectName', () => {
+  it('returns pronounceable name', () => {
+    const name = generateProjectName();
+    expect(name).toMatch(/^[A-Z][a-z]+ [A-Z][a-z]+$/);
+  });
+});

--- a/apps/mc-pack-tool/package.json
+++ b/apps/mc-pack-tool/package.json
@@ -58,7 +58,8 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
     "unzipper": "^0.12.3",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "@testing-library/dom": "^10.4.0"
   },
   "dependencies": {
     "archiver": "^7.0.1",
@@ -71,6 +72,7 @@
     "react-dom": "^19.1.0",
     "react-loader-spinner": "^6.1.6",
     "uuid": "^11.1.0",
-    "zod": "^3.25.63"
+    "zod": "^3.25.63",
+    "unique-names-generator": "^4.7.1"
   }
 }

--- a/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useToast } from './ToastProvider';
+import { generateProjectName } from '../utils/names';
 
 // Lists all available projects and lets the user open them.  Mimics the
 // project selection dialog used in game engines like Godot.
@@ -10,7 +11,7 @@ const ProjectManager: React.FC = () => {
     version: string;
   }
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [name, setName] = useState('');
+  const [name, setName] = useState(() => generateProjectName());
   const [version, setVersion] = useState('');
   const [versions, setVersions] = useState<string[]>([]);
 
@@ -37,7 +38,7 @@ const ProjectManager: React.FC = () => {
       refresh();
       toast('Project created', 'success');
     });
-    setName('');
+    setName(generateProjectName());
     setVersion('');
   };
 

--- a/apps/mc-pack-tool/src/renderer/utils/names.ts
+++ b/apps/mc-pack-tool/src/renderer/utils/names.ts
@@ -1,0 +1,12 @@
+import {
+  uniqueNamesGenerator,
+  adjectives,
+  animals,
+} from 'unique-names-generator';
+
+export const generateProjectName = (): string =>
+  uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+    separator: ' ',
+    style: 'capital',
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.1.0",
         "react-loader-spinner": "^6.1.6",
+        "unique-names-generator": "^4.7.1",
         "uuid": "^11.1.0",
         "zod": "^3.25.63"
       },
@@ -39,6 +40,7 @@
         "@electron-forge/plugin-webpack": "^7.8.1",
         "@electron/fuses": "^1.8.0",
         "@tailwindcss/postcss": "^4.1.10",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@types/archiver": "^6.0.3",
@@ -2644,6 +2646,26 @@
         "tailwindcss": "4.1.10"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
@@ -2761,6 +2783,13 @@
       "dependencies": {
         "@types/readdir-glob": "*"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -6019,6 +6048,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -10561,6 +10597,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -12152,6 +12198,34 @@
         "renderkid": "^3.0.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proc-log": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
@@ -12362,6 +12436,13 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-loader-spinner": {
       "version": "6.1.6",
@@ -14888,6 +14969,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-names-generator": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.7.1.tgz",
+      "integrity": "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unique-slug": {


### PR DESCRIPTION
## Summary
- generate pronounceable names with unique-names-generator
- use generator for default project names
- test name generator and updated ProjectManager flow
- record new packages in package.json

## Testing
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bc22700288331bfb3bc599268f324