### PR TITLE
Implement AssetSelector category filters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,7 +38,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [x] Properly formatted texture names, with original filename fallback
 - [x] Responsive grid thumbnails (zoom 24–128 px, hover ring)
 - [ ] Drag‑or‑click to add asset to project
-- [ ] Quick filters: Blocks / Items / Entity / UI / Audio
+- [x] Quick filters: Blocks / Items / Entity / UI / Audio
 - [ ] Neutral‑lighting preview pane
 
 ---

--- a/__tests__/AssetSelector.filters.test.tsx
+++ b/__tests__/AssetSelector.filters.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssetSelector from '../src/renderer/components/AssetSelector';
+
+describe('AssetSelector filters', () => {
+  const listTextures = vi.fn();
+  const getTextureUrl = vi.fn();
+
+  beforeEach(() => {
+    interface ElectronAPI {
+      listTextures: (path: string) => Promise<string[]>;
+      addTexture: (path: string, tex: string) => Promise<void>;
+      getTextureUrl: (project: string, tex: string) => Promise<string>;
+    }
+    (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
+      listTextures,
+      addTexture: vi.fn(),
+      getTextureUrl,
+    };
+    listTextures.mockResolvedValue([
+      'block/stone.png',
+      'item/apple.png',
+      'entity/zombie.png',
+    ]);
+    getTextureUrl.mockImplementation((_p, n) => `texture://${n}`);
+    vi.clearAllMocks();
+  });
+
+  it('filters textures by category chip and supports keyboard toggle', async () => {
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'png' } });
+    await screen.findByText('blocks');
+    expect(
+      screen.getByRole('button', { name: 'item/apple.png' })
+    ).toBeInTheDocument();
+    const itemChip = screen.getByRole('button', { name: 'Items' });
+    fireEvent.click(itemChip);
+    expect(
+      screen.queryByRole('button', { name: 'block/stone.png' })
+    ).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'item/apple.png' })
+    ).toBeInTheDocument();
+    fireEvent.keyDown(itemChip, { key: 'Enter' });
+    expect(
+      screen.getByRole('button', { name: 'block/stone.png' })
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add category chips and filtering in AssetSelector
- allow keyboard toggle of chips
- test chip filtering behaviour
- mark TODO item complete

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7f9b3354833186052c9b6654a203