### PR TITLE
Add preview in Texture Lab modal

### DIFF
--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -5,8 +5,12 @@ import TextureLab from '../src/renderer/components/TextureLab';
 
 describe('TextureLab', () => {
   it('renders modal with controls', () => {
-    render(<TextureLab file="foo.png" onClose={() => {}} />);
+    render(
+      <TextureLab file="/proj/foo.png" projectPath="/proj" onClose={() => {}} />
+    );
     expect(screen.getByTestId('texture-lab')).toBeInTheDocument();
     expect(screen.getByText('Texture Lab')).toBeInTheDocument();
+    const img = screen.getByAltText('preview');
+    expect(img).toHaveAttribute('src', 'ptex://foo.png');
   });
 });

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -107,7 +107,11 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
         )}
         {lab && (
           <Suspense fallback={<Spinner />}>
-            <TextureLab file={full} onClose={() => setLab(false)} />
+            <TextureLab
+              file={full}
+              projectPath={projectPath}
+              onClose={() => setLab(false)}
+            />
           </Suspense>
         )}
       </div>

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -1,12 +1,15 @@
 import React, { useState } from 'react';
+import path from 'path';
 import Spinner from './Spinner';
 import type { TextureEditOptions } from '../../shared/texture';
 
 export default function TextureLab({
   file,
+  projectPath,
   onClose,
 }: {
   file: string;
+  projectPath: string;
   onClose: () => void;
 }) {
   const [hue, setHue] = useState(0);
@@ -15,6 +18,11 @@ export default function TextureLab({
   const [sat, setSat] = useState(1);
   const [bright, setBright] = useState(1);
   const [busy, setBusy] = useState(false);
+
+  const rel = path.relative(projectPath, file).split(path.sep).join('/');
+  const filter = `hue-rotate(${hue}deg) saturate(${sat}) brightness(${bright})${
+    gray ? ' grayscale(1)' : ''
+  }`;
 
   const apply = () => {
     const opts: TextureEditOptions = {
@@ -38,6 +46,17 @@ export default function TextureLab({
         }}
       >
         <h3 className="font-bold text-lg">Texture Lab</h3>
+        <div className="flex justify-center">
+          <img
+            src={`ptex://${rel}`}
+            alt="preview"
+            style={{
+              imageRendering: 'pixelated',
+              transform: `rotate(${rotate}deg)`,
+              filter,
+            }}
+          />
+        </div>
         <label className="flex items-center gap-2">
           Hue
           <input


### PR DESCRIPTION
## Summary
- show the Texture Lab preview using project-relative `ptex://` URLs
- update AssetInfo to pass `projectPath` to TextureLab
- test that TextureLab renders preview image

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684e70d4a76c8331ae9872958a826cc4