### PR TITLE
Refactor AssetBrowser with file hook

### DIFF
--- a/__tests__/AssetBrowserItem.test.tsx
+++ b/__tests__/AssetBrowserItem.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssetBrowserItem from '../src/renderer/components/AssetBrowserItem';
+
+const openInFolder = vi.fn();
+const openFile = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (
+    window as unknown as {
+      electronAPI: {
+        openInFolder: typeof openInFolder;
+        openFile: typeof openFile;
+      };
+    }
+  ).electronAPI = {
+    openInFolder,
+    openFile,
+  };
+});
+
+describe('AssetBrowserItem', () => {
+  it('calls IPC actions from context menu', async () => {
+    const confirmDelete = vi.fn();
+    const openRename = vi.fn();
+    render(
+      <AssetBrowserItem
+        projectPath="/proj"
+        file="a.txt"
+        selected={new Set()}
+        setSelected={() => undefined}
+        noExport={new Set()}
+        toggleNoExport={() => undefined}
+        confirmDelete={confirmDelete}
+        openRename={openRename}
+      />
+    );
+    const item = screen.getByText('a.txt');
+    fireEvent.contextMenu(item);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
+    expect(openInFolder).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.contextMenu(item);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
+    expect(openFile).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.contextMenu(item);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    expect(openRename).toHaveBeenCalledWith('a.txt');
+    fireEvent.contextMenu(item);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(confirmDelete).toHaveBeenCalledWith(['/proj/a.txt']);
+  });
+
+  it('toggles noExport for selected files', () => {
+    const toggleNoExport = vi.fn();
+    const selected = new Set(['a.txt', 'b.txt']);
+    render(
+      <AssetBrowserItem
+        projectPath="/proj"
+        file="a.txt"
+        selected={selected}
+        setSelected={() => undefined}
+        noExport={new Set()}
+        toggleNoExport={toggleNoExport}
+        confirmDelete={() => undefined}
+        openRename={() => undefined}
+      />
+    );
+    const item = screen.getByText('a.txt');
+    fireEvent.contextMenu(item);
+    const toggle = screen.getByRole('checkbox', { name: /No Export/i });
+    fireEvent.click(toggle);
+    expect(toggleNoExport).toHaveBeenCalledWith(['a.txt', 'b.txt'], true);
+  });
+});

--- a/__tests__/useProjectFiles.test.tsx
+++ b/__tests__/useProjectFiles.test.tsx
@@ -1,0 +1,86 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useProjectFiles } from '../src/renderer/components/file/useProjectFiles';
+
+const watchProject = vi.fn(async () => ['a.txt', 'b.png']);
+const unwatchProject = vi.fn();
+const onFileAdded = vi.fn();
+const onFileRemoved = vi.fn();
+const onFileRenamed = vi.fn();
+const getNoExport = vi.fn(async () => []);
+const setNoExport = vi.fn();
+
+declare global {
+  interface Window {
+    electronAPI?: {
+      watchProject: typeof watchProject;
+      unwatchProject: typeof unwatchProject;
+      onFileAdded: typeof onFileAdded;
+      onFileRemoved: typeof onFileRemoved;
+      onFileRenamed: typeof onFileRenamed;
+      getNoExport: typeof getNoExport;
+      setNoExport: typeof setNoExport;
+    };
+  }
+}
+
+describe('useProjectFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
+      {
+        watchProject,
+        unwatchProject,
+        onFileAdded,
+        onFileRemoved,
+        onFileRenamed,
+        getNoExport,
+        setNoExport,
+      };
+  });
+
+  it('watches project and handles events', async () => {
+    let added: ((e: unknown, p: string) => void) | undefined;
+    let removed: ((e: unknown, p: string) => void) | undefined;
+    let renamed:
+      | ((e: unknown, args: { oldPath: string; newPath: string }) => void)
+      | undefined;
+    onFileAdded.mockImplementation((cb) => {
+      added = cb;
+    });
+    onFileRemoved.mockImplementation((cb) => {
+      removed = cb;
+    });
+    onFileRenamed.mockImplementation((cb) => {
+      renamed = cb;
+    });
+    const { result, unmount } = renderHook(() => useProjectFiles('/proj'));
+    await waitFor(() =>
+      expect(result.current.files).toEqual(['a.txt', 'b.png'])
+    );
+    act(() => {
+      added?.({}, 'c.txt');
+    });
+    expect(result.current.files).toContain('c.txt');
+    act(() => {
+      removed?.({}, 'a.txt');
+    });
+    expect(result.current.files).not.toContain('a.txt');
+    act(() => {
+      renamed?.({}, { oldPath: 'b.png', newPath: 'd.png' });
+    });
+    expect(result.current.files).toContain('d.png');
+    unmount();
+    expect(unwatchProject).toHaveBeenCalledWith('/proj');
+  });
+
+  it('toggles noExport state', async () => {
+    const { result } = renderHook(() => useProjectFiles('/proj'));
+    await waitFor(() => expect(result.current.files.length).toBeGreaterThan(0));
+    act(() => {
+      result.current.toggleNoExport(['a.txt'], true);
+    });
+    expect(setNoExport).toHaveBeenCalledWith('/proj', ['a.txt'], true);
+    expect(result.current.noExport.has('a.txt')).toBe(true);
+  });
+});

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -1,10 +1,8 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import path from 'path';
 import RenameModal from './RenameModal';
-import { formatTextureName } from '../utils/textureNames';
-
-// Simple file list that updates whenever files inside the project directory
-// change on disk. Updates are received via the IPC file watcher service.
+import AssetBrowserItem from './AssetBrowserItem';
+import { useProjectFiles } from './file/useProjectFiles';
 
 interface Props {
   path: string;
@@ -15,59 +13,15 @@ const AssetBrowser: React.FC<Props> = ({
   path: projectPath,
   onSelectionChange,
 }) => {
-  const [files, setFiles] = useState<string[]>([]);
+  const { files, noExport, toggleNoExport } = useProjectFiles(projectPath);
   const [selected, setSelected] = useState<Set<string>>(new Set());
-  const [noExport, setNoExport] = useState<Set<string>>(new Set());
-  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
+  const [renameTarget, setRenameTarget] = useState<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     onSelectionChange?.(Array.from(selected));
   }, [selected, onSelectionChange]);
-
-  useEffect(() => {
-    let alive = true;
-    window.electronAPI
-      ?.watchProject(projectPath)
-      .then((list) => {
-        if (alive && list) setFiles(list);
-      })
-      .catch(() => {
-        /* ignore */
-      });
-    const add = (_e: unknown, p: string) => setFiles((f) => [...f, p]);
-    const remove = (_e: unknown, p: string) =>
-      setFiles((f) => f.filter((x) => x !== p));
-    const rename = (_e: unknown, args: { oldPath: string; newPath: string }) =>
-      setFiles((f) => f.map((x) => (x === args.oldPath ? args.newPath : x)));
-    window.electronAPI?.onFileAdded(add);
-    window.electronAPI?.onFileRemoved(remove);
-    window.electronAPI?.onFileRenamed(rename);
-    return () => {
-      alive = false;
-      window.electronAPI?.unwatchProject(projectPath);
-    };
-  }, [projectPath]);
-
-  useEffect(() => {
-    let active = true;
-    window.electronAPI?.getNoExport(projectPath).then((list) => {
-      if (active && list) setNoExport(new Set(list));
-    });
-    return () => {
-      active = false;
-    };
-  }, [projectPath]);
-
-  const [menuTarget, setMenuTarget] = useState<string | null>(null);
-  const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
-  const [renameTarget, setRenameTarget] = useState<string | null>(null);
-  const firstItem = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (menuTarget && firstItem.current) {
-      firstItem.current.focus();
-    }
-  }, [menuTarget]);
 
   const handleDeleteSelected = () => {
     setConfirmDelete(
@@ -78,11 +32,8 @@ const AssetBrowser: React.FC<Props> = ({
   return (
     <div
       data-testid="asset-browser"
+      ref={wrapperRef}
       className="grid grid-cols-6 gap-2"
-      onClick={() => {
-        setMenuTarget(null);
-        setMenuPos(null);
-      }}
       onKeyDown={(e) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();
@@ -91,173 +42,19 @@ const AssetBrowser: React.FC<Props> = ({
       }}
       tabIndex={0}
     >
-      {files.map((f) => {
-        const full = path.join(projectPath, f);
-        const name = path.basename(f);
-        const formatted = f.endsWith('.png') ? formatTextureName(name) : name;
-        let thumb: string | null = null;
-        if (f.endsWith('.png')) {
-          const rel = f.split(path.sep).join('/');
-          thumb = `ptex://${rel}`;
-        }
-        const openFolder = () => window.electronAPI?.openInFolder(full);
-        const openFile = () => window.electronAPI?.openFile(full);
-        const showRename = () => setRenameTarget(f);
-        const confirmDel = () => setConfirmDelete([full]);
-        const showMenu = (x: number, y: number) => {
-          setMenuPos({ x, y });
-          setMenuTarget(f);
-        };
-        const handleKey = (e: React.KeyboardEvent) => {
-          if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
-            e.preventDefault();
-            const rect = (
-              e.currentTarget as HTMLElement
-            ).getBoundingClientRect();
-            showMenu(rect.right, rect.bottom);
-          }
-        };
-        const menuOpen = menuTarget === f;
-        const isSelected = selected.has(f);
-        const toggleSelect = (e: React.MouseEvent) => {
-          e.stopPropagation();
-          const ns = new Set(selected);
-          if (e.ctrlKey || e.metaKey || e.shiftKey) {
-            if (ns.has(f)) ns.delete(f);
-            else ns.add(f);
-          } else {
-            ns.clear();
-            ns.add(f);
-          }
-          setSelected(ns);
-        };
-        const handleContext = (e: React.MouseEvent) => {
-          e.preventDefault();
-          if (!selected.has(f)) {
-            setSelected(new Set([f]));
-          }
-          showMenu(e.clientX, e.clientY);
-        };
-        return (
-          <div
-            key={f}
-            className={`p-1 cursor-pointer hover:ring ring-accent relative text-center tooltip ${
-              isSelected ? 'ring' : ''
-            } ${noExport.has(f) ? 'opacity-50 border border-gray-400' : ''}`}
-            data-tip={`${formatted} \n${name}`}
-            tabIndex={0}
-            onClick={toggleSelect}
-            onDoubleClick={openFile}
-            onContextMenu={handleContext}
-            onKeyDown={handleKey}
-            onBlur={(e) => {
-              if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-                setMenuTarget(null);
-                setMenuPos(null);
-              }
-            }}
-          >
-            {thumb ? (
-              <>
-                <img
-                  src={thumb}
-                  alt={formatted}
-                  className="w-full aspect-square"
-                  style={{ imageRendering: 'pixelated' }}
-                />
-                <div className="text-xs leading-tight mt-1">
-                  <div>{formatted}</div>
-                  <div className="opacity-50">{name}</div>
-                </div>
-              </>
-            ) : (
-              <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
-                {name}
-              </div>
-            )}
-            <ul
-              className={`menu dropdown-content bg-base-200 rounded-box fixed z-10 w-40 p-1 shadow ${
-                menuOpen ? 'block' : 'hidden'
-              }`}
-              style={{ left: menuPos?.x, top: menuPos?.y }}
-              role="menu"
-            >
-              <li>
-                <button ref={firstItem} role="menuitem" onClick={openFolder}>
-                  Reveal
-                </button>
-              </li>
-              <li>
-                <button role="menuitem" onClick={openFile}>
-                  Open
-                </button>
-              </li>
-              <li>
-                <button
-                  role="menuitem"
-                  onClick={showRename}
-                  disabled={selected.size > 1}
-                >
-                  Rename
-                </button>
-              </li>
-              <li>
-                <label className="flex gap-2 items-center cursor-pointer px-2">
-                  <span>No Export</span>
-                  <input
-                    type="checkbox"
-                    className="toggle toggle-sm"
-                    checked={(() => {
-                      const list = selected.has(f) ? Array.from(selected) : [f];
-                      return list.every((x) => noExport.has(x));
-                    })()}
-                    onChange={(e) => {
-                      const files = selected.has(f)
-                        ? Array.from(selected)
-                        : [f];
-                      window.electronAPI?.setNoExport(
-                        projectPath,
-                        files,
-                        e.target.checked
-                      );
-                      setNoExport((prev) => {
-                        const ns = new Set(prev);
-                        files.forEach((file) => {
-                          if (e.target.checked) ns.add(file);
-                          else ns.delete(file);
-                        });
-                        return ns;
-                      });
-                    }}
-                  />
-                </label>
-              </li>
-              {selected.size > 1 ? (
-                <li>
-                  <button
-                    role="menuitem"
-                    onClick={() =>
-                      setConfirmDelete(
-                        Array.from(selected).map((s) =>
-                          path.join(projectPath, s)
-                        )
-                      )
-                    }
-                  >
-                    Delete Selected
-                  </button>
-                </li>
-              ) : (
-                <li>
-                  <button role="menuitem" onClick={confirmDel}>
-                    Delete
-                  </button>
-                </li>
-              )}
-            </ul>
-          </div>
-        );
-      })}
+      {files.map((f) => (
+        <AssetBrowserItem
+          key={f}
+          projectPath={projectPath}
+          file={f}
+          selected={selected}
+          setSelected={setSelected}
+          noExport={noExport}
+          toggleNoExport={toggleNoExport}
+          confirmDelete={(files) => setConfirmDelete(files)}
+          openRename={(file) => setRenameTarget(file)}
+        />
+      ))}
       {confirmDelete && (
         <dialog className="modal modal-open" data-testid="delete-modal">
           <div className="modal-box">
@@ -303,4 +100,5 @@ const AssetBrowser: React.FC<Props> = ({
     </div>
   );
 };
+
 export default AssetBrowser;

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -1,0 +1,191 @@
+import React, { useEffect, useRef, useState } from 'react';
+import path from 'path';
+import { formatTextureName } from '../utils/textureNames';
+
+interface Props {
+  projectPath: string;
+  file: string;
+  selected: Set<string>;
+  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
+  noExport: Set<string>;
+  toggleNoExport: (files: string[], flag: boolean) => void;
+  confirmDelete: (files: string[]) => void;
+  openRename: (file: string) => void;
+}
+
+const AssetBrowserItem: React.FC<Props> = ({
+  projectPath,
+  file,
+  selected,
+  setSelected,
+  noExport,
+  toggleNoExport,
+  confirmDelete,
+  openRename,
+}) => {
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const firstItem = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (menuPos && firstItem.current) {
+      firstItem.current.focus();
+    }
+  }, [menuPos]);
+
+  const full = path.join(projectPath, file);
+  const name = path.basename(file);
+  const formatted = file.endsWith('.png') ? formatTextureName(name) : name;
+  let thumb: string | null = null;
+  if (file.endsWith('.png')) {
+    const rel = file.split(path.sep).join('/');
+    thumb = `ptex://${rel}`;
+  }
+
+  const isSelected = selected.has(file);
+
+  const toggleSelect = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    const ns = new Set(selected);
+    if (e.ctrlKey || e.metaKey || e.shiftKey) {
+      if (ns.has(file)) ns.delete(file);
+      else ns.add(file);
+    } else {
+      ns.clear();
+      ns.add(file);
+    }
+    setSelected(ns);
+  };
+
+  const showMenu = (x: number, y: number) => {
+    setMenuPos({ x, y });
+  };
+
+  const handleContext = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!selected.has(file)) {
+      setSelected(new Set([file]));
+    }
+    showMenu(e.clientX, e.clientY);
+  };
+
+  const handleKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+      e.preventDefault();
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      showMenu(rect.right, rect.bottom);
+    }
+  };
+
+  const closeMenu = () => setMenuPos(null);
+
+  return (
+    <div
+      className={`p-1 cursor-pointer hover:ring ring-accent relative text-center tooltip ${
+        isSelected ? 'ring' : ''
+      } ${noExport.has(file) ? 'opacity-50 border border-gray-400' : ''}`}
+      data-tip={`${formatted} \n${name}`}
+      tabIndex={0}
+      onClick={toggleSelect}
+      onDoubleClick={() => window.electronAPI?.openFile(full)}
+      onContextMenu={handleContext}
+      onKeyDown={handleKey}
+      onBlur={(e) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+          closeMenu();
+        }
+      }}
+    >
+      {thumb ? (
+        <>
+          <img
+            src={thumb}
+            alt={formatted}
+            className="w-full aspect-square"
+            style={{ imageRendering: 'pixelated' }}
+          />
+          <div className="text-xs leading-tight mt-1">
+            <div>{formatted}</div>
+            <div className="opacity-50">{name}</div>
+          </div>
+        </>
+      ) : (
+        <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
+          {name}
+        </div>
+      )}
+      <ul
+        className={`menu dropdown-content bg-base-200 rounded-box fixed z-10 w-40 p-1 shadow ${
+          menuPos ? 'block' : 'hidden'
+        }`}
+        style={{ left: menuPos?.x, top: menuPos?.y }}
+        role="menu"
+      >
+        <li>
+          <button
+            ref={firstItem}
+            role="menuitem"
+            onClick={() => window.electronAPI?.openInFolder(full)}
+          >
+            Reveal
+          </button>
+        </li>
+        <li>
+          <button
+            role="menuitem"
+            onClick={() => window.electronAPI?.openFile(full)}
+          >
+            Open
+          </button>
+        </li>
+        <li>
+          <button
+            role="menuitem"
+            onClick={() => openRename(file)}
+            disabled={selected.size > 1}
+          >
+            Rename
+          </button>
+        </li>
+        <li>
+          <label className="flex gap-2 items-center cursor-pointer px-2">
+            <span>No Export</span>
+            <input
+              type="checkbox"
+              className="toggle toggle-sm"
+              checked={(() => {
+                const list = selected.has(file) ? Array.from(selected) : [file];
+                return list.every((x) => noExport.has(x));
+              })()}
+              onChange={(e) => {
+                const list = selected.has(file) ? Array.from(selected) : [file];
+                toggleNoExport(list, e.target.checked);
+              }}
+            />
+          </label>
+        </li>
+        {selected.size > 1 ? (
+          <li>
+            <button
+              role="menuitem"
+              onClick={() =>
+                confirmDelete(
+                  Array.from(selected).map((s) => path.join(projectPath, s))
+                )
+              }
+            >
+              Delete Selected
+            </button>
+          </li>
+        ) : (
+          <li>
+            <button role="menuitem" onClick={() => confirmDelete([full])}>
+              Delete
+            </button>
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+};
+
+export default AssetBrowserItem;

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+export function useProjectFiles(projectPath: string) {
+  const [files, setFiles] = useState<string[]>([]);
+  const [noExport, setNoExport] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let alive = true;
+    window.electronAPI
+      ?.watchProject(projectPath)
+      .then((list) => {
+        if (alive && list) setFiles(list);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+    const add = (_e: unknown, p: string) => setFiles((f) => [...f, p]);
+    const remove = (_e: unknown, p: string) =>
+      setFiles((f) => f.filter((x) => x !== p));
+    const rename = (_e: unknown, args: { oldPath: string; newPath: string }) =>
+      setFiles((f) => f.map((x) => (x === args.oldPath ? args.newPath : x)));
+    window.electronAPI?.onFileAdded(add);
+    window.electronAPI?.onFileRemoved(remove);
+    window.electronAPI?.onFileRenamed(rename);
+    return () => {
+      alive = false;
+      window.electronAPI?.unwatchProject(projectPath);
+    };
+  }, [projectPath]);
+
+  useEffect(() => {
+    let active = true;
+    window.electronAPI?.getNoExport(projectPath).then((list) => {
+      if (active && list) setNoExport(new Set(list));
+    });
+    return () => {
+      active = false;
+    };
+  }, [projectPath]);
+
+  const toggleNoExport = (list: string[], flag: boolean) => {
+    window.electronAPI?.setNoExport(projectPath, list, flag);
+    setNoExport((prev) => {
+      const ns = new Set(prev);
+      list.forEach((file) => {
+        if (flag) ns.add(file);
+        else ns.delete(file);
+      });
+      return ns;
+    });
+  };
+
+  return { files, noExport, toggleNoExport };
+}


### PR DESCRIPTION
## Summary
- add useProjectFiles hook for file watching
- extract AssetBrowserItem component for individual entries
- refactor AssetBrowser to use the new hook and subcomponent
- add unit tests for hook and subcomponent

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d67995cf88331a06808ecc286a752