### PR TITLE
Add arborist tree mode for asset views

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -14,6 +14,7 @@ const onFileRenamed = vi.fn();
 describe('AssetBrowser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    watchProject.mockResolvedValue(['a.txt', 'b.png']);
     (
       window as unknown as {
         electronAPI: {
@@ -275,5 +276,13 @@ describe('AssetBrowser', () => {
     fireEvent.click(itemsChip);
     expect(screen.queryByText('stone.png')).toBeNull();
     expect(screen.getByText('apple.png')).toBeInTheDocument();
+  });
+
+  it('shows tree view', async () => {
+    render(<AssetBrowser path="/proj" />);
+    await screen.findByText('a.txt');
+    fireEvent.click(screen.getByText('Tree'));
+    expect(screen.getByTestId('file-tree')).toBeInTheDocument();
+    expect(screen.getByText('a.txt')).toBeInTheDocument();
   });
 });

--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -30,7 +30,8 @@ describe('AssetSelector', () => {
   });
 
   it('lists textures and handles selection', async () => {
-    render(<AssetSelector path="/proj" />);
+    const onSelect = vi.fn();
+    render(<AssetSelector path="/proj" onAssetSelect={onSelect} />);
     expect(listTextures).toHaveBeenCalledWith('/proj');
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
@@ -44,7 +45,8 @@ describe('AssetSelector', () => {
     expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/grass.png');
     expect(img.src).toContain('texture://block/grass.png');
     fireEvent.click(button);
-    expect(addTexture).toHaveBeenCalledWith('/proj', 'block/grass.png');
+    expect(addTexture).not.toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledWith('block/grass.png');
   });
 
   it('shows items in the items category', async () => {
@@ -98,5 +100,15 @@ describe('AssetSelector', () => {
     expect(
       screen.getAllByRole('button', { name: /block\/test/ }).length
     ).toBeLessThan(50);
+  });
+
+  it('shows tree view', async () => {
+    render(<AssetSelector path="/proj" />);
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'grass' } });
+    await screen.findByText('blocks');
+    fireEvent.click(screen.getByText('Tree'));
+    expect(screen.getByText('block')).toBeInTheDocument();
+    expect(screen.getByText('grass.png')).toBeInTheDocument();
   });
 });

--- a/__tests__/AssetSelectorInfoPanel.test.tsx
+++ b/__tests__/AssetSelectorInfoPanel.test.tsx
@@ -1,16 +1,27 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import AssetSelectorInfoPanel from '../src/renderer/components/AssetSelectorInfoPanel';
 
 describe('AssetSelectorInfoPanel', () => {
   it('shows placeholder when no asset', () => {
-    render(<AssetSelectorInfoPanel asset={null} />);
+    render(<AssetSelectorInfoPanel projectPath="/p" asset={null} />);
     expect(screen.getByText('No asset selected')).toBeInTheDocument();
   });
 
   it('displays asset name', () => {
-    render(<AssetSelectorInfoPanel asset="block/a.png" />);
+    render(<AssetSelectorInfoPanel projectPath="/p" asset="block/a.png" />);
     expect(screen.getByText('block/a.png')).toBeInTheDocument();
+  });
+
+  it('adds asset on button click', () => {
+    const addTexture = vi.fn();
+    interface API {
+      addTexture: typeof addTexture;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = { addTexture };
+    render(<AssetSelectorInfoPanel projectPath="/p" asset="block/a.png" />);
+    screen.getByText('Add').click();
+    expect(addTexture).toHaveBeenCalledWith('/p', 'block/a.png');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "global-agent": "^3.0.0",
         "minecraft-data": "^3.89.0",
         "react": "^19.1.0",
+        "react-arborist": "^3.4.3",
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.1.0",
         "react-loader-spinner": "^6.1.6",
@@ -2469,6 +2470,24 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@react-dnd/asap": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@react-dnd/asap/-/asap-4.0.1.tgz",
+      "integrity": "sha512-kLy0PJDDwvwwTXxqTFNAAllPHD73AycE9ypWeln/IguoGBEbvFcPDbCV03G52bEcC5E+YgupBE0VzHGdC8SIXg==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/invariant": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/invariant/-/invariant-2.0.0.tgz",
+      "integrity": "sha512-xL4RCQBCBDJ+GRwKTFhGUW8GXa4yoDfJrPbLblc3U09ciS+9ZJXJ3Qrcs/x2IODOdIE5kQxvMmE2UKyqUictUw==",
+      "license": "MIT"
+    },
+    "node_modules/@react-dnd/shallowequal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-dnd/shallowequal/-/shallowequal-2.0.0.tgz",
+      "integrity": "sha512-Pc/AFTdwZwEKJxFJvlxrSmGe/di+aAOBn60sremrpLo6VI/6cmiUYNNwlI5KNYttg7uypzA3ILPMPgxB2GYZEg==",
+      "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.43.0",
@@ -6526,6 +6545,26 @@
         "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/dnd-core": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-14.0.1.tgz",
+      "integrity": "sha512-+PVS2VPTgKFPYWo3vAFEA8WPbTf7/xo43TifH9G8S1KqnrQu0o77A3unrF5yOugy4mIz7K5wAVFHUcha7wsz6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/asap": "^4.0.0",
+        "@react-dnd/invariant": "^2.0.0",
+        "redux": "^4.1.1"
+      }
+    },
+    "node_modules/dnd-core/node_modules/redux": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
+      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.9.2"
+      }
+    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
@@ -9218,6 +9257,21 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/hoist-non-react-statics": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "react-is": "^16.7.0"
+      }
+    },
+    "node_modules/hoist-non-react-statics/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
@@ -13090,6 +13144,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-arborist": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/react-arborist/-/react-arborist-3.4.3.tgz",
+      "integrity": "sha512-yFnq1nIQhT2uJY4TZVz2tgAiBb9lxSyvF4vC3S8POCK8xLzjGIxVv3/4dmYquQJ7AHxaZZArRGHiHKsEewKdTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-dnd": "^14.0.3",
+        "react-dnd-html5-backend": "^14.0.3",
+        "react-window": "^1.8.11",
+        "redux": "^5.0.0",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14",
+        "react-dom": ">= 16.14"
+      }
+    },
     "node_modules/react-canvas-confetti": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/react-canvas-confetti/-/react-canvas-confetti-2.0.7.tgz",
@@ -13101,6 +13172,45 @@
       },
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-dnd": {
+      "version": "14.0.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-14.0.5.tgz",
+      "integrity": "sha512-9i1jSgbyVw0ELlEVt/NkCUkxy1hmhJOkePoCH713u75vzHGyXhPDm28oLfc2NMSBjZRM1Y+wRjHXJT3sPrTy+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-dnd/invariant": "^2.0.0",
+        "@react-dnd/shallowequal": "^2.0.0",
+        "dnd-core": "14.0.1",
+        "fast-deep-equal": "^3.1.3",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "peerDependencies": {
+        "@types/hoist-non-react-statics": ">= 3.3.1",
+        "@types/node": ">= 12",
+        "@types/react": ">= 16",
+        "react": ">= 16.14"
+      },
+      "peerDependenciesMeta": {
+        "@types/hoist-non-react-statics": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-dnd-html5-backend": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/react-dnd-html5-backend/-/react-dnd-html5-backend-14.1.0.tgz",
+      "integrity": "sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==",
+      "license": "MIT",
+      "dependencies": {
+        "dnd-core": "14.0.1"
       }
     },
     "node_modules/react-dom": {
@@ -13409,6 +13519,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -15961,6 +16077,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/username": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "global-agent": "^3.0.0",
     "minecraft-data": "^3.89.0",
     "react": "^19.1.0",
+    "react-arborist": "^3.4.3",
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.1.0",
     "react-loader-spinner": "^6.1.6",

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -4,6 +4,7 @@ import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
 import { useToast } from './ToastProvider';
+import FileTree from './FileTree';
 
 interface Props {
   path: string;
@@ -48,6 +49,7 @@ const AssetBrowser: React.FC<Props> = ({
   const [query, setQuery] = useState('');
   const [zoom, setZoom] = useState(64);
   const [filters, setFilters] = useState<Filter[]>([]);
+  const [view, setView] = useState<'grid' | 'tree'>('grid');
   const wrapperRef = useRef<HTMLDivElement>(null);
   const toast = useToast();
 
@@ -135,6 +137,20 @@ const AssetBrowser: React.FC<Props> = ({
           onChange={(e) => setZoom(Number(e.target.value))}
           className="range range-xs w-32"
         />
+        <div className="btn-group">
+          <button
+            className={`btn btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
+            onClick={() => setView('grid')}
+          >
+            Grid
+          </button>
+          <button
+            className={`btn btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
+            onClick={() => setView('tree')}
+          >
+            Tree
+          </button>
+        </div>
       </div>
       <div className="flex gap-1 mb-2">
         {FILTERS.map((f) => (
@@ -152,35 +168,45 @@ const AssetBrowser: React.FC<Props> = ({
           </span>
         ))}
       </div>
-      {(['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
-        (key) => {
-          const list = categories[key];
-          if (list.length === 0) return null;
-          return (
-            <div className="collapse collapse-arrow mb-2" key={key}>
-              <input type="checkbox" defaultChecked />
-              <div className="collapse-title font-medium capitalize">{key}</div>
-              <div className="collapse-content">
-                <div className="grid grid-cols-6 gap-2">
-                  {list.map((f) => (
-                    <AssetBrowserItem
-                      key={f}
-                      projectPath={projectPath}
-                      file={f}
-                      selected={selected}
-                      setSelected={setSelected}
-                      noExport={noExport}
-                      toggleNoExport={toggleNoExport}
-                      confirmDelete={(files) => setConfirmDelete(files)}
-                      openRename={(file) => setRenameTarget(file)}
-                      zoom={zoom}
-                    />
-                  ))}
+      {view === 'grid' ? (
+        (['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
+          (key) => {
+            const list = categories[key];
+            if (list.length === 0) return null;
+            return (
+              <div className="collapse collapse-arrow mb-2" key={key}>
+                <input type="checkbox" defaultChecked />
+                <div className="collapse-title font-medium capitalize">
+                  {key}
+                </div>
+                <div className="collapse-content">
+                  <div className="grid grid-cols-6 gap-2">
+                    {list.map((f) => (
+                      <AssetBrowserItem
+                        key={f}
+                        projectPath={projectPath}
+                        file={f}
+                        selected={selected}
+                        setSelected={setSelected}
+                        noExport={noExport}
+                        toggleNoExport={toggleNoExport}
+                        confirmDelete={(files) => setConfirmDelete(files)}
+                        openRename={(file) => setRenameTarget(file)}
+                        zoom={zoom}
+                      />
+                    ))}
+                  </div>
                 </div>
               </div>
-            </div>
-          );
-        }
+            );
+          }
+        )
+      ) : (
+        <FileTree
+          files={visible}
+          selected={selected}
+          setSelected={setSelected}
+        />
       )}
       {confirmDelete && (
         <dialog className="modal modal-open" data-testid="delete-modal">

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import TextureGrid, { TextureInfo } from './TextureGrid';
+import TextureTree from './TextureTree';
 
 interface Props {
   path: string;
@@ -31,6 +32,7 @@ const AssetSelector: React.FC<Props> = ({
   const [query, setQuery] = useState('');
   const [zoom, setZoom] = useState(64);
   const [filters, setFilters] = useState<Filter[]>([]);
+  const [view, setView] = useState<'grid' | 'tree'>('grid');
 
   useEffect(() => {
     const load = async () => {
@@ -79,7 +81,6 @@ const AssetSelector: React.FC<Props> = ({
   }, [filtered]);
 
   const handleSelect = (name: string) => {
-    window.electronAPI?.addTexture(projectPath, name);
     onAssetSelect?.(name);
   };
 
@@ -109,6 +110,20 @@ const AssetSelector: React.FC<Props> = ({
           onChange={(e) => setZoom(Number(e.target.value))}
           className="range range-xs w-32"
         />
+        <div className="btn-group">
+          <button
+            className={`btn btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
+            onClick={() => setView('grid')}
+          >
+            Grid
+          </button>
+          <button
+            className={`btn btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
+            onClick={() => setView('tree')}
+          >
+            Tree
+          </button>
+        </div>
       </div>
       <div className="flex gap-1 mb-2">
         {FILTERS.map((f) => (
@@ -126,25 +141,31 @@ const AssetSelector: React.FC<Props> = ({
           </span>
         ))}
       </div>
-      {(['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
-        (key) => {
-          const list = categories[key];
-          if (list.length === 0) return null;
-          return (
-            <div className="collapse collapse-arrow mb-2" key={key}>
-              <input type="checkbox" defaultChecked />
-              <div className="collapse-title font-medium capitalize">{key}</div>
-              <div className="collapse-content">
-                <TextureGrid
-                  testId="texture-grid"
-                  textures={list}
-                  zoom={zoom}
-                  onSelect={handleSelect}
-                />
+      {view === 'grid' ? (
+        (['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
+          (key) => {
+            const list = categories[key];
+            if (list.length === 0) return null;
+            return (
+              <div className="collapse collapse-arrow mb-2" key={key}>
+                <input type="checkbox" defaultChecked />
+                <div className="collapse-title font-medium capitalize">
+                  {key}
+                </div>
+                <div className="collapse-content">
+                  <TextureGrid
+                    testId="texture-grid"
+                    textures={list}
+                    zoom={zoom}
+                    onSelect={handleSelect}
+                  />
+                </div>
               </div>
-            </div>
-          );
-        }
+            );
+          }
+        )
+      ) : (
+        <TextureTree textures={filtered} onSelect={handleSelect} />
       )}
     </div>
   );

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-export default function AssetSelectorInfoPanel({
-  asset,
-}: {
+interface Props {
+  projectPath: string;
   asset: string | null;
-}) {
+}
+
+export default function AssetSelectorInfoPanel({ projectPath, asset }: Props) {
   if (!asset) return <div className="p-2">No asset selected</div>;
   return (
     <div className="p-2" data-testid="selector-info">
@@ -15,6 +16,12 @@ export default function AssetSelectorInfoPanel({
         style={{ imageRendering: 'pixelated' }}
       />
       <p className="break-all text-sm">{asset}</p>
+      <button
+        className="btn btn-primary btn-sm mt-2"
+        onClick={() => window.electronAPI?.addTexture(projectPath, asset)}
+      >
+        Add
+      </button>
     </div>
   );
 }

--- a/src/renderer/components/FileTree.tsx
+++ b/src/renderer/components/FileTree.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Tree } from 'react-arborist';
+import path from 'path';
+import { buildTree, TreeItem } from '../utils/tree';
+
+interface Props {
+  files: string[];
+  selected: Set<string>;
+  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
+}
+
+export default function FileTree({ files, selected, setSelected }: Props) {
+  const data = React.useMemo<TreeItem[]>(() => buildTree(files), [files]);
+  const handleSelect = (id: string) => {
+    setSelected(new Set([id]));
+  };
+  return (
+    <div
+      style={{ height: '12rem' }}
+      className="overflow-y-auto"
+      data-testid="file-tree"
+    >
+      <Tree
+        initialData={data}
+        openByDefault
+        rowHeight={24}
+        width={300}
+        height={192}
+      >
+        {({ node, style }) => (
+          <div
+            style={style}
+            className={`cursor-pointer pl-1 ${selected.has(node.id) ? 'bg-base-300' : ''}`}
+            onClick={() => node.isLeaf && handleSelect(node.id)}
+          >
+            {node.isLeaf ? path.basename(node.data.name) : node.data.name}
+          </div>
+        )}
+      </Tree>
+    </div>
+  );
+}

--- a/src/renderer/components/TextureTree.tsx
+++ b/src/renderer/components/TextureTree.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { Tree } from 'react-arborist';
+import { formatTextureName } from '../utils/textureNames';
+import { buildTree, TreeItem } from '../utils/tree';
+import type { TextureInfo } from './TextureGrid';
+
+interface Props {
+  textures: TextureInfo[];
+  onSelect: (name: string) => void;
+}
+
+export default function TextureTree({ textures, onSelect }: Props) {
+  const data = React.useMemo<TreeItem[]>(
+    () => buildTree(textures.map((t) => t.name)),
+    [textures]
+  );
+  const urlMap = React.useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const t of textures) map[t.name] = t.url;
+    return map;
+  }, [textures]);
+
+  return (
+    <div style={{ height: '12rem' }} className="overflow-y-auto">
+      <Tree
+        initialData={data}
+        openByDefault
+        rowHeight={32}
+        width={300}
+        height={192}
+      >
+        {({ node, style }) => (
+          <div
+            style={style}
+            className="flex items-center gap-1 cursor-pointer"
+            onClick={() => {
+              if (node.isLeaf) onSelect(node.id);
+            }}
+          >
+            {node.isLeaf && (
+              <img
+                src={urlMap[node.id]}
+                alt={formatTextureName(node.id)}
+                style={{ width: 24, height: 24, imageRendering: 'pixelated' }}
+              />
+            )}
+            <span className="text-sm break-all">{node.data.name}</span>
+          </div>
+        )}
+      </Tree>
+    </div>
+  );
+}

--- a/src/renderer/utils/tree.ts
+++ b/src/renderer/utils/tree.ts
@@ -1,0 +1,34 @@
+export interface TreeItem {
+  id: string;
+  name: string;
+  children?: TreeItem[];
+}
+
+interface NodeMap {
+  id: string;
+  name: string;
+  children: Record<string, NodeMap>;
+}
+
+export function buildTree(paths: string[]): TreeItem[] {
+  const root: Record<string, NodeMap> = {};
+  for (const p of paths) {
+    const parts = p.split('/');
+    let map = root;
+    let cur = '';
+    for (const part of parts) {
+      cur = cur ? `${cur}/${part}` : part;
+      if (!map[part]) {
+        map[part] = { id: cur, name: part, children: {} };
+      }
+      map = map[part].children;
+    }
+  }
+  const convert = (m: Record<string, NodeMap>): TreeItem[] =>
+    Object.values(m).map((n) => ({
+      id: n.id,
+      name: n.name,
+      children: convert(n.children),
+    }));
+  return convert(root);
+}

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -112,7 +112,10 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
               <div className="w-full h-px bg-base-content"></div>
             </PanelResizeHandle>
             <Panel defaultSize={30} className="overflow-y-auto">
-              <AssetSelectorInfoPanel asset={selectorAsset} />
+              <AssetSelectorInfoPanel
+                projectPath={projectPath}
+                asset={selectorAsset}
+              />
             </Panel>
           </PanelGroup>
         </Panel>


### PR DESCRIPTION
## Summary
- add `react-arborist` to deps
- create `TextureTree` and `FileTree` components
- support tree view toggle in Asset Selector and Asset Browser
- move add-to-project action to AssetSelectorInfoPanel button
- update EditorView and tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684e67217a0083318a123786d169db41