### PR TITLE
Improve asset filtering and editor layout

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -263,4 +263,17 @@ describe('AssetBrowser', () => {
     fireEvent.change(slider, { target: { value: '80' } });
     expect(img.style.width).toBe('80px');
   });
+
+  it('filters files by category chip', async () => {
+    watchProject.mockResolvedValue([
+      'assets/minecraft/textures/block/stone.png',
+      'assets/minecraft/textures/item/apple.png',
+    ]);
+    render(<AssetBrowser path="/proj" />);
+    await screen.findByText('stone.png');
+    const chip = screen.getByText('Items');
+    fireEvent.click(chip);
+    expect(screen.queryByText('stone.png')).toBeNull();
+    expect(screen.getByText('apple.png')).toBeInTheDocument();
+  });
 });

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -9,12 +9,19 @@ describe('ProjectInfoPanel', () => {
   const load = vi.fn();
   const onExport = vi.fn();
   const onBack = vi.fn();
+  const openInFolder = vi.fn();
 
   beforeEach(() => {
     (
-      window as unknown as { electronAPI: { loadPackMeta: typeof load } }
+      window as unknown as {
+        electronAPI: {
+          loadPackMeta: typeof load;
+          openInFolder: typeof openInFolder;
+        };
+      }
     ).electronAPI = {
       loadPackMeta: load,
+      openInFolder,
     } as never;
     load.mockResolvedValue(meta);
     vi.clearAllMocks();
@@ -32,6 +39,8 @@ describe('ProjectInfoPanel', () => {
     await screen.findByText('desc');
     fireEvent.click(screen.getByText('Export Pack'));
     expect(onExport).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Open Folder'));
+    expect(openInFolder).toHaveBeenCalledWith('/p/Pack');
     fireEvent.click(screen.getByText('Back to Projects'));
     expect(onBack).toHaveBeenCalled();
     expect(screen.getByText('/p/Pack')).toBeInTheDocument();

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -4,6 +4,9 @@ import '@testing-library/jest-dom/vitest';
 
 afterEach(() => {
   cleanup();
+  // reset global IPC mocks between tests
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).electronAPI = undefined;
 });
 
 if (!window.matchMedia) {

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -14,16 +14,23 @@ const FILTERS = ['blocks', 'items', 'entity', 'ui', 'audio'] as const;
 type Filter = (typeof FILTERS)[number];
 
 const getCategory = (name: string): Filter | 'misc' => {
-  if (name.startsWith('block/')) return 'blocks';
-  if (name.startsWith('item/')) return 'items';
-  if (name.startsWith('entity/')) return 'entity';
+  const norm = (() => {
+    const parts = name.split('/');
+    const tIndex = parts.indexOf('textures');
+    if (tIndex !== -1 && parts.length > tIndex + 1)
+      return parts.slice(tIndex + 1).join('/');
+    return name;
+  })();
+  if (norm.startsWith('block/')) return 'blocks';
+  if (norm.startsWith('item/')) return 'items';
+  if (norm.startsWith('entity/')) return 'entity';
   if (
-    name.startsWith('gui/') ||
-    name.startsWith('font/') ||
-    name.startsWith('misc/')
+    norm.startsWith('gui/') ||
+    norm.startsWith('font/') ||
+    norm.startsWith('misc/')
   )
     return 'ui';
-  if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
+  if (norm.startsWith('sound/') || norm.startsWith('sounds/')) return 'audio';
   return 'misc';
 };
 

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -10,16 +10,23 @@ const FILTERS = ['blocks', 'items', 'entity', 'ui', 'audio'] as const;
 type Filter = (typeof FILTERS)[number];
 
 const getCategory = (name: string): Filter | 'misc' => {
-  if (name.startsWith('block/')) return 'blocks';
-  if (name.startsWith('item/')) return 'items';
-  if (name.startsWith('entity/')) return 'entity';
+  const norm = (() => {
+    const parts = name.split('/');
+    const tIndex = parts.indexOf('textures');
+    if (tIndex !== -1 && parts.length > tIndex + 1)
+      return parts.slice(tIndex + 1).join('/');
+    return name;
+  })();
+  if (norm.startsWith('block/')) return 'blocks';
+  if (norm.startsWith('item/')) return 'items';
+  if (norm.startsWith('entity/')) return 'entity';
   if (
-    name.startsWith('gui/') ||
-    name.startsWith('font/') ||
-    name.startsWith('misc/')
+    norm.startsWith('gui/') ||
+    norm.startsWith('font/') ||
+    norm.startsWith('misc/')
   )
     return 'ui';
-  if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
+  if (norm.startsWith('sound/') || norm.startsWith('sounds/')) return 'audio';
   return 'misc';
 };
 
@@ -51,8 +58,10 @@ const AssetSelector: React.FC<Props> = ({
   const filtered = query
     ? all.filter((t) => {
         if (!t.name.includes(query)) return false;
-        if (filters.length > 0 && !filters.includes(getCategory(t.name))) {
-          return false;
+        const cat = getCategory(t.name);
+        if (filters.length > 0) {
+          if (cat === 'misc') return false;
+          if (!filters.includes(cat)) return false;
         }
         return true;
       })

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -21,22 +21,29 @@ export default function ProjectInfoPanel({
   }, [name]);
 
   return (
-    <div
-      className="p-2 flex flex-col items-center gap-2"
-      data-testid="project-info"
-    >
-      <button className="link link-primary self-start" onClick={onBack}>
-        Back to Projects
-      </button>
-      <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
-      <h2 className="font-display text-lg">{name}</h2>
-      <p className="text-xs break-all">{projectPath}</p>
-      <p className="text-sm text-center break-all flex-1">
-        {meta?.description}
-      </p>
-      <button className="btn btn-accent btn-sm mt-auto" onClick={onExport}>
-        Export Pack
-      </button>
+    <div className="card bg-base-100 shadow flex-1" data-testid="project-info">
+      <div className="card-body p-4 flex flex-col">
+        <button className="link link-primary self-start" onClick={onBack}>
+          Back to Projects
+        </button>
+        <figure className="mt-2">
+          <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
+        </figure>
+        <h2 className="card-title break-all">{name}</h2>
+        <p className="text-xs break-all">{projectPath}</p>
+        <p className="text-sm break-all flex-1">{meta?.description}</p>
+        <div className="card-actions justify-end">
+          <button
+            className="btn btn-sm"
+            onClick={() => window.electronAPI?.openInFolder(projectPath)}
+          >
+            Open Folder
+          </button>
+          <button className="btn btn-accent btn-sm" onClick={onExport}>
+            Export Pack
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -58,7 +58,7 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
   };
 
   return (
-    <main className="p-4 flex flex-col gap-4 h-full" data-testid="editor-view">
+    <main className="p-4 flex flex-col gap-4 flex-1" data-testid="editor-view">
       <div className="flex items-center justify-end mb-2">
         <ExternalLink
           href="https://minecraft.wiki/w/Resource_pack"


### PR DESCRIPTION
## Summary
- fix category detection in AssetBrowser and AssetSelector
- stretch EditorView to fill remaining space
- restyle ProjectInfoPanel using daisyUI card and open-folder button
- ensure electron API mocks reset between tests
- test asset browser category chips and open-folder button

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e5dad55d08331a9b8d492ede4e015