### PR TITLE
Refactor AssetBrowserItem with daisyUI card

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -41,11 +41,11 @@ describe('AssetBrowser', () => {
   it('renders files from directory', async () => {
     render(<AssetBrowser path="/proj" />);
     expect(watchProject).toHaveBeenCalledWith('/proj');
-    expect(await screen.findByText('a.txt')).toBeInTheDocument();
+    expect((await screen.findAllByText('a.txt'))[0]).toBeInTheDocument();
     const img = screen.getByAltText('B') as HTMLImageElement;
     expect(img.src).toContain('ptex://b.png');
     expect(screen.getByText('B')).toBeInTheDocument();
-    expect(screen.getByText('b.png')).toBeInTheDocument();
+    expect(screen.getAllByText('b.png')[0]).toBeInTheDocument();
     expect(img.style.imageRendering).toBe('pixelated');
   });
 
@@ -84,7 +84,7 @@ describe('AssetBrowser', () => {
       setNoExport: vi.fn(),
     };
     render(<AssetBrowser path="/proj" />);
-    const item = await screen.findByText('a.txt');
+    const item = (await screen.findAllByText('a.txt'))[0];
     fireEvent.contextMenu(item);
     const revealBtn = (
       await screen.findAllByRole('menuitem', { name: 'Reveal' })
@@ -138,19 +138,19 @@ describe('AssetBrowser', () => {
     });
 
     render(<AssetBrowser path="/proj" />);
-    await screen.findByText('a.txt');
+    await screen.findAllByText('a.txt');
 
     added?.({}, 'c.txt');
-    expect(await screen.findByText('c.txt')).toBeInTheDocument();
+    expect((await screen.findAllByText('c.txt'))[0]).toBeInTheDocument();
 
     removed?.({}, 'a.txt');
-    await screen.findByText('c.txt');
+    await screen.findAllByText('c.txt');
     expect(screen.queryByText('a.txt')).toBeNull();
 
     renamed?.({}, { oldPath: 'b.png', newPath: 'd.png' });
-    await screen.findByText('d.png');
+    await screen.findAllByText('d.png');
     expect(screen.queryByText('b.png')).toBeNull();
-    expect(screen.getByText('d.png')).toBeInTheDocument();
+    expect(screen.getAllByText('d.png')[0]).toBeInTheDocument();
   });
 
   it('supports multi selection and delete key', async () => {
@@ -176,8 +176,8 @@ describe('AssetBrowser', () => {
       setNoExport: vi.fn(),
     };
     render(<AssetBrowser path="/proj" />);
-    const a = await screen.findByText('a.txt');
-    const b = screen.getByText('b.png');
+    const a = (await screen.findAllByText('a.txt'))[0];
+    const b = screen.getAllByText('b.png')[0];
     fireEvent.click(a);
     fireEvent.click(b, { ctrlKey: true });
     const wrapper = screen.getByTestId('asset-browser');
@@ -209,8 +209,8 @@ describe('AssetBrowser', () => {
       onFileRenamed,
     };
     render(<AssetBrowser path="/proj" />);
-    const a = await screen.findByText('a.txt');
-    const b = screen.getByText('b.png');
+    const a = (await screen.findAllByText('a.txt'))[0];
+    const b = screen.getAllByText('b.png')[0];
     fireEvent.click(a);
     fireEvent.click(b, { ctrlKey: true });
     fireEvent.contextMenu(a);
@@ -244,20 +244,20 @@ describe('AssetBrowser', () => {
       onFileRenamed,
     };
     render(<AssetBrowser path="/proj" />);
-    const el = await screen.findByText('a.txt');
+    const el = (await screen.findAllByText('a.txt'))[0];
     const container = el.closest('div[tabindex="0"]') as HTMLElement;
     expect(container.className).toMatch(/border-gray-400/);
-    const inner = container.querySelector('div') as HTMLElement;
+    const inner = container.querySelector('figure') as HTMLElement;
     expect(inner.className).toMatch(/opacity-50/);
   });
 
   it('filters by search and adjusts zoom', async () => {
     render(<AssetBrowser path="/proj" />);
-    await screen.findByText('a.txt');
+    await screen.findAllByText('a.txt');
     const search = screen.getByPlaceholderText('Search files');
     fireEvent.change(search, { target: { value: 'b.png' } });
     expect(screen.queryByText('a.txt')).toBeNull();
-    expect(screen.getByText('b.png')).toBeInTheDocument();
+    expect(screen.getAllByText('b.png')[0]).toBeInTheDocument();
     const slider = screen.getByLabelText('Zoom');
     const img = screen.getByAltText('B') as HTMLImageElement;
     expect(img.style.width).toBe('64px');
@@ -271,18 +271,18 @@ describe('AssetBrowser', () => {
       'assets/minecraft/textures/item/apple.png',
     ]);
     render(<AssetBrowser path="/proj" />);
-    await screen.findByText('stone.png');
+    await screen.findAllByText('stone.png');
     const itemsChip = screen.getByText('Items');
     fireEvent.click(itemsChip);
     expect(screen.queryByText('stone.png')).toBeNull();
-    expect(screen.getByText('apple.png')).toBeInTheDocument();
+    expect(screen.getAllByText('apple.png')[0]).toBeInTheDocument();
   });
 
   it('shows tree view', async () => {
     render(<AssetBrowser path="/proj" />);
-    await screen.findByText('a.txt');
+    await screen.findAllByText('a.txt');
     fireEvent.click(screen.getByText('Tree'));
     expect(screen.getByTestId('file-tree')).toBeInTheDocument();
-    expect(screen.getByText('a.txt')).toBeInTheDocument();
+    expect(screen.getAllByText('a.txt')[0]).toBeInTheDocument();
   });
 });

--- a/__tests__/AssetBrowserItem.test.tsx
+++ b/__tests__/AssetBrowserItem.test.tsx
@@ -39,7 +39,7 @@ describe('AssetBrowserItem', () => {
         zoom={64}
       />
     );
-    const item = screen.getByText('a.txt');
+    const item = screen.getAllByText('a.txt')[0];
     fireEvent.contextMenu(item);
     fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
     expect(openInFolder).toHaveBeenCalledWith(path.join('/proj', 'a.txt'));
@@ -70,7 +70,7 @@ describe('AssetBrowserItem', () => {
         zoom={64}
       />
     );
-    const item = screen.getByText('a.txt');
+    const item = screen.getAllByText('a.txt')[0];
     fireEvent.contextMenu(item);
     const toggle = screen.getByRole('checkbox', { name: /No Export/i });
     fireEvent.click(toggle);
@@ -91,7 +91,7 @@ describe('AssetBrowserItem', () => {
         zoom={64}
       />
     );
-    const item = screen.getByText('a.txt');
+    const item = screen.getAllByText('a.txt')[0];
     const container = item.closest('div[tabindex="0"]') as HTMLElement;
     fireEvent.contextMenu(container);
     const menu = screen.getByRole('menu');
@@ -114,7 +114,7 @@ describe('AssetBrowserItem', () => {
         zoom={64}
       />
     );
-    const item = screen.getByText('a.txt');
+    const item = screen.getAllByText('a.txt')[0];
     fireEvent.contextMenu(item);
     const menu = screen.getByRole('menu');
     expect(menu.className).not.toMatch('opacity-50');

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -102,7 +102,7 @@ describe('EditorView', () => {
 
   it('opens asset selector modal', () => {
     render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Add Assets' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add From Vanilla' }));
     expect(screen.getByTestId('asset-selector-modal')).toBeInTheDocument();
   });
 });

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -83,7 +83,7 @@ const AssetBrowserItem: React.FC<Props> = ({
 
   return (
     <div
-      className={`p-1 cursor-pointer hover:ring ring-accent relative text-center tooltip ${
+      className={`card card-compact cursor-pointer hover:ring ring-accent relative text-center tooltip ${
         isSelected ? 'ring' : ''
       } ${noExport.has(file) ? 'border border-gray-400' : ''}`}
       data-tip={`${formatted} \n${name}`}
@@ -98,23 +98,17 @@ const AssetBrowserItem: React.FC<Props> = ({
         }
       }}
     >
-      <div className={noExport.has(file) ? 'opacity-50' : ''}>
+      <figure className={noExport.has(file) ? 'opacity-50' : ''}>
         {thumb ? (
-          <>
-            <img
-              src={thumb}
-              alt={formatted}
-              style={{
-                width: zoom,
-                height: zoom,
-                imageRendering: 'pixelated',
-              }}
-            />
-            <div className="text-xs leading-tight mt-1">
-              <div>{formatted}</div>
-              <div className="opacity-50">{name}</div>
-            </div>
-          </>
+          <img
+            src={thumb}
+            alt={formatted}
+            style={{
+              width: zoom,
+              height: zoom,
+              imageRendering: 'pixelated',
+            }}
+          />
         ) : (
           <div
             style={{ width: zoom, height: zoom }}
@@ -123,6 +117,16 @@ const AssetBrowserItem: React.FC<Props> = ({
             {name}
           </div>
         )}
+      </figure>
+      <div className="card-body p-1">
+        <div className="text-xs leading-tight">
+          <div className="truncate" style={{ width: zoom }}>
+            {formatted}
+          </div>
+          <div className="opacity-50 truncate" style={{ width: zoom }}>
+            {name}
+          </div>
+        </div>
       </div>
       <AssetContextMenu
         filePath={full}


### PR DESCRIPTION
## Summary
- restyle `AssetBrowserItem` as a daisyUI card
- adjust related tests for new markup

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684edf8c40288331af79dd6295d52450