### PR TITLE
Add project metadata sidebar

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [x] Create • Import • Duplicate • Delete (confirm) • Open actions
 - [x] Fuzzy search + version filter chips
 - [ ] Bulk export selected rows
-- [ ] Rich metadata sidebar (Description, Author, URLs, etc.)
+- [x] Rich metadata sidebar (Description, Author, URLs, etc.)
 
 ---
 

--- a/apps/mc-pack-tool/__tests__/PackMetaModal.test.tsx
+++ b/apps/mc-pack-tool/__tests__/PackMetaModal.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import PackMetaModal from '../src/renderer/components/PackMetaModal';
+import type { PackMeta } from '../src/main/projects';
+
+describe('PackMetaModal', () => {
+  it('submits edited metadata', () => {
+    const meta: PackMeta = {
+      description: 'desc',
+      author: 'me',
+      urls: ['https://a.com'],
+      created: 0,
+    };
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(<PackMetaModal meta={meta} onSave={onSave} onCancel={onCancel} />);
+    fireEvent.change(screen.getByPlaceholderText('Description'), {
+      target: { value: 'new' },
+    });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'new' })
+    );
+  });
+});

--- a/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
@@ -43,4 +43,39 @@ describe('ProjectSidebar', () => {
     );
     expect(screen.getByTestId('project-sidebar')).toBeInTheDocument();
   });
+
+  it('updates when project changes', async () => {
+    const load = vi
+      .fn()
+      .mockResolvedValueOnce({
+        description: 'First',
+        author: '',
+        urls: [],
+        created: 0,
+      })
+      .mockResolvedValueOnce({
+        description: 'Second',
+        author: '',
+        urls: [],
+        created: 0,
+      });
+    interface API {
+      loadPackMeta: typeof load;
+      savePackMeta: () => void;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      loadPackMeta: load,
+      savePackMeta: vi.fn(),
+    };
+    const { rerender } = render(
+      <ProjectSidebar project="A" open={true} onClose={() => undefined} />
+    );
+    await screen.findByText('First');
+    rerender(
+      <ProjectSidebar project="B" open={true} onClose={() => undefined} />
+    );
+    expect(load).toHaveBeenLastCalledWith('B');
+    await screen.findByText('Second');
+    expect(screen.queryByText('First')).toBeNull();
+  });
 });

--- a/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProjectSidebar from '../src/renderer/components/ProjectSidebar';
+
+describe('ProjectSidebar', () => {
+  it('loads metadata when opened', async () => {
+    const load = vi.fn().mockResolvedValue({
+      description: 'A pack',
+      author: 'Me',
+      urls: ['https://a.com'],
+      created: 0,
+    });
+    interface API {
+      loadPackMeta: typeof load;
+      savePackMeta: () => void;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      loadPackMeta: load,
+      savePackMeta: vi.fn(),
+    };
+    render(
+      <ProjectSidebar project="Pack" open={true} onClose={() => undefined} />
+    );
+    expect(load).toHaveBeenCalledWith('Pack');
+    await screen.findByText('A pack');
+  });
+
+  it('toggles visibility', () => {
+    const load = vi
+      .fn()
+      .mockResolvedValue({ description: '', author: '', urls: [], created: 0 });
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      loadPackMeta: load,
+      savePackMeta: vi.fn(),
+    };
+    const { rerender } = render(
+      <ProjectSidebar project="Pack" open={false} onClose={() => undefined} />
+    );
+    expect(screen.queryByTestId('project-sidebar')).toBeNull();
+    rerender(
+      <ProjectSidebar project="Pack" open={true} onClose={() => undefined} />
+    );
+    expect(screen.getByTestId('project-sidebar')).toBeInTheDocument();
+  });
+});

--- a/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
+++ b/apps/mc-pack-tool/__tests__/ProjectSidebar.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import ProjectSidebar from '../src/renderer/components/ProjectSidebar';
 
 describe('ProjectSidebar', () => {
-  it('loads metadata when opened', async () => {
+  it('loads metadata when given a project', async () => {
     const load = vi.fn().mockResolvedValue({
       description: 'A pack',
       author: 'Me',
@@ -19,29 +19,20 @@ describe('ProjectSidebar', () => {
       loadPackMeta: load,
       savePackMeta: vi.fn(),
     };
-    render(
-      <ProjectSidebar project="Pack" open={true} onClose={() => undefined} />
-    );
+    render(<ProjectSidebar project="Pack" />);
     expect(load).toHaveBeenCalledWith('Pack');
     await screen.findByText('A pack');
   });
 
-  it('toggles visibility', () => {
-    const load = vi
-      .fn()
-      .mockResolvedValue({ description: '', author: '', urls: [], created: 0 });
+  it('shows placeholder without a project', () => {
+    const load = vi.fn();
     (window as unknown as { electronAPI: API }).electronAPI = {
       loadPackMeta: load,
       savePackMeta: vi.fn(),
     };
-    const { rerender } = render(
-      <ProjectSidebar project="Pack" open={false} onClose={() => undefined} />
-    );
-    expect(screen.queryByTestId('project-sidebar')).toBeNull();
-    rerender(
-      <ProjectSidebar project="Pack" open={true} onClose={() => undefined} />
-    );
-    expect(screen.getByTestId('project-sidebar')).toBeInTheDocument();
+    render(<ProjectSidebar project={null} />);
+    expect(screen.getByText(/select a project/i)).toBeInTheDocument();
+    expect(load).not.toHaveBeenCalled();
   });
 
   it('updates when project changes', async () => {
@@ -67,13 +58,9 @@ describe('ProjectSidebar', () => {
       loadPackMeta: load,
       savePackMeta: vi.fn(),
     };
-    const { rerender } = render(
-      <ProjectSidebar project="A" open={true} onClose={() => undefined} />
-    );
+    const { rerender } = render(<ProjectSidebar project="A" />);
     await screen.findByText('First');
-    rerender(
-      <ProjectSidebar project="B" open={true} onClose={() => undefined} />
-    );
+    rerender(<ProjectSidebar project="B" />);
     expect(load).toHaveBeenLastCalledWith('B');
     await screen.findByText('Second');
     expect(screen.queryByText('First')).toBeNull();

--- a/apps/mc-pack-tool/src/global.d.ts
+++ b/apps/mc-pack-tool/src/global.d.ts
@@ -26,6 +26,13 @@ declare global {
       openFile: (file: string) => Promise<void>;
       renameFile: (oldPath: string, newPath: string) => Promise<void>;
       deleteFile: (file: string) => Promise<void>;
+      loadPackMeta: (
+        name: string
+      ) => Promise<import('./main/projects').PackMeta>;
+      savePackMeta: (
+        name: string,
+        meta: import('./main/projects').PackMeta
+      ) => Promise<void>;
     };
   }
 }

--- a/apps/mc-pack-tool/src/minecraft/project.ts
+++ b/apps/mc-pack-tool/src/minecraft/project.ts
@@ -8,3 +8,13 @@ export const ProjectMetadataSchema = z.object({
 });
 
 export type ProjectMetadata = z.infer<typeof ProjectMetadataSchema>;
+
+export const PackMetaSchema = z.object({
+  description: z.string().default(''),
+  author: z.string().default(''),
+  urls: z.array(z.string()).default([]),
+  created: z.number(),
+  updated: z.number().optional(),
+});
+
+export type PackMeta = z.infer<typeof PackMetaSchema>;

--- a/apps/mc-pack-tool/src/preload.ts
+++ b/apps/mc-pack-tool/src/preload.ts
@@ -73,6 +73,16 @@ const api = {
   // Delete a file from disk
   deleteFile: (file: string) =>
     ipcRenderer.invoke('delete-file', file) as Promise<void>,
+
+  // Load metadata from pack.json
+  loadPackMeta: (name: string) =>
+    ipcRenderer.invoke('load-pack-meta', name) as Promise<
+      import('./main/projects').PackMeta
+    >,
+
+  // Save metadata to pack.json
+  savePackMeta: (name: string, meta: import('./main/projects').PackMeta) =>
+    ipcRenderer.invoke('save-pack-meta', name, meta) as Promise<void>,
 };
 
 if (process.contextIsolated) {

--- a/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react';
+import { PackMeta } from '../../main/projects';
+
+export default function PackMetaModal({
+  meta,
+  onSave,
+  onCancel,
+}: {
+  meta: PackMeta;
+  onSave: (m: PackMeta) => void;
+  onCancel: () => void;
+}) {
+  const [desc, setDesc] = useState(meta.description);
+  const [author, setAuthor] = useState(meta.author);
+  const [urls, setUrls] = useState(meta.urls.join('\n'));
+  return (
+    <dialog className="modal modal-open" data-testid="meta-modal">
+      <form
+        className="modal-box flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onSave({
+            ...meta,
+            description: desc,
+            author,
+            urls: urls
+              .split(/\n+/)
+              .map((u) => u.trim())
+              .filter((u) => u),
+            updated: Date.now(),
+          });
+        }}
+      >
+        <h3 className="font-bold text-lg">Edit Metadata</h3>
+        <textarea
+          className="textarea textarea-bordered"
+          value={desc}
+          onChange={(e) => setDesc(e.target.value)}
+          placeholder="Description"
+        />
+        <input
+          className="input input-bordered"
+          value={author}
+          onChange={(e) => setAuthor(e.target.value)}
+          placeholder="Author"
+        />
+        <textarea
+          className="textarea textarea-bordered"
+          value={urls}
+          onChange={(e) => setUrls(e.target.value)}
+          placeholder="URLs (one per line)"
+        />
+        <div className="modal-action">
+          <button type="button" className="btn" onClick={onCancel}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Save
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { PackMeta } from '../../main/projects';
+import type { PackMeta } from '../../main/projects';
 
 export default function PackMetaModal({
   meta,

--- a/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
@@ -4,6 +4,7 @@ import { useToast } from './ToastProvider';
 import { generateProjectName } from '../utils/names';
 import RenameModal from './RenameModal';
 import ConfirmModal from './ConfirmModal';
+import ProjectSidebar from './ProjectSidebar';
 
 // Lists all available projects and lets the user open them.  Mimics the
 // project selection dialog used in game engines like Godot.
@@ -25,6 +26,7 @@ const ProjectManager: React.FC = () => {
   const [filterVersion, setFilterVersion] = useState<string | null>(null);
   const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [sidebarProject, setSidebarProject] = useState<string | null>(null);
 
   const refresh = () => {
     window.electronAPI?.listProjects().then(setProjects);
@@ -195,6 +197,12 @@ const ProjectManager: React.FC = () => {
                   Open
                 </button>
                 <button
+                  className="btn btn-outline btn-sm"
+                  onClick={() => setSidebarProject(p.name)}
+                >
+                  Info
+                </button>
+                <button
                   className="btn btn-info btn-sm"
                   onClick={() => handleDuplicate(p.name)}
                 >
@@ -241,6 +249,13 @@ const ProjectManager: React.FC = () => {
               toast('Project deleted', 'info');
             });
           }}
+        />
+      )}
+      {sidebarProject && (
+        <ProjectSidebar
+          project={sidebarProject}
+          open={!!sidebarProject}
+          onClose={() => setSidebarProject(null)}
         />
       )}
     </section>

--- a/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectManager.tsx
@@ -26,7 +26,7 @@ const ProjectManager: React.FC = () => {
   const [filterVersion, setFilterVersion] = useState<string | null>(null);
   const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [sidebarProject, setSidebarProject] = useState<string | null>(null);
+  const [activeProject, setActiveProject] = useState<string | null>(null);
 
   const refresh = () => {
     window.electronAPI?.listProjects().then(setProjects);
@@ -99,165 +99,176 @@ const ProjectManager: React.FC = () => {
   });
 
   return (
-    <section>
-      <h2 className="font-display text-xl mb-2">Projects</h2>
-      <form onSubmit={handleCreate} className="flex gap-2 mb-4">
-        <input
-          className="input input-bordered input-sm"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Name"
-        />
-        <select
-          className="select select-bordered select-sm"
-          value={version}
-          onChange={(e) => setVersion(e.target.value)}
-        >
-          <option value="" disabled>
-            Select version
-          </option>
-          {versions.map((v) => (
-            <option key={v} value={v}>
-              {v}
+    <section className="flex gap-4">
+      <div className="flex-1">
+        <h2 className="font-display text-xl mb-2">Projects</h2>
+        <form onSubmit={handleCreate} className="flex gap-2 mb-4">
+          <input
+            className="input input-bordered input-sm"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Name"
+          />
+          <select
+            className="select select-bordered select-sm"
+            value={version}
+            onChange={(e) => setVersion(e.target.value)}
+          >
+            <option value="" disabled>
+              Select version
             </option>
-          ))}
-        </select>
-        <button className="btn btn-primary btn-sm" type="submit">
-          Create
-        </button>
-        <button
-          type="button"
-          onClick={handleImport}
-          className="btn btn-secondary btn-sm"
-        >
-          Import
-        </button>
-      </form>
-      <div className="flex items-center gap-2 mb-2">
-        <input
-          className="input input-bordered input-sm w-40"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search"
-        />
-        <div className="flex gap-1">
-          {chipVersions.map((v) => (
-            <span
-              key={v}
-              role="button"
-              tabIndex={0}
-              onClick={() => setFilterVersion(filterVersion === v ? null : v)}
-              onKeyDown={(e) =>
-                e.key === 'Enter' &&
-                setFilterVersion(filterVersion === v ? null : v)
-              }
-              className={`badge badge-outline cursor-pointer select-none ${filterVersion === v ? 'badge-primary' : ''}`}
-            >
-              {v}
-            </span>
-          ))}
+            {versions.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+          <button className="btn btn-primary btn-sm" type="submit">
+            Create
+          </button>
+          <button
+            type="button"
+            onClick={handleImport}
+            className="btn btn-secondary btn-sm"
+          >
+            Import
+          </button>
+        </form>
+        <div className="flex items-center gap-2 mb-2">
+          <input
+            className="input input-bordered input-sm w-40"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search"
+          />
+          <div className="flex gap-1">
+            {chipVersions.map((v) => (
+              <span
+                key={v}
+                role="button"
+                tabIndex={0}
+                onClick={() => setFilterVersion(filterVersion === v ? null : v)}
+                onKeyDown={(e) =>
+                  e.key === 'Enter' &&
+                  setFilterVersion(filterVersion === v ? null : v)
+                }
+                className={`badge badge-outline cursor-pointer select-none ${filterVersion === v ? 'badge-primary' : ''}`}
+              >
+                {v}
+              </span>
+            ))}
+          </div>
         </div>
+        <div className="flex-1 overflow-x-auto">
+          <table className="table table-zebra w-full">
+            <thead>
+              <tr>
+                <th
+                  onClick={() => handleSort('name')}
+                  className="cursor-pointer"
+                >
+                  Name
+                </th>
+                <th
+                  onClick={() => handleSort('version')}
+                  className="cursor-pointer"
+                >
+                  MC Version
+                </th>
+                <th
+                  onClick={() => handleSort('assets')}
+                  className="cursor-pointer"
+                >
+                  Assets
+                </th>
+                <th
+                  onClick={() => handleSort('lastOpened')}
+                  className="cursor-pointer"
+                >
+                  Last opened
+                </th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {sortedProjects.map((p) => (
+                <tr
+                  key={p.name}
+                  onClick={() => setActiveProject(p.name)}
+                  className="cursor-pointer"
+                >
+                  <td>{p.name}</td>
+                  <td>{p.version}</td>
+                  <td>{p.assets}</td>
+                  <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
+                  <td className="flex gap-1">
+                    <button
+                      className="btn btn-accent btn-sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleOpen(p.name);
+                      }}
+                    >
+                      Open
+                    </button>
+                    <button
+                      className="btn btn-info btn-sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDuplicate(p.name);
+                      }}
+                    >
+                      Duplicate
+                    </button>
+                    <button
+                      className="btn btn-error btn-sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(p.name);
+                      }}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        {duplicateTarget && (
+          <RenameModal
+            current={`${duplicateTarget} Copy`}
+            title="Duplicate Project"
+            confirmText="Duplicate"
+            onCancel={() => setDuplicateTarget(null)}
+            onRename={(newName) => {
+              const src = duplicateTarget;
+              setDuplicateTarget(null);
+              window.electronAPI?.duplicateProject(src, newName).then(() => {
+                refresh();
+                toast('Project duplicated', 'success');
+              });
+            }}
+          />
+        )}
+        {deleteTarget && (
+          <ConfirmModal
+            title="Delete Project"
+            message={`Delete project ${deleteTarget}?`}
+            confirmText="Delete"
+            onCancel={() => setDeleteTarget(null)}
+            onConfirm={() => {
+              const target = deleteTarget;
+              setDeleteTarget(null);
+              window.electronAPI?.deleteProject(target).then(() => {
+                refresh();
+                toast('Project deleted', 'info');
+              });
+            }}
+          />
+        )}
       </div>
-      <table className="table table-zebra w-full">
-        <thead>
-          <tr>
-            <th onClick={() => handleSort('name')} className="cursor-pointer">
-              Name
-            </th>
-            <th
-              onClick={() => handleSort('version')}
-              className="cursor-pointer"
-            >
-              MC Version
-            </th>
-            <th onClick={() => handleSort('assets')} className="cursor-pointer">
-              Assets
-            </th>
-            <th
-              onClick={() => handleSort('lastOpened')}
-              className="cursor-pointer"
-            >
-              Last opened
-            </th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {sortedProjects.map((p) => (
-            <tr key={p.name}>
-              <td>{p.name}</td>
-              <td>{p.version}</td>
-              <td>{p.assets}</td>
-              <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
-              <td className="flex gap-1">
-                <button
-                  className="btn btn-accent btn-sm"
-                  onClick={() => handleOpen(p.name)}
-                >
-                  Open
-                </button>
-                <button
-                  className="btn btn-outline btn-sm"
-                  onClick={() => setSidebarProject(p.name)}
-                >
-                  Info
-                </button>
-                <button
-                  className="btn btn-info btn-sm"
-                  onClick={() => handleDuplicate(p.name)}
-                >
-                  Duplicate
-                </button>
-                <button
-                  className="btn btn-error btn-sm"
-                  onClick={() => handleDelete(p.name)}
-                >
-                  Delete
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {duplicateTarget && (
-        <RenameModal
-          current={`${duplicateTarget} Copy`}
-          title="Duplicate Project"
-          confirmText="Duplicate"
-          onCancel={() => setDuplicateTarget(null)}
-          onRename={(newName) => {
-            const src = duplicateTarget;
-            setDuplicateTarget(null);
-            window.electronAPI?.duplicateProject(src, newName).then(() => {
-              refresh();
-              toast('Project duplicated', 'success');
-            });
-          }}
-        />
-      )}
-      {deleteTarget && (
-        <ConfirmModal
-          title="Delete Project"
-          message={`Delete project ${deleteTarget}?`}
-          confirmText="Delete"
-          onCancel={() => setDeleteTarget(null)}
-          onConfirm={() => {
-            const target = deleteTarget;
-            setDeleteTarget(null);
-            window.electronAPI?.deleteProject(target).then(() => {
-              refresh();
-              toast('Project deleted', 'info');
-            });
-          }}
-        />
-      )}
-      {sidebarProject && (
-        <ProjectSidebar
-          project={sidebarProject}
-          open={!!sidebarProject}
-          onClose={() => setSidebarProject(null)}
-        />
-      )}
+      <ProjectSidebar project={activeProject} />
     </section>
   );
 };

--- a/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
@@ -5,46 +5,23 @@ import type { PackMeta } from '../../main/projects';
 
 export default function ProjectSidebar({
   project,
-  open,
-  onClose,
 }: {
-  project: string;
-  open: boolean;
-  onClose: () => void;
+  project: string | null;
 }) {
   const [meta, setMeta] = useState<PackMeta | null>(null);
   const [edit, setEdit] = useState(false);
 
   useEffect(() => {
-    if (open) {
+    if (project) {
       setMeta(null);
       window.electronAPI?.loadPackMeta(project).then(setMeta);
     }
-  }, [open, project]);
-
-  if (!open) return null;
+  }, [project]);
 
   return (
-    <div
-      className={`drawer drawer-end z-50 ${open ? 'drawer-open' : ''}`}
-      data-testid="project-sidebar"
-    >
-      <input
-        id="project-sidebar-toggle"
-        type="checkbox"
-        className="drawer-toggle"
-        checked={open}
-        onChange={onClose}
-        data-testid="sidebar-toggle"
-      />
-      <div className="drawer-content" />
-      <div className="drawer-side">
-        <label
-          className="drawer-overlay"
-          onClick={onClose}
-          htmlFor="project-sidebar-toggle"
-        />
-        <aside className="p-4 w-80 bg-base-200">
+    <aside data-testid="project-sidebar" className="w-80 p-4 bg-base-200">
+      {project ? (
+        <>
           <h2 className="font-display text-lg mb-2">{project}</h2>
           {meta ? (
             <div className="card bg-base-100 p-4">
@@ -77,13 +54,16 @@ export default function ProjectSidebar({
           ) : (
             <div>Loading...</div>
           )}
-        </aside>
-      </div>
+        </>
+      ) : (
+        <p>Select a project to view metadata.</p>
+      )}
       {edit && meta && (
         <PackMetaModal
           meta={meta}
           onCancel={() => setEdit(false)}
           onSave={(m) => {
+            if (!project) return;
             window.electronAPI?.savePackMeta(project, m).then(() => {
               setMeta(m);
               setEdit(false);
@@ -91,6 +71,6 @@ export default function ProjectSidebar({
           }}
         />
       )}
-    </div>
+    </aside>
   );
 }

--- a/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ExternalLink from './ExternalLink';
 import PackMetaModal from './PackMetaModal';
-import { PackMeta } from '../../main/projects';
+import type { PackMeta } from '../../main/projects';
 
 export default function ProjectSidebar({
   project,
@@ -17,6 +17,7 @@ export default function ProjectSidebar({
 
   useEffect(() => {
     if (open) {
+      setMeta(null);
       window.electronAPI?.loadPackMeta(project).then(setMeta);
     }
   }, [open, project]);
@@ -25,10 +26,11 @@ export default function ProjectSidebar({
 
   return (
     <div
-      className={`drawer drawer-end ${open ? 'drawer-open' : ''}`}
+      className={`drawer drawer-end z-50 ${open ? 'drawer-open' : ''}`}
       data-testid="project-sidebar"
     >
       <input
+        id="project-sidebar-toggle"
         type="checkbox"
         className="drawer-toggle"
         checked={open}
@@ -37,7 +39,11 @@ export default function ProjectSidebar({
       />
       <div className="drawer-content" />
       <div className="drawer-side">
-        <label className="drawer-overlay" onClick={onClose} />
+        <label
+          className="drawer-overlay"
+          onClick={onClose}
+          htmlFor="project-sidebar-toggle"
+        />
         <aside className="p-4 w-80 bg-base-200">
           <h2 className="font-display text-lg mb-2">{project}</h2>
           {meta ? (

--- a/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useState } from 'react';
+import ExternalLink from './ExternalLink';
+import PackMetaModal from './PackMetaModal';
+import { PackMeta } from '../../main/projects';
+
+export default function ProjectSidebar({
+  project,
+  open,
+  onClose,
+}: {
+  project: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const [meta, setMeta] = useState<PackMeta | null>(null);
+  const [edit, setEdit] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      window.electronAPI?.loadPackMeta(project).then(setMeta);
+    }
+  }, [open, project]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className={`drawer drawer-end ${open ? 'drawer-open' : ''}`}
+      data-testid="project-sidebar"
+    >
+      <input
+        type="checkbox"
+        className="drawer-toggle"
+        checked={open}
+        onChange={onClose}
+        data-testid="sidebar-toggle"
+      />
+      <div className="drawer-content" />
+      <div className="drawer-side">
+        <label className="drawer-overlay" onClick={onClose} />
+        <aside className="p-4 w-80 bg-base-200">
+          <h2 className="font-display text-lg mb-2">{project}</h2>
+          {meta ? (
+            <div className="card bg-base-100 p-4">
+              <p>{meta.description}</p>
+              <p className="text-sm mt-1">Author: {meta.author}</p>
+              <ul className="list-disc list-inside mt-2">
+                {meta.urls.map((u) => (
+                  <li key={u}>
+                    <ExternalLink href={u} className="link link-primary">
+                      {u}
+                    </ExternalLink>
+                  </li>
+                ))}
+              </ul>
+              <p className="text-xs mt-2">
+                Created: {new Date(meta.created).toLocaleDateString()}
+              </p>
+              {meta.updated && (
+                <p className="text-xs">
+                  Updated: {new Date(meta.updated).toLocaleDateString()}
+                </p>
+              )}
+              <button
+                className="btn btn-primary btn-sm mt-2"
+                onClick={() => setEdit(true)}
+              >
+                Edit
+              </button>
+            </div>
+          ) : (
+            <div>Loading...</div>
+          )}
+        </aside>
+      </div>
+      {edit && meta && (
+        <PackMetaModal
+          meta={meta}
+          onCancel={() => setEdit(false)}
+          onSave={(m) => {
+            window.electronAPI?.savePackMeta(project, m).then(() => {
+              setMeta(m);
+              setEdit(false);
+            });
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -64,7 +64,7 @@ Both protocols are registered in `src/index.ts` when Electron starts.
 
 ## Project Metadata Sidebar
 
-The projects dashboard shows a drawer on the right when you click **Info** on a
-project row. This sidebar loads `pack.json` via IPC and displays the pack
-description, author, related URLs and creation timestamps. You can edit these
-fields through the **Edit** button which writes back to `pack.json`.
+The projects dashboard includes a sidebar next to the project table. Selecting a
+row loads `pack.json` via IPC and displays the pack description, author, related
+URLs and creation timestamps. Use the **Edit** button to modify these fields and
+save back to `pack.json`.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -61,3 +61,10 @@ Two custom protocols simplify image previews:
   asset browser to preview modified assets.
 
 Both protocols are registered in `src/index.ts` when Electron starts.
+
+## Project Metadata Sidebar
+
+The projects dashboard shows a drawer on the right when you click **Info** on a
+project row. This sidebar loads `pack.json` via IPC and displays the pack
+description, author, related URLs and creation timestamps. You can edit these
+fields through the **Edit** button which writes back to `pack.json`.


### PR DESCRIPTION
## Summary
- show project metadata in a new sidebar drawer
- fetch and save `pack.json` via IPC
- add modal to edit metadata
- document sidebar usage in developer handbook
- check off metadata sidebar in TODO list
- cover the sidebar with new tests

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c15026660833195bffaf3773b78c7