### PR TITLE
Add TextureLab mini-lab with Sharp IPC

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -58,7 +58,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 - [x] 1 : 1 pixel preview + zoom slider
 - [ ] External edit button (auto‑reload on save)
-- [ ] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
+- [x] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
 - [ ] Revision history (max 20)
 
 ---

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TextureLab from '../src/renderer/components/TextureLab';
+
+describe('TextureLab component', () => {
+  it('renders modal', () => {
+    render(<TextureLab file="foo.png" onClose={() => {}} />);
+    expect(screen.getByTestId('texture-lab')).toBeInTheDocument();
+    expect(screen.getByText('Texture Lab')).toBeInTheDocument();
+  });
+});

--- a/__tests__/textureOps.test.ts
+++ b/__tests__/textureOps.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+import sharp from 'sharp';
+import type { TextureOps } from '../src/main/textureLab';
+
+let applyHandler:
+  | ((e: unknown, file: string, ops: TextureOps) => Promise<void>)
+  | undefined;
+let sendMock: ReturnType<typeof vi.fn>;
+
+vi.mock('electron', () => {
+  sendMock = vi.fn();
+  return {
+    BrowserWindow: vi.fn(() => ({ webContents: { send: sendMock } })),
+    ipcMain: {
+      handle: (channel: string, fn: (...args: unknown[]) => void) => {
+        if (channel === 'apply-texture-ops')
+          applyHandler = fn as typeof applyHandler;
+      },
+    },
+  };
+});
+
+import { registerTextureLabHandlers } from '../src/main/textureLab';
+
+const tmpDir = path.join(os.tmpdir(), `tl-${uuid()}`);
+const imgPath = path.join(tmpDir, 'img.png');
+
+beforeAll(async () => {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  await sharp({
+    create: { width: 16, height: 8, channels: 4, background: '#f00' },
+  })
+    .png()
+    .toFile(imgPath);
+});
+
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('apply-texture-ops IPC', () => {
+  it('rotates image and sends progress', async () => {
+    const { BrowserWindow, ipcMain } = await import('electron');
+    const win = new BrowserWindow();
+    registerTextureLabHandlers(
+      ipcMain as unknown as import('electron').IpcMain,
+      win as unknown as import('electron').BrowserWindow
+    );
+
+    await applyHandler?.({}, imgPath, { rotate: 90 });
+    const meta = await sharp(imgPath).metadata();
+    expect(meta.width).toBe(8);
+    expect(meta.height).toBe(16);
+    expect(sendMock).toHaveBeenCalledWith('texture-progress', 100);
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -133,3 +133,7 @@ the pane adjusts the zoom. The pane is lazy loaded and displays a
 When writing tests or other code that constructs file system paths, prefer
 `path.join()` over string concatenation. Hard coded `/` separators can cause
 failures on Windows where the standard separator is `\`.
+
+## Texture Mini-Lab
+
+The texture inspector includes a modal lab for quick edits. Sliders let you shift hue, apply 90° rotations, toggle gray-scale and adjust saturation and brightness. These operations are processed via Sharp in the main process using IPC. Progress events are emitted as `texture-progress`.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import {
   registerProjectTextureProtocol,
 } from './assets';
 import { registerLayoutHandlers } from './layout';
+import { registerTextureLabHandlers } from './textureLab';
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'texture', privileges: { standard: true, secure: true } },
@@ -52,6 +53,7 @@ const createMainWindow = () => {
   });
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
   registerFileWatcherHandlers(ipcMain, mainWindow);
+  registerTextureLabHandlers(ipcMain, mainWindow);
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/src/main/textureLab.ts
+++ b/src/main/textureLab.ts
@@ -1,0 +1,63 @@
+import type { IpcMain, BrowserWindow } from 'electron';
+import sharp from 'sharp';
+
+export interface TextureOps {
+  hue?: number;
+  rotate?: number;
+  grayscale?: boolean;
+  saturation?: number;
+  brightness?: number;
+}
+
+export async function applyTextureOps(
+  file: string,
+  ops: TextureOps,
+  onProgress?: (pct: number) => void
+): Promise<void> {
+  let img = sharp(file);
+  const steps =
+    (ops.hue ? 1 : 0) +
+    (ops.rotate ? 1 : 0) +
+    (ops.grayscale ? 1 : 0) +
+    (ops.saturation ? 1 : 0) +
+    (ops.brightness ? 1 : 0);
+  let done = 0;
+  const step = () => {
+    done++;
+    onProgress?.(Math.round((done / steps) * 100));
+  };
+  if (
+    ops.hue !== undefined ||
+    ops.saturation !== undefined ||
+    ops.brightness !== undefined
+  ) {
+    img = img.modulate({
+      hue: ops.hue ?? 0,
+      saturation: ops.saturation ? 1 + ops.saturation / 100 : undefined,
+      brightness: ops.brightness ? 1 + ops.brightness / 100 : undefined,
+    });
+    step();
+  }
+  if (ops.rotate) {
+    img = img.rotate(ops.rotate);
+    step();
+  }
+  if (ops.grayscale) {
+    img = img.grayscale();
+    step();
+  }
+  const buf = await img.toBuffer();
+  await sharp(buf).toFile(file);
+  if (steps === 0) onProgress?.(100);
+}
+
+export function registerTextureLabHandlers(ipc: IpcMain, win: BrowserWindow) {
+  ipc.handle(
+    'apply-texture-ops',
+    async (_e, file: string, ops: TextureOps): Promise<void> => {
+      await applyTextureOps(file, ops, (p) => {
+        win.webContents.send('texture-progress', p);
+      });
+    }
+  );
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -58,6 +58,10 @@ const api = {
     invoke('set-no-export', project, files, flag),
   getEditorLayout: () => invoke('get-editor-layout'),
   setEditorLayout: (layout: number[]) => invoke('set-editor-layout', layout),
+  applyTextureOps: (
+    file: string,
+    ops: import('../main/textureLab').TextureOps
+  ) => invoke('apply-texture-ops', file, ops),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>
@@ -68,6 +72,8 @@ const api = {
   loadPackMeta: (name: string) => invoke('load-pack-meta', name),
   savePackMeta: (name: string, meta: import('../main/projects').PackMeta) =>
     invoke('save-pack-meta', name, meta),
+  onTextureProgress: (listener: (e: unknown, p: number) => void) =>
+    on('texture-progress', listener),
 };
 
 if (process.contextIsolated) {

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -1,0 +1,114 @@
+import React, { useEffect, useState } from 'react';
+
+interface Props {
+  file: string;
+  onClose: () => void;
+}
+
+export default function TextureLab({ file, onClose }: Props) {
+  const [hue, setHue] = useState(0);
+  const [rotate, setRotate] = useState(0);
+  const [gray, setGray] = useState(false);
+  const [sat, setSat] = useState(0);
+  const [bright, setBright] = useState(0);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    const handler = (_: unknown, p: number) => setProgress(p);
+    window.electronAPI?.onTextureProgress(handler);
+    return () => {
+      // no remove function but event listeners are cleaned when window reloads
+    };
+  }, []);
+
+  const apply = () => {
+    setProgress(0);
+    window.electronAPI
+      ?.applyTextureOps(file, {
+        hue,
+        rotate,
+        grayscale: gray,
+        saturation: sat,
+        brightness: bright,
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  };
+
+  return (
+    <dialog className="modal modal-open" data-testid="texture-lab">
+      <form method="dialog" className="modal-box flex flex-col gap-2">
+        <h3 className="font-bold text-lg">Texture Lab</h3>
+        <label className="flex items-center gap-2">
+          <span className="w-24">Hue</span>
+          <input
+            type="range"
+            min={-180}
+            max={180}
+            value={hue}
+            onChange={(e) => setHue(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="w-24">Rotate</span>
+          <select
+            value={rotate}
+            onChange={(e) => setRotate(Number(e.target.value))}
+            className="select select-sm flex-1"
+          >
+            <option value={0}>0°</option>
+            <option value={90}>90°</option>
+            <option value={180}>180°</option>
+            <option value={270}>270°</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="w-24">Grayscale</span>
+          <input
+            type="checkbox"
+            checked={gray}
+            onChange={(e) => setGray(e.target.checked)}
+            className="checkbox"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="w-24">Saturation</span>
+          <input
+            type="range"
+            min={-100}
+            max={100}
+            value={sat}
+            onChange={(e) => setSat(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <label className="flex items-center gap-2">
+          <span className="w-24">Brightness</span>
+          <input
+            type="range"
+            min={-100}
+            max={100}
+            value={bright}
+            onChange={(e) => setBright(Number(e.target.value))}
+            className="range range-xs flex-1"
+          />
+        </label>
+        <progress
+          className="progress w-full"
+          value={progress}
+          max={100}
+        ></progress>
+        <div className="modal-action">
+          <button type="button" className="btn" onClick={onClose}>
+            Close
+          </button>
+          <button type="button" className="btn btn-primary" onClick={apply}>
+            Apply
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -42,10 +42,12 @@ declare global {
       setNoExport: IpcInvoke<'set-no-export'>;
       getEditorLayout: IpcInvoke<'get-editor-layout'>;
       setEditorLayout: IpcInvoke<'set-editor-layout'>;
+      applyTextureOps: IpcInvoke<'apply-texture-ops'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;
       onFileRemoved: IpcListener<'file-removed'>;
       onFileRenamed: IpcListener<'file-renamed'>;
+      onTextureProgress: IpcListener<'texture-progress'>;
     };
   }
 }

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -31,6 +31,7 @@ export interface IpcRequestMap {
   'set-no-export': [string, string[], boolean];
   'get-editor-layout': [];
   'set-editor-layout': [number[]];
+  'apply-texture-ops': [string, import('../../main/textureLab').TextureOps];
 }
 
 export interface IpcResponseMap {
@@ -62,6 +63,7 @@ export interface IpcResponseMap {
   'set-no-export': void;
   'get-editor-layout': number[];
   'set-editor-layout': void;
+  'apply-texture-ops': void;
 }
 
 export interface IpcEventMap {
@@ -69,4 +71,5 @@ export interface IpcEventMap {
   'file-added': string;
   'file-removed': string;
   'file-renamed': { oldPath: string; newPath: string };
+  'texture-progress': number;
 }


### PR DESCRIPTION
## Summary
- implement `TextureLab` modal for basic image adjustments
- process edits in the main process via new IPC handlers
- expose new API bindings in the preload layer and update global types
- document the mini‑lab and mark TODO as complete
- add tests for IPC operation and component rendering

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e669f0b748331a8ef1afb77f3f82c