### PR TITLE
Add text editor for JSON/TXT assets

### DIFF
--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -1,17 +1,51 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import AssetInfo from '../src/renderer/components/AssetInfo';
 
 describe('AssetInfo', () => {
+  const readFile = vi.fn();
+  const writeFile = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (
+      window as unknown as {
+        electronAPI: { readFile: typeof readFile; writeFile: typeof writeFile };
+      }
+    ).electronAPI = { readFile, writeFile } as never;
+    readFile.mockResolvedValue('');
+    writeFile.mockResolvedValue(undefined);
+  });
+
   it('shows placeholder when no asset', () => {
-    render(<AssetInfo asset={null} />);
+    render(<AssetInfo projectPath="/p" asset={null} />);
     expect(screen.getByText('No asset selected')).toBeInTheDocument();
   });
 
   it('renders asset name', async () => {
-    render(<AssetInfo asset="foo.png" />);
+    render(<AssetInfo projectPath="/p" asset="foo.png" />);
     expect(screen.getByText('foo.png')).toBeInTheDocument();
     expect(await screen.findByTestId('preview-pane')).toBeInTheDocument();
+  });
+
+  it('edits a text file', async () => {
+    readFile.mockResolvedValue('hello');
+    render(<AssetInfo projectPath="/p" asset="a.txt" />);
+    const box = await screen.findByRole('textbox');
+    expect(box).toHaveValue('hello');
+    fireEvent.change(box, { target: { value: 'new' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(writeFile).toHaveBeenCalledWith('/p/a.txt', 'new');
+  });
+
+  it('blocks invalid json', async () => {
+    readFile.mockResolvedValue('{}');
+    render(<AssetInfo projectPath="/p" asset="b.json" />);
+    const box = await screen.findByRole('textbox');
+    fireEvent.change(box, { target: { value: '{' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(writeFile).not.toHaveBeenCalled();
+    expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
   });
 });

--- a/src/main/ipcFiles.ts
+++ b/src/main/ipcFiles.ts
@@ -13,6 +13,14 @@ export function registerFileHandlers(ipc: IpcMain) {
     shell.openPath(file);
   });
 
+  ipc.handle('read-file', (_e, file: string) => {
+    return fs.promises.readFile(file, 'utf-8');
+  });
+
+  ipc.handle('write-file', async (_e, file: string, data: string) => {
+    await fs.promises.writeFile(file, data, 'utf-8');
+  });
+
   ipc.handle('rename-file', async (_e, oldPath: string, newPath: string) => {
     await fs.promises.rename(oldPath, newPath);
     emitRenamed(oldPath, newPath);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,8 @@ const api = {
   randomizeIcon: (project: string) => invoke('randomize-icon', project),
   openInFolder: (file: string) => invoke('open-in-folder', file),
   openFile: (file: string) => invoke('open-file', file),
+  readFile: (file: string) => invoke('read-file', file),
+  writeFile: (file: string, data: string) => invoke('write-file', file, data),
   renameFile: (oldPath: string, newPath: string) =>
     invoke('rename-file', oldPath, newPath),
   deleteFile: (file: string) => invoke('delete-file', file),

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -1,9 +1,63 @@
-import React, { Suspense, lazy } from 'react';
+import React, { Suspense, lazy, useEffect, useState } from 'react';
+import path from 'path';
 import { Oval } from 'react-loader-spinner';
+import { useToast } from './ToastProvider';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 
-export default function AssetInfo({ asset }: { asset: string | null }) {
+interface Props {
+  projectPath: string;
+  asset: string | null;
+  count?: number;
+}
+
+export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
+  const toast = useToast();
+  const [text, setText] = useState('');
+  const [orig, setOrig] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const full = asset ? path.join(projectPath, asset) : '';
+
+  const isText = asset
+    ? ['.txt', '.json', '.mcmeta'].includes(path.extname(asset).toLowerCase())
+    : false;
+  const isJson = asset
+    ? ['.json', '.mcmeta'].includes(path.extname(asset).toLowerCase())
+    : false;
+
+  useEffect(() => {
+    if (asset && count === 1 && isText) {
+      window.electronAPI?.readFile(full).then((data) => {
+        setOrig(data ?? '');
+        setText(data ?? '');
+      });
+    } else {
+      setOrig('');
+      setText('');
+    }
+  }, [asset, count, full, isText]);
+
+  const handleSave = () => {
+    if (!asset) return;
+    if (isJson) {
+      try {
+        JSON.parse(text);
+      } catch {
+        setError('Invalid JSON');
+        toast('Invalid JSON', 'error');
+        return;
+      }
+    }
+    setError(null);
+    window.electronAPI?.writeFile(full, text).then(() => {
+      setOrig(text);
+      toast('File saved', 'success');
+    });
+  };
+
+  const handleReset = () => setText(orig);
+
   if (!asset) return <div>No asset selected</div>;
   return (
     <div className="p-2 flex gap-2" data-testid="asset-info">
@@ -16,8 +70,29 @@ export default function AssetInfo({ asset }: { asset: string | null }) {
       >
         <PreviewPane texture={asset} />
       </Suspense>
-      <div>
-        <h3 className="font-bold mb-1">{asset}</h3>
+      <div className="flex-1 max-w-md">
+        <h3 className="font-bold mb-1 break-all">{asset}</h3>
+        {count === 1 && isText && (
+          <>
+            <textarea
+              className="textarea textarea-bordered w-full mb-2"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            {error && <div className="text-error mb-1">{error}</div>}
+            <div className="flex gap-2">
+              <button className="btn btn-primary btn-sm" onClick={handleSave}>
+                Save
+              </button>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={handleReset}
+              >
+                Reset
+              </button>
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -67,7 +67,11 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
               onSelectionChange={(sel) => setSelected(sel)}
             />
           </Suspense>
-          <AssetInfo asset={selected[0] ?? null} />
+          <AssetInfo
+            projectPath={projectPath}
+            asset={selected[0] ?? null}
+            count={selected.length}
+          />
         </div>
       </div>
       {summary && (

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -32,6 +32,8 @@ declare global {
       exportProjects: IpcInvoke<'export-projects'>;
       openInFolder: IpcInvoke<'open-in-folder'>;
       openFile: IpcInvoke<'open-file'>;
+      readFile: IpcInvoke<'read-file'>;
+      writeFile: IpcInvoke<'write-file'>;
       renameFile: IpcInvoke<'rename-file'>;
       deleteFile: IpcInvoke<'delete-file'>;
       watchProject: IpcInvoke<'watch-project'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -21,6 +21,8 @@ export interface IpcRequestMap {
   'export-projects': [string[]];
   'open-in-folder': [string];
   'open-file': [string];
+  'read-file': [string];
+  'write-file': [string, string];
   'rename-file': [string, string];
   'delete-file': [string];
   'watch-project': [string];
@@ -48,6 +50,8 @@ export interface IpcResponseMap {
   'export-projects': void;
   'open-in-folder': void;
   'open-file': void;
+  'read-file': string;
+  'write-file': void;
   'rename-file': void;
   'delete-file': void;
   'watch-project': string[];


### PR DESCRIPTION
## Summary
- allow renderer to read/write files via IPC
- expose new IPC APIs in preload and type definitions
- show a text editor in `AssetInfo` for .mcmeta, .json and .txt files
- block saving invalid JSON and support save/reset buttons
- update `EditorView` to pass project path and selection count
- test `AssetInfo` text editing behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d975ecdfc8331bba330968c41b6ca