### PR TITLE
Extract toolbar and bulk export modal

### DIFF
--- a/__tests__/BulkExportModal.test.tsx
+++ b/__tests__/BulkExportModal.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import BulkExportModal from '../src/renderer/components/BulkExportModal';
+
+describe('BulkExportModal', () => {
+  it('shows spinner and progress', () => {
+    render(<BulkExportModal progress={{ current: 1, total: 3 }} />);
+    expect(screen.getByTestId('bulk-export-modal')).toBeInTheDocument();
+    expect(screen.getByText('1/3')).toBeInTheDocument();
+  });
+});

--- a/__tests__/SearchToolbar.test.tsx
+++ b/__tests__/SearchToolbar.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchToolbar from '../src/renderer/components/project/SearchToolbar';
+
+describe('SearchToolbar', () => {
+  it('handles search input change', () => {
+    const cb = vi.fn();
+    render(
+      <SearchToolbar
+        search=""
+        onSearchChange={cb}
+        versions={[]}
+        activeVersion={null}
+        onToggleVersion={() => {}}
+        onBulkExport={() => {}}
+        disableExport={false}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText('Search'), {
+      target: { value: 'pack' },
+    });
+    expect(cb).toHaveBeenCalledWith('pack');
+  });
+
+  it('toggles version chips and handles export', () => {
+    const toggle = vi.fn();
+    const bulk = vi.fn();
+    const { rerender } = render(
+      <SearchToolbar
+        search=""
+        onSearchChange={() => {}}
+        versions={['1.20']}
+        activeVersion="1.20"
+        onToggleVersion={toggle}
+        onBulkExport={bulk}
+        disableExport={true}
+      />
+    );
+    const chip = screen.getByRole('button', { name: '1.20' });
+    fireEvent.click(chip);
+    expect(toggle).toHaveBeenCalledWith('1.20');
+    const btn = screen.getByRole('button', { name: 'Bulk Export' });
+    expect(btn).toBeDisabled();
+    fireEvent.click(btn);
+    expect(bulk).not.toHaveBeenCalled();
+
+    rerender(
+      <SearchToolbar
+        search=""
+        onSearchChange={() => {}}
+        versions={['1.20']}
+        activeVersion={null}
+        onToggleVersion={toggle}
+        onBulkExport={bulk}
+        disableExport={false}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Bulk Export' }));
+    expect(bulk).toHaveBeenCalled();
+  });
+
+  it('input has width class', () => {
+    render(
+      <SearchToolbar
+        search=""
+        onSearchChange={() => {}}
+        versions={[]}
+        activeVersion={null}
+        onToggleVersion={() => {}}
+        onBulkExport={() => {}}
+        disableExport={false}
+      />
+    );
+    const input = screen.getByPlaceholderText('Search');
+    expect(input).toHaveClass('w-40');
+  });
+});

--- a/src/renderer/components/BulkExportModal.tsx
+++ b/src/renderer/components/BulkExportModal.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Spinner from './Spinner';
+
+export interface BulkProgress {
+  current: number;
+  total: number;
+}
+
+export default function BulkExportModal({
+  progress,
+}: {
+  progress: BulkProgress;
+}) {
+  return (
+    <dialog className="modal modal-open" data-testid="bulk-export-modal">
+      <div className="modal-box flex flex-col items-center">
+        <h3 className="font-bold text-lg mb-2">Exporting...</h3>
+        <Spinner />
+        <p className="mt-2">
+          {progress.current}/{progress.total}
+        </p>
+      </div>
+    </dialog>
+  );
+}

--- a/src/renderer/components/project/SearchToolbar.tsx
+++ b/src/renderer/components/project/SearchToolbar.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+export default function SearchToolbar({
+  search,
+  onSearchChange,
+  versions,
+  activeVersion,
+  onToggleVersion,
+  onBulkExport,
+  disableExport,
+}: {
+  search: string;
+  onSearchChange: (v: string) => void;
+  versions: string[];
+  activeVersion: string | null;
+  onToggleVersion: (v: string) => void;
+  onBulkExport: () => void;
+  disableExport: boolean;
+}) {
+  return (
+    <div className="flex items-center gap-2 mb-2">
+      <input
+        className="input input-bordered input-sm w-40"
+        value={search}
+        onChange={(e) => onSearchChange(e.target.value)}
+        placeholder="Search"
+      />
+      <div className="flex gap-1">
+        {versions.map((v) => (
+          <span
+            key={v}
+            role="button"
+            tabIndex={0}
+            onClick={() => onToggleVersion(v)}
+            onKeyDown={(e) => e.key === 'Enter' && onToggleVersion(v)}
+            className={`badge badge-outline cursor-pointer select-none ${
+              activeVersion === v ? 'badge-primary' : ''
+            }`}
+          >
+            {v}
+          </span>
+        ))}
+      </div>
+      <button
+        className="btn btn-accent btn-sm"
+        onClick={onBulkExport}
+        disabled={disableExport}
+      >
+        Bulk Export
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SearchToolbar component for search input, version chips and bulk export button
- add BulkExportModal with spinner and progress counter
- refactor ProjectManagerView to use new components
- test SearchToolbar and BulkExportModal

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d6a437454833183f266fa174e1ef7