### PR TITLE
Switch to async fs operations

### DIFF
--- a/apps/mc-pack-tool/__tests__/openFile.test.ts
+++ b/apps/mc-pack-tool/__tests__/openFile.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 
 // Capture the IPC handler registered by registerFileHandlers
 // eslint-disable-next-line no-var
-var openHandler: ((e: unknown, file: string) => void) | undefined;
+var openHandler:
+  | ((e: unknown, file: string) => Promise<void> | void)
+  | undefined;
 // eslint-disable-next-line no-var
 var openPathMock: ReturnType<typeof vi.fn>;
 
@@ -18,7 +20,10 @@ vi.mock('electron', () => ({
     webContents: { on: vi.fn(), send: vi.fn() },
   })),
   ipcMain: {
-    handle: (channel: string, fn: (event: unknown, file: string) => void) => {
+    handle: (
+      channel: string,
+      fn: (event: unknown, file: string) => Promise<void> | void
+    ) => {
       if (channel === 'open-file') openHandler = fn;
     },
   },


### PR DESCRIPTION
## Summary
- rewrite project management functions to use `fs.promises`
- convert asset helpers to async fs methods
- update file watcher to list files asynchronously
- adjust open-file IPC test for async handler

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684ca73f6638833191370e06c002ebbc