### PR TITLE
Refactor asset context menu

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -214,8 +214,8 @@ describe('AssetBrowser', () => {
     fireEvent.click(b, { ctrlKey: true });
     fireEvent.contextMenu(a);
     const menus = await screen.findAllByRole('menu');
-    const menu = menus.find((m) =>
-      m.classList.contains('block')
+    const menu = menus.find(
+      (m) => (m as HTMLElement).style.display === 'block'
     ) as HTMLElement;
     const toggle = within(menu).getByRole('checkbox', { name: /No Export/i });
     fireEvent.click(toggle);

--- a/__tests__/AssetBrowserItem.test.tsx
+++ b/__tests__/AssetBrowserItem.test.tsx
@@ -73,4 +73,26 @@ describe('AssetBrowserItem', () => {
     fireEvent.click(toggle);
     expect(toggleNoExport).toHaveBeenCalledWith(['a.txt', 'b.txt'], true);
   });
+
+  it('closes context menu on blur', () => {
+    render(
+      <AssetBrowserItem
+        projectPath="/proj"
+        file="a.txt"
+        selected={new Set()}
+        setSelected={() => undefined}
+        noExport={new Set()}
+        toggleNoExport={() => undefined}
+        confirmDelete={() => undefined}
+        openRename={() => undefined}
+      />
+    );
+    const item = screen.getByText('a.txt');
+    const container = item.closest('div[tabindex="0"]') as HTMLElement;
+    fireEvent.contextMenu(container);
+    const menu = screen.getByRole('menu');
+    expect(menu.style.display).toBe('block');
+    fireEvent.blur(container);
+    expect(menu.style.display).toBe('none');
+  });
 });

--- a/__tests__/AssetContextMenu.test.tsx
+++ b/__tests__/AssetContextMenu.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssetContextMenu from '../src/renderer/components/file/AssetContextMenu';
+
+describe('AssetContextMenu', () => {
+  it('fires callbacks when menu items clicked', () => {
+    const reveal = vi.fn();
+    const open = vi.fn();
+    const rename = vi.fn();
+    const del = vi.fn();
+    const toggle = vi.fn();
+    render(
+      <AssetContextMenu
+        filePath="/proj/a.txt"
+        selectionCount={1}
+        noExportChecked={false}
+        onReveal={reveal}
+        onOpen={open}
+        onRename={rename}
+        onDelete={del}
+        onToggleNoExport={toggle}
+      />
+    );
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
+    expect(reveal).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
+    expect(open).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
+    expect(rename).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(del).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.click(screen.getByRole('checkbox', { name: /No Export/i }));
+    expect(toggle).toHaveBeenCalledWith(true);
+  });
+});

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import path from 'path';
 import { formatTextureName } from '../utils/textureNames';
+import AssetContextMenu from './file/AssetContextMenu';
 
 interface Props {
   projectPath: string;
@@ -113,77 +114,34 @@ const AssetBrowserItem: React.FC<Props> = ({
           {name}
         </div>
       )}
-      <ul
-        className={`menu dropdown-content bg-base-200 rounded-box fixed z-10 w-40 p-1 shadow ${
-          menuPos ? 'block' : 'hidden'
-        }`}
-        style={{ left: menuPos?.x, top: menuPos?.y }}
-        role="menu"
-      >
-        <li>
-          <button
-            ref={firstItem}
-            role="menuitem"
-            onClick={() => window.electronAPI?.openInFolder(full)}
-          >
-            Reveal
-          </button>
-        </li>
-        <li>
-          <button
-            role="menuitem"
-            onClick={() => window.electronAPI?.openFile(full)}
-          >
-            Open
-          </button>
-        </li>
-        <li>
-          <button
-            role="menuitem"
-            onClick={() => openRename(file)}
-            disabled={selected.size > 1}
-          >
-            Rename
-          </button>
-        </li>
-        <li>
-          <label className="flex gap-2 items-center cursor-pointer px-2">
-            <span>No Export</span>
-            <input
-              type="checkbox"
-              className="toggle toggle-sm"
-              checked={(() => {
-                const list = selected.has(file) ? Array.from(selected) : [file];
-                return list.every((x) => noExport.has(x));
-              })()}
-              onChange={(e) => {
-                const list = selected.has(file) ? Array.from(selected) : [file];
-                toggleNoExport(list, e.target.checked);
-              }}
-            />
-          </label>
-        </li>
-        {selected.size > 1 ? (
-          <li>
-            <button
-              role="menuitem"
-              onClick={() =>
-                confirmDelete(
-                  Array.from(selected).map((s) => path.join(projectPath, s))
-                )
-              }
-            >
-              Delete Selected
-            </button>
-          </li>
-        ) : (
-          <li>
-            <button role="menuitem" onClick={() => confirmDelete([full])}>
-              Delete
-            </button>
-          </li>
-        )}
-      </ul>
+      <AssetContextMenu
+        filePath={full}
+        selectionCount={selected.size}
+        noExportChecked={(() => {
+          const list = selected.has(file) ? Array.from(selected) : [file];
+          return list.every((x) => noExport.has(x));
+        })()}
+        style={{
+          left: menuPos?.x,
+          top: menuPos?.y,
+          display: menuPos ? 'block' : 'none',
+        }}
+        firstItemRef={firstItem}
+        onReveal={() => window.electronAPI?.openInFolder(full)}
+        onOpen={() => window.electronAPI?.openFile(full)}
+        onRename={() => openRename(file)}
+        onDelete={() =>
+          confirmDelete(
+            selected.size > 1
+              ? Array.from(selected).map((s) => path.join(projectPath, s))
+              : [full]
+          )
+        }
+        onToggleNoExport={(flag) => {
+          const list = selected.has(file) ? Array.from(selected) : [file];
+          toggleNoExport(list, flag);
+        }}
+      />
     </div>
   );
 };

--- a/src/renderer/components/file/AssetContextMenu.tsx
+++ b/src/renderer/components/file/AssetContextMenu.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+interface Props {
+  filePath: string;
+  selectionCount: number;
+  noExportChecked: boolean;
+  firstItemRef?: React.Ref<HTMLButtonElement>;
+  style?: React.CSSProperties;
+  onReveal: (file: string) => void;
+  onOpen: (file: string) => void;
+  onRename: (file: string) => void;
+  onDelete: (file: string) => void;
+  onToggleNoExport: (checked: boolean) => void;
+}
+
+export default function AssetContextMenu({
+  filePath,
+  selectionCount,
+  noExportChecked,
+  firstItemRef,
+  style,
+  onReveal,
+  onOpen,
+  onRename,
+  onDelete,
+  onToggleNoExport,
+}: Props) {
+  return (
+    <ul
+      className="menu dropdown-content bg-base-200 rounded-box fixed z-10 w-40 p-1 shadow"
+      style={style}
+      role="menu"
+    >
+      <li>
+        <button
+          ref={firstItemRef}
+          role="menuitem"
+          onClick={() => onReveal(filePath)}
+        >
+          Reveal
+        </button>
+      </li>
+      <li>
+        <button role="menuitem" onClick={() => onOpen(filePath)}>
+          Open
+        </button>
+      </li>
+      <li>
+        <button
+          role="menuitem"
+          onClick={() => onRename(filePath)}
+          disabled={selectionCount > 1}
+        >
+          Rename
+        </button>
+      </li>
+      <li>
+        <label className="flex gap-2 items-center cursor-pointer px-2">
+          <span>No Export</span>
+          <input
+            type="checkbox"
+            className="toggle toggle-sm"
+            checked={noExportChecked}
+            onChange={(e) => onToggleNoExport(e.target.checked)}
+          />
+        </label>
+      </li>
+      <li>
+        <button role="menuitem" onClick={() => onDelete(filePath)}>
+          {selectionCount > 1 ? 'Delete Selected' : 'Delete'}
+        </button>
+      </li>
+    </ul>
+  );
+}


### PR DESCRIPTION
## Summary
- create `AssetContextMenu` component
- hook `AssetBrowserItem` to use the new menu
- test new context menu component and blur closing behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d6a37071083319a3fa4858faed3c4