### PR TITLE
Fix TypeScript compile and lint warnings

### DIFF
--- a/apps/mc-pack-tool/src/main/assets.ts
+++ b/apps/mc-pack-tool/src/main/assets.ts
@@ -5,6 +5,7 @@ import type { Protocol, IpcMain } from 'electron';
 import os from 'os';
 import unzipper from 'unzipper';
 import { ProjectMetadataSchema } from '../shared/project';
+import { generatePackIcon } from './icon';
 
 /** URL pointing to Mojang's version manifest which lists all official releases. */
 const VERSION_MANIFEST =

--- a/apps/mc-pack-tool/src/main/ipc/fileWatcher.ts
+++ b/apps/mc-pack-tool/src/main/ipc/fileWatcher.ts
@@ -1,11 +1,11 @@
 import type { IpcMain } from 'electron';
 import { BrowserWindow } from 'electron';
-import chokidar from 'chokidar';
+import { watch, FSWatcher } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
 
 let win: BrowserWindow | null = null;
-const watchers = new Map<string, chokidar.FSWatcher>();
+const watchers = new Map<string, FSWatcher>();
 
 async function listFiles(dir: string): Promise<string[]> {
   const files: string[] = [];
@@ -31,7 +31,7 @@ export function registerFileWatcherHandlers(
   win = window;
   ipc.handle('watch-project', async (_e, projectPath: string) => {
     if (!watchers.has(projectPath)) {
-      const watcher = chokidar.watch(projectPath, { ignoreInitial: true });
+      const watcher = watch(projectPath, { ignoreInitial: true });
       watcher.on('add', (file) => {
         win?.webContents.send(
           'file-added',

--- a/apps/mc-pack-tool/src/renderer/components/App.tsx
+++ b/apps/mc-pack-tool/src/renderer/components/App.tsx
@@ -25,7 +25,7 @@ const App: React.FC = () => {
 
   useEffect(() => {
     // Listen for the main process telling us which project to load.
-    window.electronAPI?.onOpenProject((_event, path: string) => {
+    window.electronAPI?.onOpenProject((_event: unknown, path: string) => {
       setProjectPath(path);
       setView('projects');
     });
@@ -60,7 +60,7 @@ const App: React.FC = () => {
       window.electronAPI
         ?.exportProject(projectPath)
         .then((s) => {
-          setSummary(s);
+          if (s) setSummary(s);
           if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
             confetti.current?.({
               particleCount: 150,

--- a/apps/mc-pack-tool/src/shared/global.d.ts
+++ b/apps/mc-pack-tool/src/shared/global.d.ts
@@ -14,11 +14,31 @@ type IpcListener<C extends keyof IpcEventMap> = (
 declare global {
   interface Window {
     electronAPI?: {
-      [K in keyof IpcRequestMap as K extends keyof IpcEventMap
-        ? never
-        : K]: IpcInvoke<K>;
-    } & {
-      [K in keyof IpcEventMap as K]: IpcListener<K>;
+      listProjects: IpcInvoke<'list-projects'>;
+      listVersions: IpcInvoke<'list-versions'>;
+      createProject: IpcInvoke<'create-project'>;
+      importProject: IpcInvoke<'import-project'>;
+      duplicateProject: IpcInvoke<'duplicate-project'>;
+      deleteProject: IpcInvoke<'delete-project'>;
+      openProject: IpcInvoke<'open-project'>;
+      loadPackMeta: IpcInvoke<'load-pack-meta'>;
+      savePackMeta: IpcInvoke<'save-pack-meta'>;
+      addTexture: IpcInvoke<'add-texture'>;
+      listTextures: IpcInvoke<'list-textures'>;
+      getTexturePath: IpcInvoke<'get-texture-path'>;
+      getTextureUrl: IpcInvoke<'get-texture-url'>;
+      randomizeIcon: IpcInvoke<'randomize-icon'>;
+      exportProject: IpcInvoke<'export-project'>;
+      openInFolder: IpcInvoke<'open-in-folder'>;
+      openFile: IpcInvoke<'open-file'>;
+      renameFile: IpcInvoke<'rename-file'>;
+      deleteFile: IpcInvoke<'delete-file'>;
+      watchProject: IpcInvoke<'watch-project'>;
+      unwatchProject: IpcInvoke<'unwatch-project'>;
+      onOpenProject: IpcListener<'project-opened'>;
+      onFileAdded: IpcListener<'file-added'>;
+      onFileRemoved: IpcListener<'file-removed'>;
+      onFileRenamed: IpcListener<'file-renamed'>;
     };
   }
 }


### PR DESCRIPTION
## Summary
- fix default chokidar import and watchers
- expose camelCase api typings for window.electronAPI
- import generatePackIcon in assets
- clean up implicit any warnings in App component

## Testing
- `npm run lint`
- `npx tsc -p apps/mc-pack-tool/tsconfig.json --noEmit`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684cb25b70588331bfef449e7b17a403