### PR TITLE
Add TextureLab mini-lab

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 - [x] 1 : 1 pixel preview + zoom slider
 - [ ] External edit button (auto‑reload on save)
-- [ ] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
+- [x] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
 - [ ] Revision history (max 20)
 
 ---

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TextureLab from '../src/renderer/components/TextureLab';
+
+describe('TextureLab', () => {
+  it('renders modal with controls', () => {
+    render(<TextureLab file="foo.png" onClose={() => {}} />);
+    expect(screen.getByTestId('texture-lab')).toBeInTheDocument();
+    expect(screen.getByText('Texture Lab')).toBeInTheDocument();
+  });
+});

--- a/__tests__/textureLabIPC.test.ts
+++ b/__tests__/textureLabIPC.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import sharp from 'sharp';
+import { registerTextureLabHandlers } from '../src/main/textureLab';
+
+let handler:
+  | ((e: unknown, file: string, opts: unknown) => Promise<void>)
+  | undefined;
+const ipcMock = {
+  handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+    if (channel === 'edit-texture') handler = fn as typeof handler;
+  },
+};
+
+describe('edit-texture IPC', () => {
+  it('modifies the file using sharp', async () => {
+    const tmp = path.join(os.tmpdir(), 'lab-test.png');
+    await sharp({
+      create: { width: 2, height: 2, channels: 4, background: '#ff0000' },
+    })
+      .png()
+      .toFile(tmp);
+    registerTextureLabHandlers(
+      ipcMock as unknown as import('electron').IpcMain
+    );
+    expect(handler).toBeTypeOf('function');
+    await handler?.({}, tmp, { grayscale: true });
+    const meta = await sharp(tmp).metadata();
+    expect(meta.format).toBe('png');
+    fs.unlinkSync(tmp);
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -128,6 +128,11 @@ pixel scale and includes a zoom slider (1–8×). Scrolling the mouse wheel over
 the pane adjusts the zoom. The pane is lazy loaded and displays a
 `react-loader-spinner` indicator while loading.
 
+The **Texture Lab** modal lets you adjust PNG textures without leaving the app.
+It exposes hue shift, rotation, grayscale, saturation and brightness controls.
+Edits are processed in the main process via Sharp and the modal shows a spinner
+while the file is being updated.
+
 ## Windows Paths
 
 When writing tests or other code that constructs file system paths, prefer

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import {
   registerTextureProtocol,
   registerProjectTextureProtocol,
 } from './assets';
+import { registerTextureLabHandlers } from './textureLab';
 import { registerLayoutHandlers } from './layout';
 
 protocol.registerSchemesAsPrivileged([
@@ -65,6 +66,7 @@ registerAssetHandlers(ipcMain);
 registerExportHandlers(ipcMain, projectsDir);
 registerNoExportHandlers(ipcMain);
 registerLayoutHandlers(ipcMain);
+registerTextureLabHandlers(ipcMain);
 
 // Register file-related IPC handlers
 registerFileHandlers(ipcMain);

--- a/src/main/textureLab.ts
+++ b/src/main/textureLab.ts
@@ -1,0 +1,29 @@
+import sharp from 'sharp';
+import type { IpcMain } from 'electron';
+import type { TextureEditOptions } from '../shared/texture';
+
+export async function editTexture(
+  file: string,
+  opts: TextureEditOptions
+): Promise<void> {
+  let img = sharp(file);
+  if (opts.rotate) img = img.rotate(opts.rotate);
+
+  const modulate: { hue?: number; saturation?: number; brightness?: number } =
+    {};
+  if (typeof opts.hue === 'number') modulate.hue = opts.hue;
+  if (typeof opts.saturation === 'number')
+    modulate.saturation = opts.saturation;
+  if (typeof opts.brightness === 'number')
+    modulate.brightness = opts.brightness;
+  if (Object.keys(modulate).length) img = img.modulate(modulate);
+  if (opts.grayscale) img = img.grayscale();
+  const buf = await img.png().toBuffer();
+  await sharp(buf).toFile(file);
+}
+
+export function registerTextureLabHandlers(ipc: IpcMain) {
+  ipc.handle('edit-texture', (_e, file: string, opts: TextureEditOptions) => {
+    return editTexture(file, opts);
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,6 +51,10 @@ const api = {
   renameFile: (oldPath: string, newPath: string) =>
     invoke('rename-file', oldPath, newPath),
   deleteFile: (file: string) => invoke('delete-file', file),
+  editTexture: (
+    file: string,
+    opts: import('../shared/texture').TextureEditOptions
+  ) => invoke('edit-texture', file, opts),
   watchProject: (project: string) => invoke('watch-project', project),
   unwatchProject: (project: string) => invoke('unwatch-project', project),
   getNoExport: (project: string) => invoke('get-no-export', project),

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -2,8 +2,10 @@ import React, { Suspense, lazy, useEffect, useState } from 'react';
 import path from 'path';
 import { Oval } from 'react-loader-spinner';
 import { useToast } from './ToastProvider';
+import Spinner from './Spinner';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
+const TextureLab = lazy(() => import('./TextureLab'));
 
 interface Props {
   projectPath: string;
@@ -16,6 +18,7 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
   const [text, setText] = useState('');
   const [orig, setOrig] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [lab, setLab] = useState(false);
 
   const full = asset ? path.join(projectPath, asset) : '';
 
@@ -25,6 +28,7 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
   const isJson = asset
     ? ['.json', '.mcmeta'].includes(path.extname(asset).toLowerCase())
     : false;
+  const isPng = asset ? path.extname(asset).toLowerCase() === '.png' : false;
 
   useEffect(() => {
     if (asset && count === 1 && isText) {
@@ -92,6 +96,19 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
               </button>
             </div>
           </>
+        )}
+        {isPng && count === 1 && (
+          <button
+            className="btn btn-secondary btn-sm mt-2"
+            onClick={() => setLab(true)}
+          >
+            Open Texture Lab
+          </button>
+        )}
+        {lab && (
+          <Suspense fallback={<Spinner />}>
+            <TextureLab file={full} onClose={() => setLab(false)} />
+          </Suspense>
         )}
       </div>
     </div>

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Spinner from './Spinner';
+import type { TextureEditOptions } from '../../shared/texture';
+
+export default function TextureLab({
+  file,
+  onClose,
+}: {
+  file: string;
+  onClose: () => void;
+}) {
+  const [hue, setHue] = useState(0);
+  const [rotate, setRotate] = useState(0);
+  const [gray, setGray] = useState(false);
+  const [sat, setSat] = useState(1);
+  const [bright, setBright] = useState(1);
+  const [busy, setBusy] = useState(false);
+
+  const apply = () => {
+    const opts: TextureEditOptions = {
+      hue,
+      rotate,
+      grayscale: gray,
+      saturation: sat,
+      brightness: bright,
+    };
+    setBusy(true);
+    window.electronAPI?.editTexture(file, opts).finally(() => setBusy(false));
+  };
+
+  return (
+    <dialog className="modal modal-open" data-testid="texture-lab">
+      <form
+        className="modal-box flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          apply();
+        }}
+      >
+        <h3 className="font-bold text-lg">Texture Lab</h3>
+        <label className="flex items-center gap-2">
+          Hue
+          <input
+            type="range"
+            min={-180}
+            max={180}
+            value={hue}
+            onChange={(e) => setHue(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Rotation
+          <select
+            className="select select-sm"
+            value={rotate}
+            onChange={(e) => setRotate(Number(e.target.value))}
+          >
+            <option value={0}>0°</option>
+            <option value={90}>90°</option>
+            <option value={180}>180°</option>
+            <option value={270}>270°</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            className="checkbox"
+            checked={gray}
+            onChange={(e) => setGray(e.target.checked)}
+          />
+          Grayscale
+        </label>
+        <label className="flex items-center gap-2">
+          Saturation
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.1}
+            value={sat}
+            onChange={(e) => setSat(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          Brightness
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.1}
+            value={bright}
+            onChange={(e) => setBright(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <div className="modal-action">
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+          <button type="submit" className="btn btn-primary" disabled={busy}>
+            Apply
+          </button>
+        </div>
+        {busy && <Spinner />}
+      </form>
+    </dialog>
+  );
+}

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -36,6 +36,7 @@ declare global {
       writeFile: IpcInvoke<'write-file'>;
       renameFile: IpcInvoke<'rename-file'>;
       deleteFile: IpcInvoke<'delete-file'>;
+      editTexture: IpcInvoke<'edit-texture'>;
       watchProject: IpcInvoke<'watch-project'>;
       unwatchProject: IpcInvoke<'unwatch-project'>;
       getNoExport: IpcInvoke<'get-no-export'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -1,6 +1,7 @@
 import type { ProjectInfo } from '../../main/projects';
 import type { PackMeta } from '../project';
 import type { ExportSummary } from '../../main/exporter';
+import type { TextureEditOptions } from '../texture';
 
 export interface IpcRequestMap {
   'list-projects': [];
@@ -25,6 +26,7 @@ export interface IpcRequestMap {
   'write-file': [string, string];
   'rename-file': [string, string];
   'delete-file': [string];
+  'edit-texture': [string, TextureEditOptions];
   'watch-project': [string];
   'unwatch-project': [string];
   'get-no-export': [string];
@@ -56,6 +58,7 @@ export interface IpcResponseMap {
   'write-file': void;
   'rename-file': void;
   'delete-file': void;
+  'edit-texture': void;
   'watch-project': string[];
   'unwatch-project': void;
   'get-no-export': string[];

--- a/src/shared/texture.ts
+++ b/src/shared/texture.ts
@@ -1,0 +1,7 @@
+export interface TextureEditOptions {
+  rotate?: number;
+  hue?: number;
+  grayscale?: boolean;
+  saturation?: number;
+  brightness?: number;
+}


### PR DESCRIPTION
## Summary
- add TextureLab modal component with hue, rotation, grayscale, saturation and brightness controls
- process texture edits in the main process via Sharp and expose via IPC
- integrate texture lab with AssetInfo
- test IPC registration and component rendering
- document the mini-lab and mark TODO bullet complete

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e669f0b748331a8ef1afb77f3f82c