### PR TITLE
Refactor Project Manager components

### DIFF
--- a/__tests__/ProjectForm.test.tsx
+++ b/__tests__/ProjectForm.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectForm from '../src/renderer/components/project/ProjectForm';
+
+describe('ProjectForm', () => {
+  it('submits name and version', () => {
+    const create = vi.fn();
+    render(
+      <ProjectForm versions={['1.20']} onCreate={create} onImport={() => {}} />
+    );
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Pack' },
+    });
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: '1.20' },
+    });
+    fireEvent.click(screen.getByText('Create'));
+    expect(create).toHaveBeenCalledWith('Pack', '1.20');
+  });
+
+  it('imports when button clicked', () => {
+    const imp = vi.fn();
+    render(<ProjectForm versions={[]} onCreate={() => {}} onImport={imp} />);
+    fireEvent.click(screen.getByText('Import'));
+    expect(imp).toHaveBeenCalled();
+  });
+
+  it('does not submit without version', () => {
+    const create = vi.fn();
+    render(
+      <ProjectForm versions={['1.20']} onCreate={create} onImport={() => {}} />
+    );
+    fireEvent.change(screen.getByPlaceholderText('Name'), {
+      target: { value: 'Pack' },
+    });
+    fireEvent.click(screen.getByText('Create'));
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/ProjectModals.test.tsx
+++ b/__tests__/ProjectModals.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { useProjectModals } from '../src/renderer/components/project/ProjectModals';
+
+function Wrapper({
+  refresh,
+  toast,
+}: {
+  refresh: () => void;
+  toast: (m: string, t: 'success' | 'info' | 'error') => void;
+}) {
+  const { modals, openDuplicate, openDelete } = useProjectModals(
+    refresh,
+    toast
+  );
+  return (
+    <div>
+      <button onClick={() => openDuplicate('Alpha')}>dup</button>
+      <button onClick={() => openDelete('Alpha')}>del</button>
+      {modals}
+    </div>
+  );
+}
+
+describe('ProjectModals', () => {
+  it('duplicates project via modal', async () => {
+    const duplicateProject = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { electronAPI: { duplicateProject: typeof duplicateProject; deleteProject: () => void } }).electronAPI = {
+      duplicateProject,
+      deleteProject: vi.fn(),
+    };
+    const refresh = vi.fn();
+    const toast = vi.fn();
+    render(<Wrapper refresh={refresh} toast={toast} />);
+    fireEvent.click(screen.getByText('dup'));
+    const modal = await screen.findByTestId('rename-modal');
+    const form = modal.querySelector('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    fireEvent.click(screen.getByText('dup')); // reopen
+    const again = await screen.findByTestId('rename-modal');
+    fireEvent.click(within(again).getByText('Cancel'));
+    expect(duplicateProject).toHaveBeenCalledWith('Alpha', 'Alpha Copy');
+  });
+
+  it('deletes project via modal', async () => {
+    const deleteProject = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { electronAPI: { duplicateProject: () => void; deleteProject: typeof deleteProject } }).electronAPI = {
+      duplicateProject: vi.fn(),
+      deleteProject,
+    };
+    const refresh = vi.fn();
+    const toast = vi.fn();
+    render(<Wrapper refresh={refresh} toast={toast} />);
+    fireEvent.click(screen.getByText('del'));
+    await screen.findByTestId('confirm-modal');
+    fireEvent.click(screen.getByText('Delete'));
+    fireEvent.click(screen.getByText('del'));
+    const delModal = await screen.findByTestId('confirm-modal');
+    fireEvent.click(within(delModal).getByText('Cancel'));
+    expect(deleteProject).toHaveBeenCalledWith('Alpha');
+  });
+});

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectTable, {
+  ProjectInfo,
+} from '../src/renderer/components/project/ProjectTable';
+
+describe('ProjectTable', () => {
+  const projects: ProjectInfo[] = [
+    { name: 'Alpha', version: '1.20', assets: 2, lastOpened: 0 },
+    { name: 'Beta', version: '1.20', assets: 3, lastOpened: 0 },
+  ];
+
+  it('calls row action callbacks', () => {
+    const open = vi.fn();
+    const dup = vi.fn();
+    const del = vi.fn();
+    render(
+      <ProjectTable
+        projects={projects}
+        sortKey="name"
+        asc
+        onSort={() => {}}
+        selected={new Set()}
+        onSelect={() => {}}
+        onSelectAll={() => {}}
+        onOpen={open}
+        onDuplicate={dup}
+        onDelete={del}
+        onRowClick={() => {}}
+      />
+    );
+    fireEvent.click(screen.getAllByRole('button', { name: 'Open' })[0]);
+    expect(open).toHaveBeenCalledWith('Alpha');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Duplicate' })[0]);
+    expect(dup).toHaveBeenCalledWith('Alpha');
+    fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
+    expect(del).toHaveBeenCalledWith('Alpha');
+  });
+
+  it('selects rows and toggles all', () => {
+    const select = vi.fn();
+    const selectAll = vi.fn();
+    render(
+      <ProjectTable
+        projects={projects}
+        sortKey="name"
+        asc
+        onSort={() => {}}
+        selected={new Set()}
+        onSelect={select}
+        onSelectAll={selectAll}
+        onOpen={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        onRowClick={() => {}}
+      />
+    );
+    fireEvent.click(screen.getAllByRole('checkbox', { name: /Select/ })[1]);
+    expect(select).toHaveBeenCalledWith('Alpha', true);
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }));
+    expect(selectAll).toHaveBeenCalledWith(true);
+  });
+
+  it('sorts when header clicked', () => {
+    const sort = vi.fn();
+    render(
+      <ProjectTable
+        projects={projects}
+        sortKey="name"
+        asc
+        onSort={sort}
+        selected={new Set()}
+        onSelect={() => {}}
+        onSelectAll={() => {}}
+        onOpen={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        onRowClick={() => {}}
+      />
+    );
+    fireEvent.click(screen.getByText('Assets'));
+    expect(sort).toHaveBeenCalledWith('assets');
+  });
+});

--- a/src/renderer/components/ProjectManager.tsx
+++ b/src/renderer/components/ProjectManager.tsx
@@ -1,45 +1,40 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import Fuse from 'fuse.js';
 import { useToast } from './ToastProvider';
-import { generateProjectName } from '../utils/names';
-import RenameModal from './RenameModal';
-import ConfirmModal from './ConfirmModal';
 import ProjectSidebar from './ProjectSidebar';
 import Spinner from './Spinner';
+import ProjectForm from './project/ProjectForm';
+import ProjectTable, { ProjectInfo } from './project/ProjectTable';
+import { useProjectModals } from './project/ProjectModals';
 
-// Lists all available projects and lets the user open them.  Mimics the
-// project selection dialog used in game engines like Godot.
+// Lists all available projects and lets the user open them.
 
 const ProjectManager: React.FC = () => {
-  interface ProjectInfo {
-    name: string;
-    version: string;
-    assets: number;
-    lastOpened: number;
-  }
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [sortKey, setSortKey] = useState<keyof ProjectInfo>('name');
   const [asc, setAsc] = useState(true);
-  const [name, setName] = useState(() => generateProjectName());
-  const [version, setVersion] = useState('');
   const [versions, setVersions] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [filterVersion, setFilterVersion] = useState<string | null>(null);
-  const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [activeProject, setActiveProject] = useState<string | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [exporting, setExporting] = useState(false);
+
+  const toast = useToast();
 
   const refresh = () => {
     window.electronAPI?.listProjects().then(setProjects);
   };
 
   useEffect(() => {
-    // Fetch the list of projects and available versions when the component loads
     refresh();
     window.electronAPI?.listVersions().then(setVersions);
   }, []);
+
+  const { modals, openDuplicate, openDelete } = useProjectModals(
+    refresh,
+    toast
+  );
 
   const handleOpen = (n: string) => {
     window.electronAPI?.openProject(n);
@@ -49,25 +44,11 @@ const ProjectManager: React.FC = () => {
     window.electronAPI?.importProject().then(refresh);
   };
 
-  const handleDuplicate = (n: string) => {
-    setDuplicateTarget(n);
-  };
-
-  const handleDelete = (n: string) => {
-    setDeleteTarget(n);
-  };
-
-  const toast = useToast();
-
-  const handleCreate = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!name || !version) return;
+  const handleCreate = (name: string, version: string) => {
     window.electronAPI?.createProject(name, version).then(() => {
       refresh();
       toast('Project created', 'success');
     });
-    setName(generateProjectName());
-    setVersion('');
   };
 
   const handleSort = (key: keyof ProjectInfo) => {
@@ -114,8 +95,6 @@ const ProjectManager: React.FC = () => {
     return 0;
   });
 
-  const allSelected =
-    selected.size > 0 && sortedProjects.every((p) => selected.has(p.name));
   const toggleAll = (checked: boolean) => {
     if (checked) {
       setSelected(new Set(sortedProjects.map((p) => p.name)));
@@ -124,42 +103,22 @@ const ProjectManager: React.FC = () => {
     }
   };
 
+  const handleSelect = (name: string, checked: boolean) => {
+    const ns = new Set(selected);
+    if (checked) ns.add(name);
+    else ns.delete(name);
+    setSelected(ns);
+  };
+
   return (
     <section className="flex gap-4">
       <div className="flex-1">
         <h2 className="font-display text-xl mb-2">Projects</h2>
-        <form onSubmit={handleCreate} className="flex gap-2 mb-4">
-          <input
-            className="input input-bordered input-sm"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Name"
-          />
-          <select
-            className="select select-bordered select-sm"
-            value={version}
-            onChange={(e) => setVersion(e.target.value)}
-          >
-            <option value="" disabled>
-              Select version
-            </option>
-            {versions.map((v) => (
-              <option key={v} value={v}>
-                {v}
-              </option>
-            ))}
-          </select>
-          <button className="btn btn-primary btn-sm" type="submit">
-            Create
-          </button>
-          <button
-            type="button"
-            onClick={handleImport}
-            className="btn btn-secondary btn-sm"
-          >
-            Import
-          </button>
-        </form>
+        <ProjectForm
+          versions={versions}
+          onCreate={handleCreate}
+          onImport={handleImport}
+        />
         <div className="flex items-center gap-2 mb-2">
           <input
             className="input input-bordered input-sm w-40"
@@ -178,7 +137,9 @@ const ProjectManager: React.FC = () => {
                   e.key === 'Enter' &&
                   setFilterVersion(filterVersion === v ? null : v)
                 }
-                className={`badge badge-outline cursor-pointer select-none ${filterVersion === v ? 'badge-primary' : ''}`}
+                className={`badge badge-outline cursor-pointer select-none ${
+                  filterVersion === v ? 'badge-primary' : ''
+                }`}
               >
                 {v}
               </span>
@@ -192,108 +153,17 @@ const ProjectManager: React.FC = () => {
             Bulk Export
           </button>
         </div>
-        <div className="flex-1 overflow-x-auto">
-          <table className="table table-zebra w-full">
-            <thead>
-              <tr>
-                <th>
-                  <input
-                    type="checkbox"
-                    aria-label="Select all"
-                    checked={allSelected}
-                    onClick={(e) => e.stopPropagation()}
-                    onChange={(e) => toggleAll(e.target.checked)}
-                    className="checkbox checkbox-sm"
-                  />
-                </th>
-                <th
-                  onClick={() => handleSort('name')}
-                  className="cursor-pointer"
-                >
-                  Name
-                </th>
-                <th
-                  onClick={() => handleSort('version')}
-                  className="cursor-pointer"
-                >
-                  MC Version
-                </th>
-                <th
-                  onClick={() => handleSort('assets')}
-                  className="cursor-pointer"
-                >
-                  Assets
-                </th>
-                <th
-                  onClick={() => handleSort('lastOpened')}
-                  className="cursor-pointer"
-                >
-                  Last opened
-                </th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedProjects.map((p) => (
-                <tr
-                  key={p.name}
-                  onClick={() => setActiveProject(p.name)}
-                  className="cursor-pointer"
-                >
-                  <td>
-                    <input
-                      type="checkbox"
-                      aria-label={`Select ${p.name}`}
-                      checked={selected.has(p.name)}
-                      onClick={(e) => e.stopPropagation()}
-                      onChange={(e) => {
-                        e.stopPropagation();
-                        const ns = new Set(selected);
-                        if (e.target.checked) ns.add(p.name);
-                        else ns.delete(p.name);
-                        setSelected(ns);
-                      }}
-                      className="checkbox checkbox-sm"
-                    />
-                  </td>
-                  <td>{p.name}</td>
-                  <td>{p.version}</td>
-                  <td>{p.assets}</td>
-                  <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
-                  <td className="flex gap-1">
-                    <button
-                      className="btn btn-accent btn-sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleOpen(p.name);
-                      }}
-                    >
-                      Open
-                    </button>
-                    <button
-                      className="btn btn-info btn-sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDuplicate(p.name);
-                      }}
-                    >
-                      Duplicate
-                    </button>
-                    <button
-                      className="btn btn-error btn-sm"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleDelete(p.name);
-                      }}
-                    >
-                      Delete
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <ProjectTable
+          projects={sortedProjects}
+          onSort={handleSort}
+          selected={selected}
+          onSelect={handleSelect}
+          onSelectAll={toggleAll}
+          onOpen={handleOpen}
+          onDuplicate={openDuplicate}
+          onDelete={openDelete}
+          onRowClick={setActiveProject}
+        />
         {exporting && (
           <dialog className="modal modal-open" data-testid="bulk-export-modal">
             <div className="modal-box flex flex-col items-center">
@@ -302,38 +172,7 @@ const ProjectManager: React.FC = () => {
             </div>
           </dialog>
         )}
-        {duplicateTarget && (
-          <RenameModal
-            current={`${duplicateTarget} Copy`}
-            title="Duplicate Project"
-            confirmText="Duplicate"
-            onCancel={() => setDuplicateTarget(null)}
-            onRename={(newName) => {
-              const src = duplicateTarget;
-              setDuplicateTarget(null);
-              window.electronAPI?.duplicateProject(src, newName).then(() => {
-                refresh();
-                toast('Project duplicated', 'success');
-              });
-            }}
-          />
-        )}
-        {deleteTarget && (
-          <ConfirmModal
-            title="Delete Project"
-            message={`Delete project ${deleteTarget}?`}
-            confirmText="Delete"
-            onCancel={() => setDeleteTarget(null)}
-            onConfirm={() => {
-              const target = deleteTarget;
-              setDeleteTarget(null);
-              window.electronAPI?.deleteProject(target).then(() => {
-                refresh();
-                toast('Project deleted', 'info');
-              });
-            }}
-          />
-        )}
+        {modals}
       </div>
       <ProjectSidebar project={activeProject} />
     </section>

--- a/src/renderer/components/project/ProjectForm.tsx
+++ b/src/renderer/components/project/ProjectForm.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { generateProjectName } from '../../utils/names';
+
+export default function ProjectForm({
+  versions,
+  onCreate,
+  onImport,
+}: {
+  versions: string[];
+  onCreate: (name: string, version: string) => void;
+  onImport: () => void;
+}) {
+  const [name, setName] = useState(() => generateProjectName());
+  const [version, setVersion] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name || !version) return;
+    onCreate(name, version);
+    setName(generateProjectName());
+    setVersion('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
+      <input
+        className="input input-bordered input-sm"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name"
+      />
+      <select
+        className="select select-bordered select-sm"
+        value={version}
+        onChange={(e) => setVersion(e.target.value)}
+      >
+        <option value="" disabled>
+          Select version
+        </option>
+        {versions.map((v) => (
+          <option key={v} value={v}>
+            {v}
+          </option>
+        ))}
+      </select>
+      <button className="btn btn-primary btn-sm" type="submit">
+        Create
+      </button>
+      <button
+        type="button"
+        onClick={onImport}
+        className="btn btn-secondary btn-sm"
+      >
+        Import
+      </button>
+    </form>
+  );
+}

--- a/src/renderer/components/project/ProjectModals.tsx
+++ b/src/renderer/components/project/ProjectModals.tsx
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import RenameModal from '../RenameModal';
+import ConfirmModal from '../ConfirmModal';
+
+export function useProjectModals(
+  refresh: () => void,
+  toast: (msg: string, type: 'success' | 'info' | 'error') => void
+) {
+  const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+
+  const modals = (
+    <>
+      {duplicateTarget && (
+        <RenameModal
+          current={`${duplicateTarget} Copy`}
+          title="Duplicate Project"
+          confirmText="Duplicate"
+          onCancel={() => setDuplicateTarget(null)}
+          onRename={(newName) => {
+            const src = duplicateTarget;
+            setDuplicateTarget(null);
+            window.electronAPI?.duplicateProject(src, newName).then(() => {
+              refresh();
+              toast('Project duplicated', 'success');
+            });
+          }}
+        />
+      )}
+      {deleteTarget && (
+        <ConfirmModal
+          title="Delete Project"
+          message={`Delete project ${deleteTarget}?`}
+          confirmText="Delete"
+          onCancel={() => setDeleteTarget(null)}
+          onConfirm={() => {
+            const target = deleteTarget;
+            setDeleteTarget(null);
+            window.electronAPI?.deleteProject(target).then(() => {
+              refresh();
+              toast('Project deleted', 'info');
+            });
+          }}
+        />
+      )}
+    </>
+  );
+
+  return {
+    modals,
+    openDuplicate: setDuplicateTarget,
+    openDelete: setDeleteTarget,
+  };
+}

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+
+export interface ProjectInfo {
+  name: string;
+  version: string;
+  assets: number;
+  lastOpened: number;
+}
+
+export default function ProjectTable({
+  projects,
+  onSort,
+  selected,
+  onSelect,
+  onSelectAll,
+  onOpen,
+  onDuplicate,
+  onDelete,
+  onRowClick,
+}: {
+  projects: ProjectInfo[];
+  onSort: (k: keyof ProjectInfo) => void;
+  selected: Set<string>;
+  onSelect: (name: string, checked: boolean) => void;
+  onSelectAll: (checked: boolean) => void;
+  onOpen: (name: string) => void;
+  onDuplicate: (name: string) => void;
+  onDelete: (name: string) => void;
+  onRowClick: (name: string) => void;
+}) {
+  const allSelected =
+    selected.size > 0 && projects.every((p) => selected.has(p.name));
+
+  return (
+    <div className="flex-1 overflow-x-auto">
+      <table className="table table-zebra w-full">
+        <thead>
+          <tr>
+            <th>
+              <input
+                type="checkbox"
+                aria-label="Select all"
+                checked={allSelected}
+                onClick={(e) => e.stopPropagation()}
+                onChange={(e) => onSelectAll(e.target.checked)}
+                className="checkbox checkbox-sm"
+              />
+            </th>
+            <th onClick={() => onSort('name')} className="cursor-pointer">
+              Name
+            </th>
+            <th onClick={() => onSort('version')} className="cursor-pointer">
+              MC Version
+            </th>
+            <th onClick={() => onSort('assets')} className="cursor-pointer">
+              Assets
+            </th>
+            <th onClick={() => onSort('lastOpened')} className="cursor-pointer">
+              Last opened
+            </th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {projects.map((p) => (
+            <tr
+              key={p.name}
+              onClick={() => onRowClick(p.name)}
+              className="cursor-pointer"
+            >
+              <td>
+                <input
+                  type="checkbox"
+                  aria-label={`Select ${p.name}`}
+                  checked={selected.has(p.name)}
+                  onClick={(e) => e.stopPropagation()}
+                  onChange={(e) => {
+                    e.stopPropagation();
+                    onSelect(p.name, e.target.checked);
+                  }}
+                  className="checkbox checkbox-sm"
+                />
+              </td>
+              <td>{p.name}</td>
+              <td>{p.version}</td>
+              <td>{p.assets}</td>
+              <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
+              <td className="flex gap-1">
+                <button
+                  className="btn btn-accent btn-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onOpen(p.name);
+                  }}
+                >
+                  Open
+                </button>
+                <button
+                  className="btn btn-info btn-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDuplicate(p.name);
+                  }}
+                >
+                  Duplicate
+                </button>
+                <button
+                  className="btn btn-error btn-sm"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(p.name);
+                  }}
+                >
+                  Delete
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split project components into ProjectForm, ProjectTable and ProjectModals
- update `ProjectManager` to coordinate new sub-components
- add tests for each new component

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d535ba0e08331820af12ad61ee885