### PR TITLE
Add context menu to file explorer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 ## 4. Project File Explorer
 
 - [ ] Real‑time watcher with `chokidar`
-- [ ] Context menu: Reveal, Open, Rename, Delete
+- [x] Context menu: Reveal, Open, Rename, Delete
 - [ ] Dirty badge for changed assets
 - [ ] 🔒 No‑export toggle per file
 - [ ] Custom namespace support (non‑`minecraft` assets)

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
 
@@ -20,6 +20,12 @@ vi.mock('fs', () => ({
   },
 }));
 
+var buildMock: ReturnType<typeof vi.fn>;
+vi.mock('electron', () => {
+  buildMock = vi.fn(() => ({ popup: vi.fn() }));
+  return { Menu: { buildFromTemplate: buildMock } };
+});
+
 describe('AssetBrowser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,5 +36,41 @@ describe('AssetBrowser', () => {
     expect(screen.getByText('a.txt')).toBeInTheDocument();
     const img = screen.getByAltText('b.png') as HTMLImageElement;
     expect(img.src).toContain('ptex://b.png');
+  });
+
+  it('context menu triggers IPC calls', () => {
+    const openInFolder = vi.fn();
+    const openFile = vi.fn();
+    const renameFile = vi.fn();
+    const deleteFile = vi.fn();
+    (
+      window as unknown as {
+        electronAPI: {
+          openInFolder: typeof openInFolder;
+          openFile: typeof openFile;
+          renameFile: typeof renameFile;
+          deleteFile: typeof deleteFile;
+        };
+      }
+    ).electronAPI = {
+      openInFolder,
+      openFile,
+      renameFile,
+      deleteFile,
+    };
+    render(<AssetBrowser path="/proj" />);
+    const item = screen.getByText('a.txt');
+    fireEvent.contextMenu(item);
+    const template = buildMock.mock.calls[0][0];
+    vi.stubGlobal('prompt', () => 'renamed.txt');
+    vi.stubGlobal('confirm', () => true);
+    template[0].click();
+    expect(openInFolder).toHaveBeenCalledWith('/proj/a.txt');
+    template[1].click();
+    expect(openFile).toHaveBeenCalledWith('/proj/a.txt');
+    template[2].click();
+    expect(renameFile).toHaveBeenCalledWith('/proj/a.txt', '/proj/renamed.txt');
+    template[3].click();
+    expect(deleteFile).toHaveBeenCalledWith('/proj/a.txt');
   });
 });

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -19,6 +19,8 @@ declare global {
       getTextureUrl: (project: string, texture: string) => Promise<string>;
       openInFolder: (file: string) => Promise<void>;
       openFile: (file: string) => Promise<void>;
+      renameFile: (oldPath: string, newPath: string) => Promise<void>;
+      deleteFile: (file: string) => Promise<void>;
     };
   }
 }

--- a/apps/mc-pack-tool/src/main/ipcFiles.ts
+++ b/apps/mc-pack-tool/src/main/ipcFiles.ts
@@ -1,4 +1,5 @@
 import { ipcMain, shell } from 'electron';
+import fs from 'fs';
 
 /** Register IPC handlers for file interactions. */
 export function registerFileHandlers() {
@@ -8,5 +9,16 @@ export function registerFileHandlers() {
 
   ipcMain.handle('open-file', (_e, file: string) => {
     shell.openPath(file);
+  });
+
+  ipcMain.handle(
+    'rename-file',
+    async (_e, oldPath: string, newPath: string) => {
+      await fs.promises.rename(oldPath, newPath);
+    }
+  );
+
+  ipcMain.handle('delete-file', async (_e, file: string) => {
+    await fs.promises.unlink(file);
   });
 }

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -52,6 +52,14 @@ const api = {
   // Open a file with the default application
   openFile: (file: string) =>
     ipcRenderer.invoke('open-file', file) as Promise<void>,
+
+  // Rename a file on disk
+  renameFile: (oldPath: string, newPath: string) =>
+    ipcRenderer.invoke('rename-file', oldPath, newPath) as Promise<void>,
+
+  // Delete a file from disk
+  deleteFile: (file: string) =>
+    ipcRenderer.invoke('delete-file', file) as Promise<void>,
 };
 
 if (process.contextIsolated) {

--- a/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { watch } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
+import { Menu } from 'electron';
 
 // Simple file list that updates whenever files inside the project directory
 // change on disk. Uses chokidar to watch for edits and re-read the directory.
@@ -51,6 +52,16 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
         }
         const openFolder = () => window.electronAPI?.openInFolder(full);
         const openFile = () => window.electronAPI?.openFile(full);
+        const renameFile = () => {
+          const newName = window.prompt('Rename file', name);
+          if (!newName || newName === name) return;
+          const target = path.join(path.dirname(full), newName);
+          window.electronAPI?.renameFile(full, target);
+        };
+        const deleteFile = () => {
+          if (!window.confirm(`Delete ${name}?`)) return;
+          window.electronAPI?.deleteFile(full);
+        };
         return (
           <div
             key={f}
@@ -58,7 +69,13 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
             onDoubleClick={openFile}
             onContextMenu={(e) => {
               e.preventDefault();
-              openFolder();
+              const menu = Menu.buildFromTemplate([
+                { label: 'Reveal', click: openFolder },
+                { label: 'Open', click: openFile },
+                { label: 'Rename', click: renameFile },
+                { label: 'Delete', click: deleteFile },
+              ]);
+              menu.popup();
             }}
           >
             {thumb ? (


### PR DESCRIPTION
## Summary
- add Electron Menu-based context menu for files with Reveal/Open/Rename/Delete
- expose new rename and delete IPC handlers
- extend preload and global types for new APIs
- mark TODO for context menu complete
- test context menu interactions

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bde1aee588331967f3a16ceab8de1