### PR TITLE
Open external links via Electron shell

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -107,6 +107,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Editable keyboard shortcuts
 - [ ] Update channel + analytics opt‑in
 - [x] About pane (logo, version, links, license)
+- [x] GitHub/Documentation links open externally
 
 ---
 

--- a/apps/mc-pack-tool/__tests__/About.test.tsx
+++ b/apps/mc-pack-tool/__tests__/About.test.tsx
@@ -31,10 +31,10 @@ describe('About', () => {
     gh.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     docs.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(openExternalMock).toHaveBeenCalledWith(
-      'https://github.com/openai/minecraft-resource-packer'
+      'https://github.com/iamkaf/minecraft-resource-packer'
     );
     expect(openExternalMock).toHaveBeenCalledWith(
-      'https://github.com/openai/minecraft-resource-packer/blob/main/docs/developer-handbook.md'
+      'https://github.com/iamkaf/minecraft-resource-packer/blob/main/docs/developer-handbook.md'
     );
   });
 });

--- a/apps/mc-pack-tool/__tests__/About.test.tsx
+++ b/apps/mc-pack-tool/__tests__/About.test.tsx
@@ -1,9 +1,15 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 
 import About from '../src/renderer/components/About';
 import pkg from '../package.json';
+
+// eslint-disable-next-line no-var
+var openExternalMock: ReturnType<typeof vi.fn>;
+vi.mock('electron', () => ({
+  shell: { openExternal: (openExternalMock = vi.fn()) },
+}));
 
 describe('About', () => {
   it('shows logo, version and license', () => {
@@ -15,6 +21,20 @@ describe('About', () => {
     expect(screen.getByTestId('license')).toHaveTextContent('MIT License');
     expect(screen.getByText('GitHub').getAttribute('href')).toContain(
       'github.com'
+    );
+  });
+
+  it('opens links externally', () => {
+    render(<About />);
+    const gh = screen.getByText('GitHub');
+    const docs = screen.getByText('Documentation');
+    gh.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    docs.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(openExternalMock).toHaveBeenCalledWith(
+      'https://github.com/openai/minecraft-resource-packer'
+    );
+    expect(openExternalMock).toHaveBeenCalledWith(
+      'https://github.com/openai/minecraft-resource-packer/blob/main/docs/developer-handbook.md'
     );
   });
 });

--- a/apps/mc-pack-tool/src/renderer/components/About.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/About.tsx
@@ -22,14 +22,14 @@ export default function About() {
       <p>
         <ExternalLink
           className="link link-primary"
-          href="https://github.com/openai/minecraft-resource-packer"
+          href="https://github.com/iamkaf/minecraft-resource-packer"
         >
           GitHub
         </ExternalLink>
         {' | '}
         <ExternalLink
           className="link link-primary"
-          href="https://github.com/openai/minecraft-resource-packer/blob/main/docs/developer-handbook.md"
+          href="https://github.com/iamkaf/minecraft-resource-packer/blob/main/docs/developer-handbook.md"
         >
           Documentation
         </ExternalLink>

--- a/apps/mc-pack-tool/src/renderer/components/About.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/About.tsx
@@ -3,6 +3,7 @@ import pkg from '../../../package.json';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - webpack replaces import with URL string
 import iconPath from '../../../resources/icon.png';
+import ExternalLink from './ExternalLink';
 
 export default function About() {
   return (
@@ -19,23 +20,19 @@ export default function About() {
         Minecraft Resource Packer v{pkg.version}
       </h2>
       <p>
-        <a
+        <ExternalLink
           className="link link-primary"
           href="https://github.com/openai/minecraft-resource-packer"
-          target="_blank"
-          rel="noreferrer"
         >
           GitHub
-        </a>
+        </ExternalLink>
         {' | '}
-        <a
+        <ExternalLink
           className="link link-primary"
           href="https://github.com/openai/minecraft-resource-packer/blob/main/docs/developer-handbook.md"
-          target="_blank"
-          rel="noreferrer"
         >
           Documentation
-        </a>
+        </ExternalLink>
       </p>
       <pre className="whitespace-pre-wrap text-sm" data-testid="license">
         {`MIT License\n\nCopyright (c) 2025 Kaf`}

--- a/apps/mc-pack-tool/src/renderer/components/ExternalLink.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ExternalLink.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useExternalLink } from '../hooks/useExternalLink';
+
+interface ExternalLinkProps
+  extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  href: string;
+}
+
+export default function ExternalLink({
+  href,
+  children,
+  ...rest
+}: ExternalLinkProps) {
+  const onClick = useExternalLink(href);
+  return (
+    <a {...rest} href={href} onClick={onClick}>
+      {children}
+    </a>
+  );
+}

--- a/apps/mc-pack-tool/src/renderer/hooks/useExternalLink.ts
+++ b/apps/mc-pack-tool/src/renderer/hooks/useExternalLink.ts
@@ -1,0 +1,15 @@
+import { useCallback, MouseEvent } from 'react';
+import { shell } from 'electron';
+
+/**
+ * Returns a click handler that opens the given URL using Electron's shell.
+ */
+export function useExternalLink(url: string) {
+  return useCallback(
+    (e: MouseEvent<HTMLAnchorElement>) => {
+      e.preventDefault();
+      shell.openExternal(url);
+    },
+    [url]
+  );
+}


### PR DESCRIPTION
## Summary
- create `useExternalLink` hook and `ExternalLink` component
- update About page to use `ExternalLink`
- test that clicks on links call `shell.openExternal`
- check off TODO for opening GitHub/docs links externally

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bf220db608331a6d0ac04c8a919f1