### PR TITLE
Fix project table interactions and context menu

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -245,7 +245,8 @@ describe('AssetBrowser', () => {
     render(<AssetBrowser path="/proj" />);
     const el = await screen.findByText('a.txt');
     const container = el.closest('div[tabindex="0"]') as HTMLElement;
-    expect(container.className).toMatch(/opacity-50/);
     expect(container.className).toMatch(/border-gray-400/);
+    const inner = container.querySelector('div') as HTMLElement;
+    expect(inner.className).toMatch(/opacity-50/);
   });
 });

--- a/__tests__/AssetBrowserItem.test.tsx
+++ b/__tests__/AssetBrowserItem.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import AssetBrowserItem from '../src/renderer/components/AssetBrowserItem';
+import path from 'path';
 
 const openInFolder = vi.fn();
 const openFile = vi.fn();
@@ -40,16 +41,16 @@ describe('AssetBrowserItem', () => {
     const item = screen.getByText('a.txt');
     fireEvent.contextMenu(item);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
-    expect(openInFolder).toHaveBeenCalledWith('/proj/a.txt');
+    expect(openInFolder).toHaveBeenCalledWith(path.join('/proj', 'a.txt'));
     fireEvent.contextMenu(item);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
-    expect(openFile).toHaveBeenCalledWith('/proj/a.txt');
+    expect(openFile).toHaveBeenCalledWith(path.join('/proj', 'a.txt'));
     fireEvent.contextMenu(item);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
     expect(openRename).toHaveBeenCalledWith('a.txt');
     fireEvent.contextMenu(item);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    expect(confirmDelete).toHaveBeenCalledWith(['/proj/a.txt']);
+    expect(confirmDelete).toHaveBeenCalledWith([path.join('/proj', 'a.txt')]);
   });
 
   it('toggles noExport for selected files', () => {
@@ -94,5 +95,24 @@ describe('AssetBrowserItem', () => {
     expect(menu.style.display).toBe('block');
     fireEvent.blur(container);
     expect(menu.style.display).toBe('none');
+  });
+
+  it('menu is not dimmed when item is flagged noExport', () => {
+    render(
+      <AssetBrowserItem
+        projectPath="/proj"
+        file="a.txt"
+        selected={new Set()}
+        setSelected={() => undefined}
+        noExport={new Set(['a.txt'])}
+        toggleNoExport={() => undefined}
+        confirmDelete={() => undefined}
+        openRename={() => undefined}
+      />
+    );
+    const item = screen.getByText('a.txt');
+    fireEvent.contextMenu(item);
+    const menu = screen.getByRole('menu');
+    expect(menu.className).not.toMatch('opacity-50');
   });
 });

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -38,6 +38,31 @@ describe('ProjectTable', () => {
     expect(del).toHaveBeenCalledWith('Alpha');
   });
 
+  it('opens and deletes via keyboard', () => {
+    const open = vi.fn();
+    const del = vi.fn();
+    render(
+      <ProjectTable
+        projects={projects}
+        sortKey="name"
+        asc
+        onSort={() => {}}
+        selected={new Set()}
+        onSelect={() => {}}
+        onSelectAll={() => {}}
+        onOpen={open}
+        onDuplicate={() => {}}
+        onDelete={del}
+        onRowClick={() => {}}
+      />
+    );
+    const row = screen.getAllByRole('row')[1];
+    fireEvent.doubleClick(row);
+    expect(open).toHaveBeenCalledWith('Alpha');
+    fireEvent.keyDown(row, { key: 'Delete' });
+    expect(del).toHaveBeenCalledWith('Alpha');
+  });
+
   it('selects rows and toggles all', () => {
     const select = vi.fn();
     const selectAll = vi.fn();

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -117,3 +117,9 @@ version. Results are grouped into collapsible **Blocks**, **Items**, **Entity**,
 **UI**, **Audio** and **Misc** sections using daisyUI's collapse component. Only assets
 that match the search query appear in each section. Thumbnails respect the zoom
 slider (24–128 px) and clicking a texture adds it to the project.
+
+## Windows Paths
+
+When writing tests or other code that constructs file system paths, prefer
+`path.join()` over string concatenation. Hard coded `/` separators can cause
+failures on Windows where the standard separator is `\`.

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -83,7 +83,7 @@ const AssetBrowserItem: React.FC<Props> = ({
     <div
       className={`p-1 cursor-pointer hover:ring ring-accent relative text-center tooltip ${
         isSelected ? 'ring' : ''
-      } ${noExport.has(file) ? 'opacity-50 border border-gray-400' : ''}`}
+      } ${noExport.has(file) ? 'border border-gray-400' : ''}`}
       data-tip={`${formatted} \n${name}`}
       tabIndex={0}
       onClick={toggleSelect}
@@ -96,24 +96,26 @@ const AssetBrowserItem: React.FC<Props> = ({
         }
       }}
     >
-      {thumb ? (
-        <>
-          <img
-            src={thumb}
-            alt={formatted}
-            className="w-full aspect-square"
-            style={{ imageRendering: 'pixelated' }}
-          />
-          <div className="text-xs leading-tight mt-1">
-            <div>{formatted}</div>
-            <div className="opacity-50">{name}</div>
+      <div className={noExport.has(file) ? 'opacity-50' : ''}>
+        {thumb ? (
+          <>
+            <img
+              src={thumb}
+              alt={formatted}
+              className="w-full aspect-square"
+              style={{ imageRendering: 'pixelated' }}
+            />
+            <div className="text-xs leading-tight mt-1">
+              <div>{formatted}</div>
+              <div className="opacity-50">{name}</div>
+            </div>
+          </>
+        ) : (
+          <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
+            {name}
           </div>
-        </>
-      ) : (
-        <div className="w-full aspect-square bg-base-300 flex items-center justify-center">
-          {name}
-        </div>
-      )}
+        )}
+      </div>
       <AssetContextMenu
         filePath={full}
         selectionCount={selected.size}

--- a/src/renderer/components/file/AssetContextMenu.tsx
+++ b/src/renderer/components/file/AssetContextMenu.tsx
@@ -27,7 +27,7 @@ export default function AssetContextMenu({
 }: Props) {
   return (
     <ul
-      className="menu dropdown-content bg-base-200 rounded-box fixed z-10 w-40 p-1 shadow"
+      className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
       style={style}
       role="menu"
     >

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -66,6 +66,12 @@ export default function ProjectTable({
             <tr
               key={p.name}
               onClick={() => onRowClick(p.name)}
+              onDoubleClick={() => onOpen(p.name)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') onOpen(p.name);
+                if (e.key === 'Delete') onDelete(p.name);
+              }}
+              tabIndex={0}
               className="cursor-pointer"
             >
               <td>


### PR DESCRIPTION
## Summary
- ensure asset context menu overlays correctly and isn't dimmed
- allow double-clicking project rows to open them
- allow pressing Delete on a row to remove the project
- fix windows path expectations in tests
- document Windows path tip

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684d762129bc8331b2ff990076757a7d