### PR TITLE
Add tests for new views

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 An Electron-based tool for creating Minecraft resource packs. The interface is designed to be fun and beginner friendly so anyone can pick a version, edit textures and export a ready to use pack.
 
+## Views
+
+- **Project Manager** – lists available packs with their Minecraft version and chosen assets. Create new projects or open existing ones.
+- **Editor** – browse and modify textures inside a project then export the finished pack.
+- **Settings** – customise application preferences.
+- **About** – see version info, license and helpful links.
+
 ## Features
 
-- **Project Manager** – integrated into the main window, it keeps a list of projects with their name, Minecraft version and chosen assets. You can create new packs or open and edit existing ones without switching windows.
 - **Asset Selection** – textures are pulled from Mojang's version manifest and cached locally for quick searching.
 - **Secure Previews** – images load through custom `texture://` and `ptex://` protocols so `file://` access is never required.
 - **Asset Editing** – when an asset is added it is copied into the correct folder structure inside the project. Files can be opened in Explorer/Finder or with the default program for that type. Any changes on disk instantly appear in the UI.
-- **Live Asset Browser** – the editor window lists all files in the project directory and automatically reloads when something changes.
+- **Live Asset Browser** – the Editor view lists all files in the project directory and automatically reloads when something changes.
 - **Random pack icon** – new packs start with a pastel background and random item image; you can regenerate from pack settings.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.
 

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import EditorView from '../src/renderer/views/EditorView';
+
+vi.mock('react-canvas-confetti', () => ({
+  __esModule: true,
+  default: () => <canvas />,
+}));
+vi.mock('../src/renderer/components/AssetSelector', () => ({
+  default: () => <div>selector</div>,
+}));
+vi.mock('../src/renderer/components/AssetBrowser', () => ({
+  default: () => <div>browser</div>,
+}));
+
+const summary = {
+  fileCount: 1,
+  totalSize: 1024,
+  durationMs: 1000,
+  warnings: [],
+};
+
+describe('EditorView', () => {
+  const exportProject = vi.fn();
+
+  beforeEach(() => {
+    interface API {
+      exportProject: (path: string) => Promise<typeof summary>;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      exportProject,
+    };
+    exportProject.mockResolvedValue(summary);
+    vi.clearAllMocks();
+  });
+
+  it('shows project path and exports pack', async () => {
+    render(<EditorView projectPath="/tmp/proj" onBack={() => undefined} />);
+    expect(screen.getByText('Project: /tmp/proj')).toBeInTheDocument();
+    const btn = screen.getByText('Export Pack');
+    await act(async () => {
+      fireEvent.click(btn);
+      await Promise.resolve();
+    });
+    expect(exportProject).toHaveBeenCalledWith('/tmp/proj');
+    expect(screen.getByTestId('export-summary')).toBeInTheDocument();
+  });
+
+  it('calls onBack when Back clicked', () => {
+    const back = vi.fn();
+    render(<EditorView projectPath="/tmp" onBack={back} />);
+    fireEvent.click(screen.getByText('Back to Projects'));
+    expect(back).toHaveBeenCalled();
+  });
+});

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import SettingsView from '../src/renderer/views/SettingsView';
+
+describe('SettingsView', () => {
+  it('renders placeholder heading', () => {
+    render(<SettingsView />);
+    const section = screen.getByTestId('settings-view');
+    expect(section).toHaveTextContent('Settings');
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -43,6 +43,16 @@ npm run format
 - `src/shared/` – utilities and typed IPC definitions shared across processes
 - `__tests__/` – Vitest unit tests
 
+## Views
+
+The renderer separates the interface into four top‑level views found under
+`src/renderer/views`:
+
+- **Project Manager** – choose, create or import projects.
+- **Editor** – edit project assets and export the finished pack.
+- **Settings** – application preferences.
+- **About** – version information, license and links.
+
 ## Adding Functionality
 
 When adding features that need access to Node APIs:


### PR DESCRIPTION
## Summary
- test Editor and Settings views
- document the four views in the README and developer handbook

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d65286f388331a6a0e47c0f2f117b