### PR TITLE
Implement categorized asset sections

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 ## 3. Vanilla Asset Browser
 
-- [ ] Categorized sections
+- [x] Categorized sections
 - [x] Properly formatted texture names, with original filename fallback
 - [x] Responsive grid thumbnails (zoom 24–128 px, hover ring)
 - [ ] Drag‑or‑click to add asset to project

--- a/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
@@ -20,7 +20,11 @@ describe('AssetSelector', () => {
       addTexture,
       getTextureUrl,
     };
-    listTextures.mockResolvedValue(['block/grass.png', 'item/axe.png']);
+    listTextures.mockResolvedValue([
+      'block/grass.png',
+      'item/axe.png',
+      'other/custom.png',
+    ]);
     getTextureUrl.mockImplementation((_p, n) => `texture://${n}`);
     vi.clearAllMocks();
   });
@@ -51,6 +55,18 @@ describe('AssetSelector', () => {
     expect(
       within(section.parentElement!).getByRole('button', {
         name: 'item/axe.png',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('puts uncategorized textures into misc', async () => {
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'custom' } });
+    const section = await screen.findByText('misc');
+    expect(
+      within(section.parentElement!).getByRole('button', {
+        name: 'other/custom.png',
       })
     ).toBeInTheDocument();
   });

--- a/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 
 import AssetSelector from '../src/renderer/components/AssetSelector';
 
@@ -20,8 +20,8 @@ describe('AssetSelector', () => {
       addTexture,
       getTextureUrl,
     };
-    listTextures.mockResolvedValue(['grass.png', 'stone.png']);
-    getTextureUrl.mockResolvedValue('texture://img/grass.png');
+    listTextures.mockResolvedValue(['block/grass.png', 'item/axe.png']);
+    getTextureUrl.mockImplementation((_p, n) => `texture://${n}`);
     vi.clearAllMocks();
   });
 
@@ -30,14 +30,29 @@ describe('AssetSelector', () => {
     expect(listTextures).toHaveBeenCalledWith('/proj');
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
-    const button = await screen.findByRole('button', { name: 'grass.png' });
-    const img = (await screen.findByAltText('Grass')) as HTMLImageElement;
-    expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'grass.png');
-    expect(img.src).toContain('texture://img/grass.png');
-    expect(screen.getByText('Grass')).toBeInTheDocument();
-    expect(screen.getByText('grass.png')).toBeInTheDocument();
+    const section = await screen.findByText('blocks');
+    const button = within(section.parentElement!).getByRole('button', {
+      name: 'block/grass.png',
+    });
+    const img = within(section.parentElement!).getByAltText(
+      'Grass'
+    ) as HTMLImageElement;
+    expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/grass.png');
+    expect(img.src).toContain('texture://block/grass.png');
     fireEvent.click(button);
-    expect(addTexture).toHaveBeenCalledWith('/proj', 'grass.png');
+    expect(addTexture).toHaveBeenCalledWith('/proj', 'block/grass.png');
+  });
+
+  it('shows items in the items category', async () => {
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'axe' } });
+    const section = await screen.findByText('items');
+    expect(
+      within(section.parentElement!).getByRole('button', {
+        name: 'item/axe.png',
+      })
+    ).toBeInTheDocument();
   });
 
   it('adjusts zoom level with slider', async () => {

--- a/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
@@ -40,6 +40,7 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
       entity: [],
       ui: [],
       audio: [],
+      misc: [],
     };
     for (const tex of filtered) {
       if (tex.name.startsWith('block/')) out.blocks.push(tex);
@@ -53,6 +54,7 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
         out.ui.push(tex);
       else if (tex.name.startsWith('sound/') || tex.name.startsWith('sounds/'))
         out.audio.push(tex);
+      else out.misc.push(tex);
     }
     return out;
   }, [filtered]);
@@ -82,49 +84,51 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
           className="range range-xs w-32"
         />
       </div>
-      {(['blocks', 'items', 'entity', 'ui', 'audio'] as const).map((key) => {
-        const list = categories[key];
-        return (
-          <div className="collapse collapse-arrow mb-2" key={key}>
-            <input type="checkbox" defaultChecked />
-            <div className="collapse-title font-medium capitalize">{key}</div>
-            <div className="collapse-content overflow-y-auto h-48">
-              <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
-                {list.map((tex) => {
-                  const formatted = formatTextureName(tex.name);
-                  return (
-                    <div
-                      key={tex.name}
-                      className="text-center tooltip"
-                      data-tip={`${formatted} \n${tex.name}`}
-                    >
-                      <button
-                        aria-label={tex.name}
-                        onClick={() => handleSelect(tex.name)}
-                        className="p-1 hover:ring ring-accent rounded"
+      {(['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
+        (key) => {
+          const list = categories[key];
+          return (
+            <div className="collapse collapse-arrow mb-2" key={key}>
+              <input type="checkbox" defaultChecked />
+              <div className="collapse-title font-medium capitalize">{key}</div>
+              <div className="collapse-content overflow-y-auto h-48">
+                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
+                  {list.map((tex) => {
+                    const formatted = formatTextureName(tex.name);
+                    return (
+                      <div
+                        key={tex.name}
+                        className="text-center tooltip"
+                        data-tip={`${formatted} \n${tex.name}`}
                       >
-                        <img
-                          src={tex.url}
-                          alt={formatted}
-                          style={{
-                            width: zoom,
-                            height: zoom,
-                            imageRendering: 'pixelated',
-                          }}
-                        />
-                      </button>
-                      <div className="text-xs leading-tight">
-                        <div>{formatted}</div>
-                        <div className="opacity-50">{tex.name}</div>
+                        <button
+                          aria-label={tex.name}
+                          onClick={() => handleSelect(tex.name)}
+                          className="p-1 hover:ring ring-accent rounded"
+                        >
+                          <img
+                            src={tex.url}
+                            alt={formatted}
+                            style={{
+                              width: zoom,
+                              height: zoom,
+                              imageRendering: 'pixelated',
+                            }}
+                          />
+                        </button>
+                        <div className="text-xs leading-tight">
+                          <div>{formatted}</div>
+                          <div className="opacity-50">{tex.name}</div>
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
+                    );
+                  })}
+                </div>
               </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        }
+      )}
     </div>
   );
 };

--- a/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/AssetSelector.tsx
@@ -33,6 +33,30 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
 
   const filtered = query ? all.filter((t) => t.name.includes(query)) : [];
 
+  const categories = React.useMemo(() => {
+    const out: Record<string, TextureInfo[]> = {
+      blocks: [],
+      items: [],
+      entity: [],
+      ui: [],
+      audio: [],
+    };
+    for (const tex of filtered) {
+      if (tex.name.startsWith('block/')) out.blocks.push(tex);
+      else if (tex.name.startsWith('item/')) out.items.push(tex);
+      else if (tex.name.startsWith('entity/')) out.entity.push(tex);
+      else if (
+        tex.name.startsWith('gui/') ||
+        tex.name.startsWith('font/') ||
+        tex.name.startsWith('misc/')
+      )
+        out.ui.push(tex);
+      else if (tex.name.startsWith('sound/') || tex.name.startsWith('sounds/'))
+        out.audio.push(tex);
+    }
+    return out;
+  }, [filtered]);
+
   const handleSelect = (name: string) => {
     window.electronAPI?.addTexture(projectPath, name);
   };
@@ -58,38 +82,49 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
           className="range range-xs w-32"
         />
       </div>
-      <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2 overflow-y-auto h-48">
-        {filtered.map((tex) => {
-          const formatted = formatTextureName(tex.name);
-          return (
-            <div
-              key={tex.name}
-              className="text-center tooltip"
-              data-tip={`${formatted} \n${tex.name}`}
-            >
-              <button
-                aria-label={tex.name}
-                onClick={() => handleSelect(tex.name)}
-                className="p-1 hover:ring ring-accent rounded"
-              >
-                <img
-                  src={tex.url}
-                  alt={formatted}
-                  style={{
-                    width: zoom,
-                    height: zoom,
-                    imageRendering: 'pixelated',
-                  }}
-                />
-              </button>
-              <div className="text-xs leading-tight">
-                <div>{formatted}</div>
-                <div className="opacity-50">{tex.name}</div>
+      {(['blocks', 'items', 'entity', 'ui', 'audio'] as const).map((key) => {
+        const list = categories[key];
+        return (
+          <div className="collapse collapse-arrow mb-2" key={key}>
+            <input type="checkbox" defaultChecked />
+            <div className="collapse-title font-medium capitalize">{key}</div>
+            <div className="collapse-content overflow-y-auto h-48">
+              <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
+                {list.map((tex) => {
+                  const formatted = formatTextureName(tex.name);
+                  return (
+                    <div
+                      key={tex.name}
+                      className="text-center tooltip"
+                      data-tip={`${formatted} \n${tex.name}`}
+                    >
+                      <button
+                        aria-label={tex.name}
+                        onClick={() => handleSelect(tex.name)}
+                        className="p-1 hover:ring ring-accent rounded"
+                      >
+                        <img
+                          src={tex.url}
+                          alt={formatted}
+                          style={{
+                            width: zoom,
+                            height: zoom,
+                            imageRendering: 'pixelated',
+                          }}
+                        />
+                      </button>
+                      <div className="text-xs leading-tight">
+                        <div>{formatted}</div>
+                        <div className="opacity-50">{tex.name}</div>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
-          );
-        })}
-      </div>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -73,6 +73,6 @@ save back to `pack.json`.
 
 The vanilla asset browser lets you search textures from the selected Minecraft
 version. Results are grouped into collapsible **Blocks**, **Items**, **Entity**,
-**UI** and **Audio** sections using daisyUI's collapse component. Only assets
+**UI**, **Audio** and **Misc** sections using daisyUI's collapse component. Only assets
 that match the search query appear in each section. Thumbnails respect the zoom
 slider (24–128 px) and clicking a texture adds it to the project.

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -68,3 +68,11 @@ The projects dashboard includes a sidebar next to the project table. Selecting a
 row loads `pack.json` via IPC and displays the pack description, author, related
 URLs and creation timestamps. Use the **Edit** button to modify these fields and
 save back to `pack.json`.
+
+## Asset Browser
+
+The vanilla asset browser lets you search textures from the selected Minecraft
+version. Results are grouped into collapsible **Blocks**, **Items**, **Entity**,
+**UI** and **Audio** sections using daisyUI's collapse component. Only assets
+that match the search query appear in each section. Thumbnails respect the zoom
+slider (24–128 px) and clicking a texture adds it to the project.


### PR DESCRIPTION
## Summary
- group textures in AssetSelector by Blocks, Items, Entity, UI and Audio
- make sections collapsible via daisyUI collapse component
- add unit tests for categorized sections
- document asset browser behaviour in the handbook
- check off TODO for categorized sections

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c8f68e32883319e536d34713f3274