### PR TITLE
Add export summary modal after pack export

### DIFF
--- a/apps/mc-pack-tool/__tests__/ExportSummaryModal.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ExportSummaryModal.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExportSummaryModal from '../src/renderer/components/ExportSummaryModal';
+
+const summary = {
+  fileCount: 5,
+  totalSize: 1024 * 1024,
+  durationMs: 2000,
+  warnings: ['warn'],
+};
+
+describe('ExportSummaryModal', () => {
+  it('displays summary info and warnings', () => {
+    render(<ExportSummaryModal summary={summary} onClose={() => undefined} />);
+    expect(screen.getByText('Export Complete')).toBeInTheDocument();
+    expect(screen.getByText(/5 files/)).toBeInTheDocument();
+    expect(screen.getByText(/1.00 MB/)).toBeInTheDocument();
+    expect(screen.getByText(/2.0 seconds/)).toBeInTheDocument();
+    expect(screen.getByText('warn')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Close clicked', () => {
+    const cb = vi.fn();
+    render(<ExportSummaryModal summary={summary} onClose={cb} />);
+    fireEvent.click(screen.getByText('Close'));
+    expect(cb).toHaveBeenCalled();
+  });
+});

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -12,7 +12,9 @@ declare global {
       createProject: (name: string, version: string) => Promise<void>;
       openProject: (name: string) => Promise<void>;
       onOpenProject: (listener: (event: unknown, path: string) => void) => void;
-      exportProject: (path: string) => Promise<void>;
+      exportProject: (
+        path: string
+      ) => Promise<import('./main/exporter').ExportSummary>;
       addTexture: (project: string, name: string) => Promise<void>;
       listTextures: (project: string) => Promise<string[]>;
       getTexturePath: (project: string, texture: string) => Promise<string>;

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -27,7 +27,9 @@ const api = {
 
   // Ask the main process to export the current project as a zip
   exportProject: (path: string) =>
-    ipcRenderer.invoke('export-project', path) as Promise<void>,
+    ipcRenderer.invoke('export-project', path) as Promise<
+      import('./main/exporter').ExportSummary
+    >,
 
   // Download and copy a texture from the cached client jar
   addTexture: (project: string, name: string) =>

--- a/apps/mc-pack-tool/src/renderer/components/App.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/App.tsx
@@ -2,6 +2,8 @@ import React, { Suspense, useEffect, useState, lazy, useRef } from 'react';
 import ReactCanvasConfetti from 'react-canvas-confetti';
 import Navbar from './Navbar';
 import Spinner from './Spinner';
+import ExportSummaryModal from './ExportSummaryModal';
+import type { ExportSummary } from '../../main/exporter';
 
 const AssetBrowser = lazy(() => import('./AssetBrowser'));
 const AssetSelector = lazy(() => import('./AssetSelector'));
@@ -14,7 +16,8 @@ import DrawerLayout from './DrawerLayout';
 
 const App: React.FC = () => {
   const [projectPath, setProjectPath] = useState<string | null>(null);
-  const confetti = useRef<any>(null);
+  const [summary, setSummary] = useState<ExportSummary | null>(null);
+  const confetti = useRef<((opts: unknown) => void) | null>(null);
 
   useEffect(() => {
     // Listen for the main process telling us which project to load.
@@ -40,7 +43,8 @@ const App: React.FC = () => {
     if (projectPath) {
       window.electronAPI
         ?.exportProject(projectPath)
-        .then(() => {
+        .then((s) => {
+          setSummary(s);
           if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
             confetti.current?.({
               particleCount: 150,
@@ -76,6 +80,12 @@ const App: React.FC = () => {
           <AssetBrowser path={projectPath} />
         </Suspense>
       </main>
+      {summary && (
+        <ExportSummaryModal
+          summary={summary}
+          onClose={() => setSummary(null)}
+        />
+      )}
       <ReactCanvasConfetti
         onInit={({ confetti: c }) => {
           confetti.current = c;

--- a/apps/mc-pack-tool/src/renderer/components/ExportSummaryModal.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ExportSummaryModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ExportSummary } from '../../main/exporter';
+
+export default function ExportSummaryModal({
+  summary,
+  onClose,
+}: {
+  summary: ExportSummary;
+  onClose: () => void;
+}) {
+  const sizeMB = (summary.totalSize / (1024 * 1024)).toFixed(2);
+  const seconds = (summary.durationMs / 1000).toFixed(1);
+  return (
+    <dialog className="modal modal-open" data-testid="export-summary">
+      <div className="modal-box">
+        <h3 className="font-bold text-lg mb-2">Export Complete</h3>
+        <p>
+          {summary.fileCount} files, {sizeMB} MB
+        </p>
+        <p>{seconds} seconds</p>
+        {summary.warnings.length > 0 && (
+          <ul className="mt-2">
+            {summary.warnings.map((w, i) => (
+              <li key={i} className="text-warning">
+                {w}
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="modal-action">
+          <button className="btn" onClick={onClose}>
+            Close
+          </button>
+        </div>
+      </div>
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ExportSummary` data and modify exporter to return stats
- expose summary through IPC to renderer
- show `ExportSummaryModal` after export succeeds
- add tests for modal and update existing `App` tests

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bdcfed5a8833195199d4552bdeb50