### PR TITLE
Move asset selector to modal

### DIFF
--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -51,7 +51,7 @@ const summary = {
 describe('EditorView', () => {
   const exportProject = vi.fn();
 
-  const getLayout = vi.fn(async () => [20, 40, 40]);
+  const getLayout = vi.fn(async () => [20, 80]);
   const setLayout = vi.fn();
 
   beforeEach(() => {
@@ -98,5 +98,11 @@ describe('EditorView', () => {
     expect(openExternalMock).toHaveBeenCalledWith(
       'https://minecraft.wiki/w/Resource_pack'
     );
+  });
+
+  it('opens asset selector modal', () => {
+    render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Add Assets' }));
+    expect(screen.getByTestId('asset-selector-modal')).toBeInTheDocument();
   });
 });

--- a/__tests__/TextureGrid.test.tsx
+++ b/__tests__/TextureGrid.test.tsx
@@ -10,7 +10,7 @@ const textures: TextureInfo[] = [
   { name: 'block/dirt.png', url: 'texture://dirt' },
 ];
 
-describe('TextureGrid drag and click', () => {
+describe('TextureGrid', () => {
   it('triggers onSelect on click', () => {
     const onSelect = vi.fn();
     render(<TextureGrid textures={textures} zoom={64} onSelect={onSelect} />);
@@ -19,21 +19,9 @@ describe('TextureGrid drag and click', () => {
     expect(onSelect).toHaveBeenCalledWith('block/stone.png');
   });
 
-  it('sets drag data with texture name', () => {
-    const onSelect = vi.fn();
-    render(<TextureGrid textures={textures} zoom={64} onSelect={onSelect} />);
+  it('is not draggable', () => {
+    render(<TextureGrid textures={textures} zoom={64} onSelect={vi.fn()} />);
     const btn = screen.getByRole('button', { name: 'block/stone.png' });
-    const store: Record<string, string> = {};
-    const transfer = {
-      setData: (t: string, v: string) => {
-        store[t] = v;
-      },
-      getData: (t: string) => store[t] ?? '',
-      effectAllowed: '',
-    } as DataTransfer;
-    fireEvent.dragStart(btn, { dataTransfer: transfer });
-    expect(store['text/plain']).toBe('block/stone.png');
-    expect(transfer.effectAllowed).toBe('copy');
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(btn.getAttribute('draggable')).toBe(null);
   });
 });

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -2,7 +2,7 @@ import type { IpcMain } from 'electron';
 import Store from 'electron-store';
 
 const store = new Store<{ editorLayout: number[] }>({
-  defaults: { editorLayout: [20, 40, 40] },
+  defaults: { editorLayout: [20, 80] },
 });
 
 export function getEditorLayout(): number[] {

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -3,7 +3,6 @@ import path from 'path';
 import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
-import { useToast } from './ToastProvider';
 import FileTree from './FileTree';
 
 interface Props {
@@ -51,7 +50,6 @@ const AssetBrowser: React.FC<Props> = ({
   const [filters, setFilters] = useState<Filter[]>([]);
   const [view, setView] = useState<'grid' | 'tree'>('grid');
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const toast = useToast();
 
   useEffect(() => {
     onSelectionChange?.(Array.from(selected));
@@ -96,21 +94,10 @@ const AssetBrowser: React.FC<Props> = ({
     );
   };
 
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    const tex = e.dataTransfer.getData('text/plain');
-    if (!tex) return;
-    window.electronAPI?.addTexture(projectPath, tex).then(() => {
-      toast('Texture added', 'success');
-    });
-  };
-
   return (
     <div
       data-testid="asset-browser"
       ref={wrapperRef}
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={handleDrop}
       onKeyDown={(e) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();

--- a/src/renderer/components/TextureGrid.tsx
+++ b/src/renderer/components/TextureGrid.tsx
@@ -40,11 +40,6 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
         <button
           aria-label={tex.name}
           onClick={() => data.onSelect(tex.name)}
-          onDragStart={(e) => {
-            e.dataTransfer.setData('text/plain', tex.name);
-            e.dataTransfer.effectAllowed = 'copy';
-          }}
-          draggable
           className="p-1 hover:ring ring-accent rounded"
         >
           <img


### PR DESCRIPTION
## Summary
- update EditorView layout and open AssetSelector in a modal
- remove drag/drop support from AssetBrowser and TextureGrid
- adjust default layout
- update tests for new UI

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ecad1e17883318ae9106d4ef7a361