### PR TITLE
Replace electron menu with React dropdown

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -47,6 +47,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 - [ ] Real‑time watcher with `chokidar`
 - [x] Context menu: Reveal, Open, Rename, Delete
+- [x] React context menu with daisyUI dropdown + delete modal
 - [ ] Dirty badge for changed assets
 - [ ] 🔒 No‑export toggle per file
 - [ ] Custom namespace support (non‑`minecraft` assets)

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -56,7 +56,6 @@ describe('AssetBrowser', () => {
     render(<AssetBrowser path="/proj" />);
     const item = screen.getByText('a.txt');
     fireEvent.contextMenu(item);
-    vi.stubGlobal('prompt', () => 'renamed.txt');
     const revealBtn = (
       await screen.findAllByRole('menuitem', { name: 'Reveal' })
     )[0];
@@ -71,7 +70,14 @@ describe('AssetBrowser', () => {
     fireEvent.click(
       (await screen.findAllByRole('menuitem', { name: 'Rename' }))[0]
     );
+    const rmodal = await screen.findByTestId('rename-modal');
+    const input = within(rmodal).getByDisplayValue('a.txt');
+    fireEvent.change(input, { target: { value: 'renamed.txt' } });
+    const form = input.closest('form');
+    if (!form) throw new Error('form not found');
+    fireEvent.submit(form);
     expect(renameFile).toHaveBeenCalledWith('/proj/a.txt', '/proj/renamed.txt');
+    expect(screen.queryByTestId('rename-modal')).toBeNull();
     fireEvent.contextMenu(item);
     fireEvent.click(
       (await screen.findAllByRole('menuitem', { name: 'Delete' }))[0]

--- a/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetBrowser.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
 
@@ -20,13 +20,6 @@ vi.mock('fs', () => ({
   },
 }));
 
-// eslint-disable-next-line no-var
-var buildMock: ReturnType<typeof vi.fn>;
-vi.mock('electron', () => {
-  buildMock = vi.fn(() => ({ popup: vi.fn() }));
-  return { Menu: { buildFromTemplate: buildMock } };
-});
-
 describe('AssetBrowser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -40,7 +33,7 @@ describe('AssetBrowser', () => {
     expect(img.style.imageRendering).toBe('pixelated');
   });
 
-  it('context menu triggers IPC calls', () => {
+  it('context menu triggers IPC calls', async () => {
     const openInFolder = vi.fn();
     const openFile = vi.fn();
     const renameFile = vi.fn();
@@ -63,16 +56,29 @@ describe('AssetBrowser', () => {
     render(<AssetBrowser path="/proj" />);
     const item = screen.getByText('a.txt');
     fireEvent.contextMenu(item);
-    const template = buildMock.mock.calls[0][0];
     vi.stubGlobal('prompt', () => 'renamed.txt');
-    vi.stubGlobal('confirm', () => true);
-    template[0].click();
+    const revealBtn = (
+      await screen.findAllByRole('menuitem', { name: 'Reveal' })
+    )[0];
+    fireEvent.click(revealBtn);
     expect(openInFolder).toHaveBeenCalledWith('/proj/a.txt');
-    template[1].click();
+    fireEvent.contextMenu(item);
+    fireEvent.click(
+      (await screen.findAllByRole('menuitem', { name: 'Open' }))[0]
+    );
     expect(openFile).toHaveBeenCalledWith('/proj/a.txt');
-    template[2].click();
+    fireEvent.contextMenu(item);
+    fireEvent.click(
+      (await screen.findAllByRole('menuitem', { name: 'Rename' }))[0]
+    );
     expect(renameFile).toHaveBeenCalledWith('/proj/a.txt', '/proj/renamed.txt');
-    template[3].click();
+    fireEvent.contextMenu(item);
+    fireEvent.click(
+      (await screen.findAllByRole('menuitem', { name: 'Delete' }))[0]
+    );
+    const modal = await screen.findByTestId('delete-modal');
+    fireEvent.click(within(modal).getByText('Delete'));
     expect(deleteFile).toHaveBeenCalledWith('/proj/a.txt');
+    expect(modal).not.toBeInTheDocument();
   });
 });

--- a/apps/mc-pack-tool/__tests__/RenameModal.test.tsx
+++ b/apps/mc-pack-tool/__tests__/RenameModal.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import RenameModal from '../src/renderer/components/RenameModal';
+
+describe('RenameModal', () => {
+  it('submits new name', () => {
+    const cb = vi.fn();
+    render(
+      <RenameModal current="a.txt" onCancel={() => undefined} onRename={cb} />
+    );
+    const input = screen.getByDisplayValue('a.txt') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'b.txt' } });
+    const form = input.closest('form');
+    if (!form) throw new Error('form not found');
+    fireEvent.submit(form);
+    expect(cb).toHaveBeenCalledWith('b.txt');
+  });
+
+  it('calls onCancel when cancel clicked', () => {
+    const cancel = vi.fn();
+    render(
+      <RenameModal
+        current="a.txt"
+        onCancel={cancel}
+        onRename={() => undefined}
+      />
+    );
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(cancel).toHaveBeenCalled();
+  });
+});

--- a/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react';
 import { watch } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
+import RenameModal from './RenameModal';
 
 // Simple file list that updates whenever files inside the project directory
 // change on disk. Uses chokidar to watch for edits and re-read the directory.
@@ -41,6 +42,7 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
 
   const [menuTarget, setMenuTarget] = useState<string | null>(null);
   const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const firstItem = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
@@ -61,12 +63,7 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
         }
         const openFolder = () => window.electronAPI?.openInFolder(full);
         const openFile = () => window.electronAPI?.openFile(full);
-        const renameFile = () => {
-          const newName = window.prompt('Rename file', name);
-          if (!newName || newName === name) return;
-          const target = path.join(path.dirname(full), newName);
-          window.electronAPI?.renameFile(full, target);
-        };
+        const showRename = () => setRenameTarget(f);
         const confirmDel = () => setConfirmDelete(full);
         const showMenu = () => setMenuTarget(f);
         const handleKey = (e: React.KeyboardEvent) => {
@@ -122,7 +119,7 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
                 </button>
               </li>
               <li>
-                <button role="menuitem" onClick={renameFile}>
+                <button role="menuitem" onClick={showRename}>
                   Rename
                 </button>
               </li>
@@ -157,6 +154,18 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
             </div>
           </div>
         </dialog>
+      )}
+      {renameTarget && (
+        <RenameModal
+          current={path.basename(renameTarget)}
+          onCancel={() => setRenameTarget(null)}
+          onRename={(n) => {
+            const full = path.join(projectPath, renameTarget);
+            const target = path.join(path.dirname(full), n);
+            window.electronAPI?.renameFile(full, target);
+            setRenameTarget(null);
+          }}
+        />
       )}
     </div>
   );

--- a/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { watch } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
-import { Menu } from 'electron';
 
 // Simple file list that updates whenever files inside the project directory
 // change on disk. Uses chokidar to watch for edits and re-read the directory.
@@ -40,8 +39,18 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
     };
   }, [projectPath]);
 
+  const [menuTarget, setMenuTarget] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const firstItem = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (menuTarget && firstItem.current) {
+      firstItem.current.focus();
+    }
+  }, [menuTarget]);
+
   return (
-    <div className="grid grid-cols-6 gap-2">
+    <div className="grid grid-cols-6 gap-2" onClick={() => setMenuTarget(null)}>
       {files.map((f) => {
         const full = path.join(projectPath, f);
         const name = path.basename(f);
@@ -58,24 +67,30 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
           const target = path.join(path.dirname(full), newName);
           window.electronAPI?.renameFile(full, target);
         };
-        const deleteFile = () => {
-          if (!window.confirm(`Delete ${name}?`)) return;
-          window.electronAPI?.deleteFile(full);
+        const confirmDel = () => setConfirmDelete(full);
+        const showMenu = () => setMenuTarget(f);
+        const handleKey = (e: React.KeyboardEvent) => {
+          if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+            e.preventDefault();
+            showMenu();
+          }
         };
+        const menuOpen = menuTarget === f;
         return (
           <div
             key={f}
-            className="p-1 cursor-pointer hover:ring ring-accent"
+            className="p-1 cursor-pointer hover:ring ring-accent relative"
+            tabIndex={0}
             onDoubleClick={openFile}
             onContextMenu={(e) => {
               e.preventDefault();
-              const menu = Menu.buildFromTemplate([
-                { label: 'Reveal', click: openFolder },
-                { label: 'Open', click: openFile },
-                { label: 'Rename', click: renameFile },
-                { label: 'Delete', click: deleteFile },
-              ]);
-              menu.popup();
+              showMenu();
+            }}
+            onKeyDown={handleKey}
+            onBlur={(e) => {
+              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+                setMenuTarget(null);
+              }
             }}
           >
             {thumb ? (
@@ -90,9 +105,59 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
                 {name}
               </div>
             )}
+            <ul
+              className={`menu dropdown-content bg-base-200 rounded-box absolute z-10 w-40 p-1 shadow ${
+                menuOpen ? 'block' : 'hidden'
+              }`}
+              role="menu"
+            >
+              <li>
+                <button ref={firstItem} role="menuitem" onClick={openFolder}>
+                  Reveal
+                </button>
+              </li>
+              <li>
+                <button role="menuitem" onClick={openFile}>
+                  Open
+                </button>
+              </li>
+              <li>
+                <button role="menuitem" onClick={renameFile}>
+                  Rename
+                </button>
+              </li>
+              <li>
+                <button role="menuitem" onClick={confirmDel}>
+                  Delete
+                </button>
+              </li>
+            </ul>
           </div>
         );
       })}
+      {confirmDelete && (
+        <dialog className="modal modal-open" data-testid="delete-modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg mb-2">Confirm Delete</h3>
+            <p>{path.basename(confirmDelete)}</p>
+            <div className="modal-action">
+              <button className="btn" onClick={() => setConfirmDelete(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-error"
+                onClick={() => {
+                  if (!confirmDelete) return;
+                  window.electronAPI?.deleteFile(confirmDelete);
+                  setConfirmDelete(null);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
     </div>
   );
 };

--- a/apps/mc-pack-tool/src/renderer/components/RenameModal.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/RenameModal.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export default function RenameModal({
+  current,
+  onCancel,
+  onRename,
+}: {
+  current: string;
+  onCancel: () => void;
+  onRename: (newName: string) => void;
+}) {
+  const [name, setName] = useState(current);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+  return (
+    <dialog className="modal modal-open" data-testid="rename-modal">
+      <form
+        className="modal-box flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onRename(name);
+        }}
+      >
+        <h3 className="font-bold text-lg">Rename File</h3>
+        <input
+          ref={inputRef}
+          className="input input-bordered"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <div className="modal-action">
+          <button type="button" className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Save
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add daisyUI dropdown context menu in `AssetBrowser`
- confirm deletion with modal
- test the React menu and IPC calls
- mark TODO item for the new React context menu

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bf2216c9c83319060b6dbe7d2a3a6