### PR TITLE
Fix lint warnings and tests

### DIFF
--- a/apps/mc-pack-tool/__tests__/About.test.tsx
+++ b/apps/mc-pack-tool/__tests__/About.test.tsx
@@ -28,8 +28,12 @@ describe('About', () => {
     render(<About />);
     const gh = screen.getByText('GitHub');
     const docs = screen.getByText('Documentation');
-    gh.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    docs.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    gh.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
+    docs.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, cancelable: true })
+    );
     expect(openExternalMock).toHaveBeenCalledWith(
       'https://github.com/iamkaf/minecraft-resource-packer'
     );

--- a/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
+++ b/apps/mc-pack-tool/__tests__/AssetSelector.test.tsx
@@ -35,12 +35,12 @@ describe('AssetSelector', () => {
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
     const section = await screen.findByText('blocks');
-    const button = within(section.parentElement!).getByRole('button', {
+    expect(section.parentElement).not.toBeNull();
+    const sectionParent = section.parentElement as HTMLElement;
+    const button = within(sectionParent).getByRole('button', {
       name: 'block/grass.png',
     });
-    const img = within(section.parentElement!).getByAltText(
-      'Grass'
-    ) as HTMLImageElement;
+    const img = within(sectionParent).getByAltText('Grass') as HTMLImageElement;
     expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/grass.png');
     expect(img.src).toContain('texture://block/grass.png');
     fireEvent.click(button);
@@ -52,8 +52,10 @@ describe('AssetSelector', () => {
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'axe' } });
     const section = await screen.findByText('items');
+    expect(section.parentElement).not.toBeNull();
+    const itemParent = section.parentElement as HTMLElement;
     expect(
-      within(section.parentElement!).getByRole('button', {
+      within(itemParent).getByRole('button', {
         name: 'item/axe.png',
       })
     ).toBeInTheDocument();
@@ -64,8 +66,10 @@ describe('AssetSelector', () => {
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'custom' } });
     const section = await screen.findByText('misc');
+    expect(section.parentElement).not.toBeNull();
+    const miscParent = section.parentElement as HTMLElement;
     expect(
-      within(section.parentElement!).getByRole('button', {
+      within(miscParent).getByRole('button', {
         name: 'other/custom.png',
       })
     ).toBeInTheDocument();

--- a/apps/mc-pack-tool/__tests__/assets.test.ts
+++ b/apps/mc-pack-tool/__tests__/assets.test.ts
@@ -15,6 +15,7 @@ import {
   listVersions,
 } from '../src/main/assets';
 import { createProject } from '../src/main/projects';
+import * as icon from '../src/main/icon';
 const manifestStub = JSON.parse(
   fs.readFileSync(
     path.join(__dirname, 'fixtures', 'version_manifest.json'),
@@ -122,6 +123,7 @@ describe('listTextures', () => {
   const projDir = path.join(baseDir, 'Pack');
 
   beforeAll(async () => {
+    vi.spyOn(icon, 'generatePackIcon').mockResolvedValue();
     await createProject(baseDir, 'Pack', version);
     const texDir = path.join(
       os.tmpdir(),

--- a/apps/mc-pack-tool/__tests__/createProject.test.ts
+++ b/apps/mc-pack-tool/__tests__/createProject.test.ts
@@ -1,15 +1,17 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { v4 as uuid } from 'uuid';
 import { createProject } from '../src/main/projects';
 import { ProjectMetadataSchema } from '../src/minecraft/project';
+import * as icon from '../src/main/icon';
 
 const baseDir = path.join(os.tmpdir(), `projtest-${uuid()}`);
 
 beforeAll(() => {
   fs.mkdirSync(baseDir, { recursive: true });
+  vi.spyOn(icon, 'generatePackIcon').mockResolvedValue();
 });
 
 afterAll(() => {

--- a/apps/mc-pack-tool/src/index.ts
+++ b/apps/mc-pack-tool/src/index.ts
@@ -14,12 +14,10 @@ import { registerProjectHandlers } from './main/projects';
 import {
   addTexture,
   listTextures,
-  listVersions,
   getTexturePath,
   getTextureURL,
   registerTextureProtocol,
   registerProjectTextureProtocol,
-  setActiveProject,
 } from './main/assets';
 import { generatePackIcon } from './main/icon';
 import { ProjectMetadataSchema } from './minecraft/project';

--- a/apps/mc-pack-tool/src/main/projects.ts
+++ b/apps/mc-pack-tool/src/main/projects.ts
@@ -8,6 +8,9 @@ import {
   PackMetaSchema,
 } from '../minecraft/project';
 import { listVersions, setActiveProject } from './assets';
+
+// Re-export PackMeta so renderer and preload can import the type from this file
+export type { PackMeta } from '../minecraft/project';
 import { generatePackIcon } from './icon';
 
 export async function createProject(

--- a/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/PackMetaModal.tsx
@@ -27,8 +27,8 @@ export default function PackMetaModal({
             author,
             urls: urls
               .split(/\n+/)
-              .map((u) => u.trim())
-              .filter((u) => u),
+              .map((u: string) => u.trim())
+              .filter((u: string) => u),
             updated: Date.now(),
           });
         }}

--- a/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/ProjectSidebar.tsx
@@ -28,7 +28,7 @@ export default function ProjectSidebar({
               <p>{meta.description}</p>
               <p className="text-sm mt-1">Author: {meta.author}</p>
               <ul className="list-disc list-inside mt-2">
-                {meta.urls.map((u) => (
+                {meta.urls.map((u: string) => (
                   <li key={u}>
                     <ExternalLink href={u} className="link link-primary">
                       {u}


### PR DESCRIPTION
## Summary
- remove unused imports from `index.ts`
- re-export `PackMeta` type from `projects.ts`
- make URL handlers cancelable in `About.test`
- avoid non-null assertions in `AssetSelector.test`
- stub pack icon generation in tests
- type parameters in components

## Testing
- `npm run lint`
- `npm test`
- `npx tsc -p apps/mc-pack-tool/tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684c9590d5c883319509a53380010310