### PR TITLE
Implement About view

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -108,7 +108,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Theme (Light / Dark / System)
 - [ ] Editable keyboard shortcuts
 - [ ] Update channel + analytics opt‑in
-- [ ] About pane (logo, version, links, license)
+- [x] About pane (logo, version, links, license)
 
 ---
 

--- a/apps/mc-pack-tool/__tests__/About.test.tsx
+++ b/apps/mc-pack-tool/__tests__/About.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import About from '../src/renderer/components/About';
+import pkg from '../package.json';
+
+describe('About', () => {
+  it('shows logo, version and license', () => {
+    render(<About />);
+    expect(screen.getByAltText('App logo')).toBeInTheDocument();
+    expect(
+      screen.getByText(`Minecraft Resource Packer v${pkg.version}`)
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('license')).toHaveTextContent('MIT License');
+    expect(screen.getByText('GitHub').getAttribute('href')).toContain(
+      'github.com'
+    );
+  });
+});

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -20,6 +20,7 @@ vi.mock('fs', () => ({
   },
 }));
 
+// eslint-disable-next-line no-var
 var buildMock: ReturnType<typeof vi.fn>;
 vi.mock('electron', () => {
   buildMock = vi.fn(() => ({ popup: vi.fn() }));

--- a/apps/mc-pack-tool/__tests__/DrawerLayout.test.tsx
+++ b/apps/mc-pack-tool/__tests__/DrawerLayout.test.tsx
@@ -19,7 +19,7 @@ describe('DrawerLayout', () => {
     });
 
     render(
-      <DrawerLayout>
+      <DrawerLayout view="projects" onNavigate={vi.fn()}>
         <Navbar />
         <div>content</div>
       </DrawerLayout>
@@ -40,7 +40,7 @@ describe('DrawerLayout', () => {
     });
 
     render(
-      <DrawerLayout>
+      <DrawerLayout view="projects" onNavigate={vi.fn()}>
         <Navbar />
         <div>content</div>
       </DrawerLayout>
@@ -49,5 +49,22 @@ describe('DrawerLayout', () => {
     const label = screen.getByText('Projects');
     expect(label.className).not.toContain('hidden');
     expect(screen.getByRole('checkbox')).toBeChecked();
+  });
+
+  it('triggers navigation when menu item clicked', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    const nav = vi.fn();
+    render(
+      <DrawerLayout view="projects" onNavigate={nav}>
+        <Navbar />
+        <div>content</div>
+      </DrawerLayout>
+    );
+    fireEvent.click(screen.getByText('About'));
+    expect(nav).toHaveBeenCalledWith('about');
   });
 });

--- a/apps/mc-pack-tool/src/renderer/components/About.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/About.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import pkg from '../../../package.json';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - webpack replaces import with URL string
+import iconPath from '../../../resources/icon.png';
+
+export default function About() {
+  return (
+    <section
+      className="p-4 flex flex-col gap-4 items-center"
+      data-testid="about"
+    >
+      <img
+        src={iconPath as unknown as string}
+        alt="App logo"
+        className="w-32 h-32"
+      />
+      <h2 className="font-display text-xl">
+        Minecraft Resource Packer v{pkg.version}
+      </h2>
+      <p>
+        <a
+          className="link link-primary"
+          href="https://github.com/openai/minecraft-resource-packer"
+          target="_blank"
+          rel="noreferrer"
+        >
+          GitHub
+        </a>
+        {' | '}
+        <a
+          className="link link-primary"
+          href="https://github.com/openai/minecraft-resource-packer/blob/main/docs/developer-handbook.md"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Documentation
+        </a>
+      </p>
+      <pre className="whitespace-pre-wrap text-sm" data-testid="license">
+        {`MIT License\n\nCopyright (c) 2025 Kaf`}
+      </pre>
+    </section>
+  );
+}

--- a/apps/mc-pack-tool/src/renderer/components/App.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/App.tsx
@@ -9,6 +9,7 @@ const AssetBrowser = lazy(() => import('./AssetBrowser'));
 const AssetSelector = lazy(() => import('./AssetSelector'));
 const ProjectManager = lazy(() => import('./ProjectManager'));
 import DrawerLayout from './DrawerLayout';
+import About from './About';
 
 // Main React component shown in the editor window.  It waits for the main
 // process to notify which project is open and then displays an AssetBrowser for
@@ -17,18 +18,33 @@ import DrawerLayout from './DrawerLayout';
 const App: React.FC = () => {
   const [projectPath, setProjectPath] = useState<string | null>(null);
   const [summary, setSummary] = useState<ExportSummary | null>(null);
+  const [view, setView] = useState<'projects' | 'settings' | 'about'>(
+    'projects'
+  );
   const confetti = useRef<((opts: unknown) => void) | null>(null);
 
   useEffect(() => {
     // Listen for the main process telling us which project to load.
     window.electronAPI?.onOpenProject((_event, path: string) => {
       setProjectPath(path);
+      setView('projects');
     });
   }, []);
 
+  if (view === 'about') {
+    return (
+      <DrawerLayout view={view} onNavigate={setView}>
+        <Navbar />
+        <main className="p-4">
+          <About />
+        </main>
+      </DrawerLayout>
+    );
+  }
+
   if (!projectPath) {
     return (
-      <DrawerLayout>
+      <DrawerLayout view={view} onNavigate={setView}>
         <Navbar />
         <main className="p-4 flex flex-col gap-6">
           <Suspense fallback={<Spinner />}>
@@ -60,7 +76,7 @@ const App: React.FC = () => {
   };
 
   return (
-    <DrawerLayout>
+    <DrawerLayout view={view} onNavigate={setView}>
       <Navbar />
       <main className="p-4 flex flex-col gap-4">
         <button

--- a/apps/mc-pack-tool/src/renderer/components/DrawerLayout.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/DrawerLayout.tsx
@@ -1,10 +1,17 @@
 import React, { useEffect, useState } from 'react';
 
+type View = 'projects' | 'settings' | 'about';
 interface DrawerLayoutProps {
   children: React.ReactNode;
+  view: View;
+  onNavigate: (v: View) => void;
 }
 
-export default function DrawerLayout({ children }: DrawerLayoutProps) {
+export default function DrawerLayout({
+  children,
+  view,
+  onNavigate,
+}: DrawerLayoutProps) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -32,7 +39,12 @@ export default function DrawerLayout({ children }: DrawerLayoutProps) {
         <aside className={`menu p-4 bg-base-100 ${open ? 'w-60' : 'w-20'}`}>
           <ul>
             <li>
-              <a className="flex items-center">
+              <a
+                className={`flex items-center cursor-pointer ${
+                  view === 'projects' ? 'active' : ''
+                }`}
+                onClick={() => onNavigate('projects')}
+              >
                 <span className="text-xl">🏠</span>
                 <span className={`ml-2 ${open ? '' : 'hidden md:inline'}`}>
                   Projects
@@ -40,10 +52,28 @@ export default function DrawerLayout({ children }: DrawerLayoutProps) {
               </a>
             </li>
             <li>
-              <a className="flex items-center">
+              <a
+                className={`flex items-center cursor-pointer ${
+                  view === 'settings' ? 'active' : ''
+                }`}
+                onClick={() => onNavigate('settings')}
+              >
                 <span className="text-xl">⚙️</span>
                 <span className={`ml-2 ${open ? '' : 'hidden md:inline'}`}>
                   Settings
+                </span>
+              </a>
+            </li>
+            <li>
+              <a
+                className={`flex items-center cursor-pointer ${
+                  view === 'about' ? 'active' : ''
+                }`}
+                onClick={() => onNavigate('about')}
+              >
+                <span className="text-xl">ℹ️</span>
+                <span className={`ml-2 ${open ? '' : 'hidden md:inline'}`}>
+                  About
                 </span>
               </a>
             </li>

--- a/apps/mc-pack-tool/webpack.rules.ts
+++ b/apps/mc-pack-tool/webpack.rules.ts
@@ -28,4 +28,8 @@ export const rules: Required<ModuleOptions>['rules'] = [
       },
     },
   },
+  {
+    test: /\.(png|jpg|gif|svg)$/i,
+    type: 'asset/resource',
+  },
 ];


### PR DESCRIPTION
## Summary
- add About component with logo, version and license details
- register image loader
- update DrawerLayout for navigation
- show About view via state in App
- test new About view and drawer navigation
- mark TODO item for About pane

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run dev:headless` *(fails: Error occurred in handler for 'list-versions')*

------
https://chatgpt.com/codex/tasks/task_e_684be0ae6b988331bace6d4031e454d2