### PR TITLE
Enable drag-to-add textures

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [x] Categorized sections
 - [x] Properly formatted texture names, with original filename fallback
 - [x] Responsive grid thumbnails (zoom 24–128 px, hover ring)
-- [ ] Drag‑or‑click to add asset to project
+- [x] Drag‑or‑click to add asset to project
 - [x] Quick filters: Blocks / Items / Entity / UI / Audio
 - [ ] Neutral‑lighting preview pane
 

--- a/__tests__/TextureGrid.drag.test.tsx
+++ b/__tests__/TextureGrid.drag.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TextureGrid, {
+  TextureInfo,
+} from '../src/renderer/components/TextureGrid';
+
+const textures: TextureInfo[] = [
+  { name: 'block/stone.png', url: 'texture://stone' },
+  { name: 'block/dirt.png', url: 'texture://dirt' },
+];
+
+describe('TextureGrid drag and click', () => {
+  it('triggers onSelect on click', () => {
+    const onSelect = vi.fn();
+    render(<TextureGrid textures={textures} zoom={64} onSelect={onSelect} />);
+    const btn = screen.getByRole('button', { name: 'block/stone.png' });
+    fireEvent.click(btn);
+    expect(onSelect).toHaveBeenCalledWith('block/stone.png');
+  });
+
+  it('sets drag data with texture name', () => {
+    const onSelect = vi.fn();
+    render(<TextureGrid textures={textures} zoom={64} onSelect={onSelect} />);
+    const btn = screen.getByRole('button', { name: 'block/stone.png' });
+    const store: Record<string, string> = {};
+    const transfer = {
+      setData: (t: string, v: string) => {
+        store[t] = v;
+      },
+      getData: (t: string) => store[t] ?? '',
+      effectAllowed: '',
+    } as DataTransfer;
+    fireEvent.dragStart(btn, { dataTransfer: transfer });
+    expect(store['text/plain']).toBe('block/stone.png');
+    expect(transfer.effectAllowed).toBe('copy');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -116,7 +116,8 @@ The vanilla asset browser lets you search textures from the selected Minecraft
 version. Results are grouped into collapsible **Blocks**, **Items**, **Entity**,
 **UI**, **Audio** and **Misc** sections using daisyUI's collapse component. Only assets
 that match the search query appear in each section. Thumbnails respect the zoom
-slider (24–128 px) and clicking a texture adds it to the project.
+slider (24–128 px) and textures can be clicked or dragged into the asset browser
+to add them to the project.
 
 ## Windows Paths
 

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -3,6 +3,7 @@ import path from 'path';
 import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
+import { useToast } from './ToastProvider';
 
 interface Props {
   path: string;
@@ -18,6 +19,7 @@ const AssetBrowser: React.FC<Props> = ({
   const [confirmDelete, setConfirmDelete] = useState<string[] | null>(null);
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
+  const toast = useToast();
 
   useEffect(() => {
     onSelectionChange?.(Array.from(selected));
@@ -29,11 +31,22 @@ const AssetBrowser: React.FC<Props> = ({
     );
   };
 
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const tex = e.dataTransfer.getData('text/plain');
+    if (!tex) return;
+    window.electronAPI?.addTexture(projectPath, tex).then(() => {
+      toast('Texture added', 'success');
+    });
+  };
+
   return (
     <div
       data-testid="asset-browser"
       ref={wrapperRef}
       className="grid grid-cols-6 gap-2"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
       onKeyDown={(e) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();

--- a/src/renderer/components/TextureGrid.tsx
+++ b/src/renderer/components/TextureGrid.tsx
@@ -40,6 +40,11 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
         <button
           aria-label={tex.name}
           onClick={() => data.onSelect(tex.name)}
+          onDragStart={(e) => {
+            e.dataTransfer.setData('text/plain', tex.name);
+            e.dataTransfer.effectAllowed = 'copy';
+          }}
+          draggable
           className="p-1 hover:ring ring-accent rounded"
         >
           <img


### PR DESCRIPTION
## Summary
- drag support for `TextureGrid` items
- handle drops in `AssetBrowser` with toast confirmation
- test dragging and clicking textures
- document drag workflow in the handbook
- check off related TODO item

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d82c4358c8331910088d1ad14e2a2