### PR TITLE
Improve asset browser and project info panel

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -263,4 +263,17 @@ describe('AssetBrowser', () => {
     fireEvent.change(slider, { target: { value: '80' } });
     expect(img.style.width).toBe('80px');
   });
+
+  it('filters by category chip', async () => {
+    watchProject.mockResolvedValue([
+      'assets/minecraft/textures/block/stone.png',
+      'assets/minecraft/textures/item/apple.png',
+    ]);
+    render(<AssetBrowser path="/proj" />);
+    await screen.findByText('stone.png');
+    const itemsChip = screen.getByText('Items');
+    fireEvent.click(itemsChip);
+    expect(screen.queryByText('stone.png')).toBeNull();
+    expect(screen.getByText('apple.png')).toBeInTheDocument();
+  });
 });

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -7,14 +7,18 @@ const meta = { description: 'desc', author: '', urls: [], created: 0 };
 
 describe('ProjectInfoPanel', () => {
   const load = vi.fn();
+  const open = vi.fn();
   const onExport = vi.fn();
   const onBack = vi.fn();
 
   beforeEach(() => {
     (
-      window as unknown as { electronAPI: { loadPackMeta: typeof load } }
+      window as unknown as {
+        electronAPI: { loadPackMeta: typeof load; openInFolder: typeof open };
+      }
     ).electronAPI = {
       loadPackMeta: load,
+      openInFolder: open,
     } as never;
     load.mockResolvedValue(meta);
     vi.clearAllMocks();
@@ -32,6 +36,8 @@ describe('ProjectInfoPanel', () => {
     await screen.findByText('desc');
     fireEvent.click(screen.getByText('Export Pack'));
     expect(onExport).toHaveBeenCalled();
+    fireEvent.click(screen.getByText('Open Folder'));
+    expect(open).toHaveBeenCalledWith('/p/Pack');
     fireEvent.click(screen.getByText('Back to Projects'));
     expect(onBack).toHaveBeenCalled();
     expect(screen.getByText('/p/Pack')).toBeInTheDocument();

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -51,7 +51,10 @@ const AssetSelector: React.FC<Props> = ({
   const filtered = query
     ? all.filter((t) => {
         if (!t.name.includes(query)) return false;
-        if (filters.length > 0 && !filters.includes(getCategory(t.name))) {
+        if (
+          filters.length > 0 &&
+          !filters.includes(getCategory(t.name) as Filter)
+        ) {
           return false;
         }
         return true;

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -21,22 +21,29 @@ export default function ProjectInfoPanel({
   }, [name]);
 
   return (
-    <div
-      className="p-2 flex flex-col items-center gap-2"
-      data-testid="project-info"
-    >
-      <button className="link link-primary self-start" onClick={onBack}>
-        Back to Projects
-      </button>
-      <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
-      <h2 className="font-display text-lg">{name}</h2>
-      <p className="text-xs break-all">{projectPath}</p>
-      <p className="text-sm text-center break-all flex-1">
-        {meta?.description}
-      </p>
-      <button className="btn btn-accent btn-sm mt-auto" onClick={onExport}>
-        Export Pack
-      </button>
+    <div className="card bg-base-100 shadow" data-testid="project-info">
+      <div className="card-body items-center gap-2 p-2">
+        <button className="link link-primary self-start" onClick={onBack}>
+          Back to Projects
+        </button>
+        <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
+        <h2 className="card-title text-lg font-display">{name}</h2>
+        <p className="text-xs break-all">{projectPath}</p>
+        <p className="text-sm text-center break-all flex-1">
+          {meta?.description}
+        </p>
+        <div className="card-actions justify-end w-full mt-auto">
+          <button
+            className="btn btn-neutral btn-sm"
+            onClick={() => window.electronAPI?.openInFolder(projectPath)}
+          >
+            Open Folder
+          </button>
+          <button className="btn btn-accent btn-sm" onClick={onExport}>
+            Export Pack
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -58,7 +58,10 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
   };
 
   return (
-    <main className="p-4 flex flex-col gap-4 h-full" data-testid="editor-view">
+    <main
+      className="p-4 flex flex-col gap-4 flex-1 min-h-0"
+      data-testid="editor-view"
+    >
       <div className="flex items-center justify-end mb-2">
         <ExternalLink
           href="https://minecraft.wiki/w/Resource_pack"
@@ -75,7 +78,7 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
           setLayout(l);
           window.electronAPI?.setEditorLayout(l);
         }}
-        className="flex-1"
+        className="flex-1 min-h-0"
       >
         <Panel
           minSize={15}


### PR DESCRIPTION
## Summary
- categorize files in asset browser so filter chips work
- ensure editor view fills available space
- revamp project info panel using daisyUI card and add Open Folder button
- update tests for new behaviors

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684e5dad55d08331a9b8d492ede4e015