### PR TITLE
Add search and version filter

### DIFF
--- a/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectManager.test.tsx
@@ -148,4 +148,33 @@ describe('ProjectManager', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
     expect(deleteProject).toHaveBeenCalledWith('Alpha');
   });
+
+  it('filters by search term', async () => {
+    render(<ProjectManager />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const search = screen.getByPlaceholderText('Search');
+    fireEvent.change(search, { target: { value: 'pak' } });
+    expect(screen.getByText('Pack')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha')).toBeNull();
+  });
+
+  it('filters by version chip and combines with search', async () => {
+    render(<ProjectManager />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const chip = screen.getByRole('button', { name: '1.20' });
+    fireEvent.click(chip);
+    expect(screen.getByText('Pack')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha')).toBeNull();
+    const search = screen.getByPlaceholderText('Search');
+    fireEvent.change(search, { target: { value: 'pack' } });
+    expect(screen.getByText('Pack')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha')).toBeNull();
+  });
+
+  it('search input has reasonable width', async () => {
+    render(<ProjectManager />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const input = screen.getByPlaceholderText('Search');
+    expect(input).toHaveClass('w-40');
+  });
 });

--- a/apps/mc-pack-tool/package.json
+++ b/apps/mc-pack-tool/package.json
@@ -66,6 +66,7 @@
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
     "electron-squirrel-startup": "^1.0.1",
+    "fuse.js": "^7.1.0",
     "global-agent": "^3.0.0",
     "minecraft-data": "^3.89.0",
     "react": "^19.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
         "electron-squirrel-startup": "^1.0.1",
+        "fuse.js": "^7.1.0",
         "global-agent": "^3.0.0",
         "minecraft-data": "^3.89.0",
         "react": "^19.1.0",
@@ -8352,6 +8353,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.1.0.tgz",
+      "integrity": "sha512-trLf4SzuuUxfusZADLINj+dE8clK1frKdmqiJNb1Es75fmI5oY6X2mxLVUciLLjxqw/xr72Dhy+lER6dGd02FQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/galactus": {


### PR DESCRIPTION
## Summary
- enable Fuse.js fuzzy searching in projects table
- display version filter chips with daisyUI badges
- update ProjectManager tests for new filtering behaviour
- include fuse.js dependency

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bfa2040188331bbba7f23bca9a1be