### PR TITLE
Virtualize texture grid

### DIFF
--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -86,4 +86,17 @@ describe('AssetSelector', () => {
     fireEvent.change(slider, { target: { value: '100' } });
     expect(img.style.width).toBe('100px');
   });
+
+  it('renders only visible items', async () => {
+    listTextures.mockResolvedValue(
+      Array.from({ length: 50 }, (_, i) => `block/test${i}.png`)
+    );
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'test' } });
+    await screen.findByText('blocks');
+    expect(
+      screen.getAllByRole('button', { name: /block\/test/ }).length
+    ).toBeLessThan(50);
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,8 @@
         "react": "^19.1.0",
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.1.0",
+        "react-virtualized-auto-sizer": "^1.0.26",
+        "react-window": "^1.8.11",
         "sharp": "^0.34.2",
         "unique-names-generator": "^4.7.1",
         "uuid": "^11.1.0",
@@ -170,7 +172,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -11111,6 +11112,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
+      "license": "MIT"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -12840,6 +12847,33 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-virtualized-auto-sizer": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
+      "integrity": "sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "react": "^19.1.0",
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.1.0",
+    "react-virtualized-auto-sizer": "^1.0.26",
+    "react-window": "^1.8.11",
     "sharp": "^0.34.2",
     "unique-names-generator": "^4.7.1",
     "uuid": "^11.1.0",

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -1,13 +1,8 @@
 import React, { useEffect, useState } from 'react';
-import { formatTextureName } from '../utils/textureNames';
+import TextureGrid, { TextureInfo } from './TextureGrid';
 
 interface Props {
   path: string;
-}
-
-interface TextureInfo {
-  name: string;
-  url: string;
 }
 
 const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
@@ -91,39 +86,13 @@ const AssetSelector: React.FC<Props> = ({ path: projectPath }) => {
             <div className="collapse collapse-arrow mb-2" key={key}>
               <input type="checkbox" defaultChecked />
               <div className="collapse-title font-medium capitalize">{key}</div>
-              <div className="collapse-content overflow-y-auto h-48">
-                <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-2">
-                  {list.map((tex) => {
-                    const formatted = formatTextureName(tex.name);
-                    return (
-                      <div
-                        key={tex.name}
-                        className="text-center tooltip"
-                        data-tip={`${formatted} \n${tex.name}`}
-                      >
-                        <button
-                          aria-label={tex.name}
-                          onClick={() => handleSelect(tex.name)}
-                          className="p-1 hover:ring ring-accent rounded"
-                        >
-                          <img
-                            src={tex.url}
-                            alt={formatted}
-                            style={{
-                              width: zoom,
-                              height: zoom,
-                              imageRendering: 'pixelated',
-                            }}
-                          />
-                        </button>
-                        <div className="text-xs leading-tight">
-                          <div>{formatted}</div>
-                          <div className="opacity-50">{tex.name}</div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+              <div className="collapse-content">
+                <TextureGrid
+                  testId="texture-grid"
+                  textures={list}
+                  zoom={zoom}
+                  onSelect={handleSelect}
+                />
               </div>
             </div>
           );

--- a/src/renderer/components/TextureGrid.tsx
+++ b/src/renderer/components/TextureGrid.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { FixedSizeGrid as Grid, GridChildComponentProps } from 'react-window';
+import { formatTextureName } from '../utils/textureNames';
+
+export interface TextureInfo {
+  name: string;
+  url: string;
+}
+
+interface Props {
+  textures: TextureInfo[];
+  zoom: number;
+  onSelect: (name: string) => void;
+  testId?: string;
+}
+
+interface CellData {
+  textures: TextureInfo[];
+  columnCount: number;
+  zoom: number;
+  onSelect: (name: string) => void;
+}
+
+const Cell: React.FC<GridChildComponentProps<CellData>> = ({
+  columnIndex,
+  rowIndex,
+  style,
+  data,
+}) => {
+  const index = rowIndex * data.columnCount + columnIndex;
+  if (index >= data.textures.length) return null;
+  const tex = data.textures[index];
+  const formatted = formatTextureName(tex.name);
+  return (
+    <div style={style} className="p-2 box-border">
+      <div
+        className="text-center tooltip"
+        data-tip={`${formatted} \n${tex.name}`}
+      >
+        <button
+          aria-label={tex.name}
+          onClick={() => data.onSelect(tex.name)}
+          className="p-1 hover:ring ring-accent rounded"
+        >
+          <img
+            src={tex.url}
+            alt={formatted}
+            style={{
+              width: data.zoom,
+              height: data.zoom,
+              imageRendering: 'pixelated',
+            }}
+          />
+        </button>
+        <div className="text-xs leading-tight">
+          <div>{formatted}</div>
+          <div className="opacity-50">{tex.name}</div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const TextureGrid: React.FC<Props> = ({ textures, zoom, onSelect, testId }) => {
+  const width = typeof window !== 'undefined' ? window.innerWidth : 640;
+  const columnWidth = zoom + 40;
+  const rowHeight = zoom + 48;
+  const columnCount = Math.max(1, Math.floor(width / columnWidth));
+  const rowCount = Math.ceil(textures.length / columnCount);
+  return (
+    <div
+      style={{ height: '12rem' }}
+      data-testid={testId}
+      className="overflow-y-auto"
+    >
+      <Grid
+        columnCount={columnCount}
+        columnWidth={columnWidth}
+        height={192}
+        rowCount={rowCount}
+        rowHeight={rowHeight}
+        width={columnCount * columnWidth}
+        itemData={{ textures, columnCount, zoom, onSelect }}
+      >
+        {Cell}
+      </Grid>
+    </div>
+  );
+};
+
+export default TextureGrid;


### PR DESCRIPTION
## Summary
- add `react-window` and `auto-sizer` deps
- create `TextureGrid` component using `FixedSizeGrid`
- wrap texture sections in the virtualized grid
- test that only visible items are rendered

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d53b1c45c8331abf5c5595ec852cb