### PR TITLE
Add zoomable texture preview

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 ## 5. Editor > Texture Inspector
 
-- [ ] 1 : 1 pixel preview + zoom slider
+- [x] 1 : 1 pixel preview + zoom slider
 - [ ] External edit button (auto‑reload on save)
 - [ ] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
 - [ ] Revision history (max 20)

--- a/__tests__/TexturePreview.test.tsx
+++ b/__tests__/TexturePreview.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PreviewPane from '../src/renderer/components/PreviewPane';
+
+describe('PreviewPane zoom behaviour', () => {
+  it('zooms image using slider', () => {
+    render(<PreviewPane texture="foo.png" />);
+    const img = screen.getByRole('img') as HTMLImageElement;
+    expect(img.style.transform).toBe('scale(1)');
+    const slider = screen.getByLabelText('Zoom');
+    fireEvent.change(slider, { target: { value: '3' } });
+    expect(img.style.transform).toBe('scale(3)');
+  });
+
+  it('zooms image with mouse wheel', () => {
+    render(<PreviewPane texture="foo.png" />);
+    const pane = screen.getByTestId('preview-pane');
+    const img = screen.getByRole('img') as HTMLImageElement;
+    fireEvent.wheel(pane, { deltaY: -100 });
+    expect(img.style.transform).toBe('scale(2)');
+    fireEvent.wheel(pane, { deltaY: 100 });
+    expect(img.style.transform).toBe('scale(1)');
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -123,7 +123,9 @@ slider (24–128 px) and textures can be clicked or dragged into the asset bro
 to add them to the project.
 
 Beside the asset information panel, a **Preview Pane** shows the currently
-selected texture under neutral lighting. The pane is lazy loaded and displays a
+selected texture under neutral lighting. The pane renders textures at a 1:1
+pixel scale and includes a zoom slider (1–8×). Scrolling the mouse wheel over
+the pane adjusts the zoom. The pane is lazy loaded and displays a
 `react-loader-spinner` indicator while loading.
 
 ## Windows Paths

--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 interface PreviewPaneProps {
   texture: string | null;
@@ -9,19 +9,46 @@ export default function PreviewPane({
   texture,
   lighting = 'neutral',
 }: PreviewPaneProps) {
+  const [zoom, setZoom] = useState(1);
   const bgClass = lighting === 'neutral' ? 'bg-gray-200' : 'bg-transparent';
+
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!texture) return;
+    e.preventDefault();
+    setZoom((z) => {
+      const next = z + (e.deltaY < 0 ? 1 : -1);
+      return Math.min(8, Math.max(1, next));
+    });
+  };
+
   return (
     <div
       data-testid="preview-pane"
-      className={`w-32 h-32 flex items-center justify-center border ${bgClass}`}
+      onWheel={handleWheel}
+      className={`border p-2 flex flex-col items-center ${bgClass}`}
     >
       {texture ? (
-        <img
-          src={`ptex://${texture}`}
-          alt={texture}
-          className="max-w-full max-h-full"
-          style={{ imageRendering: 'pixelated' }}
-        />
+        <>
+          <img
+            src={`ptex://${texture}`}
+            alt={texture}
+            style={{
+              imageRendering: 'pixelated',
+              transform: `scale(${zoom})`,
+              transformOrigin: 'top left',
+            }}
+          />
+          <input
+            type="range"
+            min={1}
+            max={8}
+            step={1}
+            value={zoom}
+            aria-label="Zoom"
+            onChange={(e) => setZoom(Number(e.target.value))}
+            className="range range-xs w-32 mt-2"
+          />
+        </>
       ) : (
         <span>No preview</span>
       )}


### PR DESCRIPTION
## Summary
- implement zoom slider + mouse wheel support for `PreviewPane`
- document zoom behaviour in developer handbook
- mark TODO for texture inspector feature
- add tests verifying zoom interaction

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d936f49148331b72cf2855d828288