### PR TITLE
Use modals for asset and project actions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -14,6 +14,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [x] Loading indicators for every async op (`react-loader-spinner`)
 - [x] Confetti celebration on successful export (`react-canvas-confetti`)
 - [ ] Undo/Redo queue (last 20 actions)
+- [x] window.prompt is not supported
 
 ### Wiki Quick‑Links
 

--- a/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import ProjectManager from '../src/renderer/components/ProjectManager';
+import ToastProvider from '../src/renderer/components/ToastProvider';
 
 describe('ProjectManager', () => {
   const listProjects = vi.fn();
@@ -133,19 +134,36 @@ describe('ProjectManager', () => {
     expect(importProject).toHaveBeenCalled();
   });
 
-  it('duplicates project via prompt', async () => {
-    render(<ProjectManager />);
+  it('duplicates project via modal', async () => {
+    render(
+      <ToastProvider>
+        <ProjectManager />
+      </ToastProvider>
+    );
     await screen.findAllByRole('button', { name: 'Open' });
-    vi.stubGlobal('prompt', () => 'Alpha Copy');
     fireEvent.click(screen.getAllByRole('button', { name: 'Duplicate' })[0]);
+    const modal = await screen.findByTestId('duplicate-modal');
+    fireEvent.change(modal.querySelector('input')!, {
+      target: { value: 'Alpha Copy' },
+    });
+    fireEvent.click(screen.getByText('Save'));
     expect(duplicateProject).toHaveBeenCalledWith('Alpha', 'Alpha Copy');
+    await screen.findAllByText('Project duplicated');
   });
 
-  it('deletes project with confirmation', async () => {
-    render(<ProjectManager />);
+  it('deletes project with confirmation modal', async () => {
+    render(
+      <ToastProvider>
+        <ProjectManager />
+      </ToastProvider>
+    );
     await screen.findAllByRole('button', { name: 'Open' });
-    vi.stubGlobal('confirm', () => true);
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    const modal = await screen.findByTestId('delete-project-modal');
+    fireEvent.click(
+      modal.querySelector('button.btn-error') as HTMLButtonElement
+    );
     expect(deleteProject).toHaveBeenCalledWith('Alpha');
+    await screen.findAllByText('Project deleted');
   });
 });

--- a/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetBrowser.tsx
@@ -3,6 +3,7 @@ import { watch } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
 import { Menu } from 'electron';
+import { useToast } from './ToastProvider';
 
 // Simple file list that updates whenever files inside the project directory
 // change on disk. Uses chokidar to watch for edits and re-read the directory.
@@ -13,6 +14,16 @@ interface Props {
 
 const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
   const [files, setFiles] = useState<string[]>([]);
+  const [renameTarget, setRenameTarget] = useState<{
+    path: string;
+    name: string;
+  } | null>(null);
+  const [renameValue, setRenameValue] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<{
+    path: string;
+    name: string;
+  } | null>(null);
+  const toast = useToast();
 
   useEffect(() => {
     const loadFiles = () => {
@@ -41,59 +52,116 @@ const AssetBrowser: React.FC<Props> = ({ path: projectPath }) => {
   }, [projectPath]);
 
   return (
-    <div className="grid grid-cols-6 gap-2">
-      {files.map((f) => {
-        const full = path.join(projectPath, f);
-        const name = path.basename(f);
-        let thumb: string | null = null;
-        if (f.endsWith('.png')) {
-          const rel = f.split(path.sep).join('/');
-          thumb = `ptex://${rel}`;
-        }
-        const openFolder = () => window.electronAPI?.openInFolder(full);
-        const openFile = () => window.electronAPI?.openFile(full);
-        const renameFile = () => {
-          const newName = window.prompt('Rename file', name);
-          if (!newName || newName === name) return;
-          const target = path.join(path.dirname(full), newName);
-          window.electronAPI?.renameFile(full, target);
-        };
-        const deleteFile = () => {
-          if (!window.confirm(`Delete ${name}?`)) return;
-          window.electronAPI?.deleteFile(full);
-        };
-        return (
-          <div
-            key={f}
-            className="p-1 cursor-pointer hover:ring ring-accent"
-            onDoubleClick={openFile}
-            onContextMenu={(e) => {
-              e.preventDefault();
-              const menu = Menu.buildFromTemplate([
-                { label: 'Reveal', click: openFolder },
-                { label: 'Open', click: openFile },
-                { label: 'Rename', click: renameFile },
-                { label: 'Delete', click: deleteFile },
-              ]);
-              menu.popup();
-            }}
-          >
-            {thumb ? (
-              <img
-                src={thumb}
-                alt={name}
-                className="w-full aspect-square"
-                style={{ imageRendering: 'pixelated' }}
-              />
-            ) : (
-              <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
-                {name}
-              </div>
-            )}
+    <>
+      <div className="grid grid-cols-6 gap-2">
+        {files.map((f) => {
+          const full = path.join(projectPath, f);
+          const name = path.basename(f);
+          let thumb: string | null = null;
+          if (f.endsWith('.png')) {
+            const rel = f.split(path.sep).join('/');
+            thumb = `ptex://${rel}`;
+          }
+          const openFolder = () => window.electronAPI?.openInFolder(full);
+          const openFile = () => window.electronAPI?.openFile(full);
+          const renameFile = () => {
+            setRenameTarget({ path: full, name });
+            setRenameValue(name);
+          };
+          const deleteFile = () => {
+            setDeleteTarget({ path: full, name });
+          };
+          return (
+            <div
+              key={f}
+              className="p-1 cursor-pointer hover:ring ring-accent"
+              onDoubleClick={openFile}
+              onContextMenu={(e) => {
+                e.preventDefault();
+                const menu = Menu.buildFromTemplate([
+                  { label: 'Reveal', click: openFolder },
+                  { label: 'Open', click: openFile },
+                  { label: 'Rename', click: renameFile },
+                  { label: 'Delete', click: deleteFile },
+                ]);
+                menu.popup();
+              }}
+            >
+              {thumb ? (
+                <img
+                  src={thumb}
+                  alt={name}
+                  className="w-full aspect-square"
+                  style={{ imageRendering: 'pixelated' }}
+                />
+              ) : (
+                <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
+                  {name}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {renameTarget && (
+        <dialog className="modal modal-open" data-testid="rename-modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg mb-2">Rename file</h3>
+            <input
+              autoFocus
+              className="input input-bordered w-full"
+              value={renameValue}
+              onChange={(e) => setRenameValue(e.target.value)}
+            />
+            <div className="modal-action">
+              <button className="btn" onClick={() => setRenameTarget(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  const target = path.join(
+                    path.dirname(renameTarget.path),
+                    renameValue
+                  );
+                  window.electronAPI
+                    ?.renameFile(renameTarget.path, target)
+                    .then(() => toast('File renamed', 'success'));
+                  setRenameTarget(null);
+                }}
+              >
+                Save
+              </button>
+            </div>
           </div>
-        );
-      })}
-    </div>
+        </dialog>
+      )}
+      {deleteTarget && (
+        <dialog className="modal modal-open" data-testid="delete-modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg mb-2">
+              Delete {deleteTarget.name}?
+            </h3>
+            <div className="modal-action">
+              <button className="btn" onClick={() => setDeleteTarget(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-error"
+                onClick={() => {
+                  window.electronAPI
+                    ?.deleteFile(deleteTarget.path)
+                    .then(() => toast('File deleted', 'info'));
+                  setDeleteTarget(null);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
+    </>
   );
 };
 export default AssetBrowser;

--- a/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
@@ -18,6 +18,9 @@ const ProjectManager: React.FC = () => {
   const [name, setName] = useState(() => generateProjectName());
   const [version, setVersion] = useState('');
   const [versions, setVersions] = useState<string[]>([]);
+  const [dupTarget, setDupTarget] = useState<string | null>(null);
+  const [dupValue, setDupValue] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const refresh = () => {
     window.electronAPI?.listProjects().then(setProjects);
@@ -38,20 +41,12 @@ const ProjectManager: React.FC = () => {
   };
 
   const handleDuplicate = (n: string) => {
-    const dup = prompt('Duplicate as', `${n} Copy`);
-    if (!dup) return;
-    window.electronAPI?.duplicateProject(n, dup).then(() => {
-      refresh();
-      toast('Project duplicated', 'success');
-    });
+    setDupTarget(n);
+    setDupValue(`${n} Copy`);
   };
 
   const handleDelete = (n: string) => {
-    if (!confirm(`Delete project ${n}?`)) return;
-    window.electronAPI?.deleteProject(n).then(() => {
-      refresh();
-      toast('Project deleted', 'info');
-    });
+    setDeleteTarget(n);
   };
 
   const toast = useToast();
@@ -173,6 +168,63 @@ const ProjectManager: React.FC = () => {
           ))}
         </tbody>
       </table>
+      {dupTarget && (
+        <dialog className="modal modal-open" data-testid="duplicate-modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg mb-2">Duplicate project</h3>
+            <input
+              autoFocus
+              className="input input-bordered w-full"
+              value={dupValue}
+              onChange={(e) => setDupValue(e.target.value)}
+            />
+            <div className="modal-action">
+              <button className="btn" onClick={() => setDupTarget(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  if (!dupTarget) return;
+                  window.electronAPI
+                    ?.duplicateProject(dupTarget, dupValue)
+                    .then(() => {
+                      refresh();
+                      toast('Project duplicated', 'success');
+                    });
+                  setDupTarget(null);
+                }}
+              >
+                Save
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
+      {deleteTarget && (
+        <dialog className="modal modal-open" data-testid="delete-project-modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg mb-2">Delete {deleteTarget}?</h3>
+            <div className="modal-action">
+              <button className="btn" onClick={() => setDeleteTarget(null)}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-error"
+                onClick={() => {
+                  window.electronAPI?.deleteProject(deleteTarget).then(() => {
+                    refresh();
+                    toast('Project deleted', 'info');
+                  });
+                  setDeleteTarget(null);
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </dialog>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- replace `window.prompt`/`window.confirm` in `AssetBrowser` and `ProjectManager`
- fire daisyUI modal dialogs for rename/duplicate/delete
- show results via toast notifications
- test modal interaction and IPC wiring
- check off obsolete TODO entry

## Testing
- `npm test --silent`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684bf220dbe08331b972370c60d59273