### PR TITLE
Implement zoomable asset grid

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 ## 3. Vanilla Asset Browser
 
 - [ ] Version‑scoped folder tree (powered by `minecraft-assets`)
-- [ ] Responsive grid thumbnails (zoom 24–128 px, hover ring)
+- [x] Responsive grid thumbnails (zoom 24–128 px, hover ring)
 - [ ] Drag‑or‑click to add asset to project
 - [ ] Quick filters: Blocks / Items / Entity / UI / Audio
 - [ ] Neutral‑lighting preview pane

--- a/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
@@ -30,11 +30,22 @@ describe('AssetSelector', () => {
     expect(listTextures).toHaveBeenCalledWith('/proj');
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
-    const item = await screen.findByText('grass.png');
+    const button = await screen.findByRole('button', { name: 'grass.png' });
     const img = (await screen.findByAltText('grass.png')) as HTMLImageElement;
     expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'grass.png');
     expect(img.src).toContain('texture://img/grass.png');
-    fireEvent.click(item);
+    fireEvent.click(button);
     expect(addTexture).toHaveBeenCalledWith('/proj', 'grass.png');
+  });
+
+  it('adjusts zoom level with slider', async () => {
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'grass' } });
+    const img = (await screen.findByAltText('grass.png')) as HTMLImageElement;
+    expect(img.style.width).toBe('64px');
+    const slider = screen.getByLabelText('Zoom');
+    fireEvent.change(slider, { target: { value: '100' } });
+    expect(img.style.width).toBe('100px');
   });
 });

--- a/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
@@ -12,6 +12,7 @@ interface TextureInfo {
 const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
   const [all, setAll] = useState<TextureInfo[]>([]);
   const [query, setQuery] = useState('');
+  const [zoom, setZoom] = useState(64);
 
   useEffect(() => {
     const load = async () => {
@@ -37,25 +38,41 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
 
   return (
     <div className="mb-4">
-      <input
-        className="border px-1 mb-2"
-        placeholder="Search texture"
-        value={query}
-        onChange={(e) => setQuery(e.target.value)}
-      />
-      <ul className="h-48 overflow-y-scroll border p-1">
+      <div className="flex items-center gap-2 mb-2">
+        <input
+          className="border px-1 flex-1"
+          placeholder="Search texture"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <input
+          type="range"
+          min={24}
+          max={128}
+          step={1}
+          value={zoom}
+          aria-label="Zoom"
+          data-testid="zoom-range"
+          onChange={(e) => setZoom(Number(e.target.value))}
+          className="range range-xs w-32"
+        />
+      </div>
+      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2 overflow-y-auto h-48">
         {filtered.map((tex) => (
-          <li key={tex.name} className="flex items-center space-x-2">
-            <img src={tex.url} alt={tex.name} className="w-8 h-8" />
-            <button
-              className="underline text-blue-600"
-              onClick={() => handleSelect(tex.name)}
-            >
-              {tex.name}
-            </button>
-          </li>
+          <button
+            key={tex.name}
+            aria-label={tex.name}
+            onClick={() => handleSelect(tex.name)}
+            className="p-1 hover:ring ring-accent rounded"
+          >
+            <img
+              src={tex.url}
+              alt={tex.name}
+              style={{ width: zoom, height: zoom }}
+            />
+          </button>
         ))}
-      </ul>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- implement zoom slider and responsive grid in asset selector
- add tests for zoom control
- check off TODO for asset browser grid

## Testing
- `npm run lint`
- `npm test`
- `npm run dev:headless` *(fails: ENOENT '/workspace/minecraft-resource-packer/apps/mc-pack-tool/.webpack/minecraft/version_manifest.json')*

------
https://chatgpt.com/codex/tasks/task_e_684bdc1c7944833186d2baa94c9a2732