### PR TITLE
Implement external editor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ An Electron-based tool for creating Minecraft resource packs. The interface is d
 - **Live Asset Browser** – the Editor view lists all files in the project directory and automatically reloads when something changes.
 - **Random pack icon** – new packs start with a pastel background and random item image; you can regenerate from pack settings.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.
+- **External Editing** – configure your favourite image editor in **Settings** and launch it from the asset info panel.
 
 ## Development
 
@@ -57,3 +58,9 @@ This project uses **Tailwind CSS** with the
 Texture filenames are displayed in a friendlier form by removing the path and
 extension, replacing underscores with spaces and capitalising each word. The
 original filename is still shown alongside the formatted name and in tooltips.
+
+### External Editor
+
+Specify the path to your preferred image editor under **Settings**. PNG textures
+can then be opened directly from the asset info panel using the **Edit
+Externally** button.

--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 ## 5. Editor > Texture Inspector
 
 - [x] 1 : 1 pixel preview + zoom slider
-- [ ] External edit button (auto‑reload on save)
+- [x] External edit button (auto‑reload on save)
 - [x] Sharp mini‑lab: Hue‑shift • Rotate 90° • Gray‑scale • ±Saturation • ±Brightness
 - [ ] Revision history (max 20)
 

--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -7,14 +7,23 @@ import path from 'path';
 describe('AssetInfo', () => {
   const readFile = vi.fn();
   const writeFile = vi.fn();
+  const openExternalEditor = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     (
       window as unknown as {
-        electronAPI: { readFile: typeof readFile; writeFile: typeof writeFile };
+        electronAPI: {
+          readFile: typeof readFile;
+          writeFile: typeof writeFile;
+          openExternalEditor: typeof openExternalEditor;
+        };
       }
-    ).electronAPI = { readFile, writeFile } as never;
+    ).electronAPI = {
+      readFile,
+      writeFile,
+      openExternalEditor,
+    } as never;
     readFile.mockResolvedValue('');
     writeFile.mockResolvedValue(undefined);
   });
@@ -28,6 +37,13 @@ describe('AssetInfo', () => {
     render(<AssetInfo projectPath="/p" asset="foo.png" />);
     expect(screen.getByText('foo.png')).toBeInTheDocument();
     expect(await screen.findByTestId('preview-pane')).toBeInTheDocument();
+  });
+
+  it('opens external editor for png', async () => {
+    render(<AssetInfo projectPath="/p" asset="img.png" />);
+    const btn = await screen.findByRole('button', { name: 'Edit Externally' });
+    fireEvent.click(btn);
+    expect(openExternalEditor).toHaveBeenCalledWith(path.join('/p', 'img.png'));
   });
 
   it('edits a text file', async () => {

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -102,7 +102,7 @@ describe('EditorView', () => {
 
   it('opens asset selector modal', () => {
     render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Add Assets' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add From Vanilla' }));
     expect(screen.getByTestId('asset-selector-modal')).toBeInTheDocument();
   });
 });

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 
 import SettingsView from '../src/renderer/views/SettingsView';
 
 // eslint-disable-next-line no-var
 var openExternalMock: ReturnType<typeof vi.fn>;
+const getTextureEditor = vi.fn();
+const setTextureEditor = vi.fn();
 vi.mock('electron', () => ({
   shell: { openExternal: (openExternalMock = vi.fn()) },
 }));
@@ -13,6 +15,16 @@ vi.mock('electron', () => ({
 describe('SettingsView', () => {
   beforeEach(() => {
     openExternalMock.mockResolvedValue(undefined);
+    (
+      window as unknown as {
+        electronAPI: {
+          getTextureEditor: typeof getTextureEditor;
+          setTextureEditor: typeof setTextureEditor;
+        };
+      }
+    ).electronAPI = { getTextureEditor, setTextureEditor } as never;
+    getTextureEditor.mockResolvedValue('/usr/bin/gimp');
+    setTextureEditor.mockResolvedValue(undefined);
   });
 
   it('renders placeholder heading', () => {
@@ -30,5 +42,14 @@ describe('SettingsView', () => {
     expect(openExternalMock).toHaveBeenCalledWith(
       'https://minecraft.wiki/w/Options'
     );
+  });
+
+  it('loads and saves external editor path', async () => {
+    render(<SettingsView />);
+    const input = await screen.findByLabelText('External texture editor');
+    expect(input).toHaveValue('/usr/bin/gimp');
+    fireEvent.change(input, { target: { value: '/opt/editor' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
   });
 });

--- a/__tests__/externalEditorIPC.test.ts
+++ b/__tests__/externalEditorIPC.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Capture the IPC handler registered by registerExternalEditorHandlers
+// eslint-disable-next-line no-var
+var handler: ((e: unknown, file: string) => void | Promise<void>) | undefined;
+// eslint-disable-next-line no-var
+var spawnMock: ReturnType<typeof vi.fn>;
+
+vi.mock('child_process', () => {
+  spawnMock = vi.fn(() => ({ unref: vi.fn() }));
+  return { spawn: spawnMock, default: { spawn: spawnMock } };
+});
+
+vi.mock('../src/main/layout', () => ({
+  getTextureEditor: () => '/usr/bin/gimp',
+}));
+
+const ipcMainMock = {
+  handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+    if (channel === 'open-external-editor') handler = fn as typeof handler;
+  },
+};
+
+import { registerExternalEditorHandlers } from '../src/main/externalEditor';
+registerExternalEditorHandlers(
+  ipcMainMock as unknown as import('electron').IpcMain
+);
+
+describe('open-external-editor IPC', () => {
+  it('spawns configured editor with file path', async () => {
+    expect(handler).toBeTypeOf('function');
+    await handler?.({}, '/tmp/a.png');
+    expect(spawnMock).toHaveBeenCalledWith('/usr/bin/gimp', ['/tmp/a.png'], {
+      detached: true,
+      stdio: 'ignore',
+    });
+  });
+});

--- a/src/main/externalEditor.ts
+++ b/src/main/externalEditor.ts
@@ -1,0 +1,18 @@
+import { spawn } from 'child_process';
+import type { IpcMain } from 'electron';
+import { getTextureEditor } from './layout';
+
+export function openWithEditor(file: string): void {
+  const editor = getTextureEditor();
+  if (!editor) return;
+  spawn(editor, [file], {
+    detached: true,
+    stdio: 'ignore',
+  }).unref();
+}
+
+export function registerExternalEditorHandlers(ipc: IpcMain): void {
+  ipc.handle('open-external-editor', (_e, file: string) =>
+    openWithEditor(file)
+  );
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -19,6 +19,7 @@ import {
 } from './assets';
 import { registerTextureLabHandlers } from './textureLab';
 import { registerLayoutHandlers } from './layout';
+import { registerExternalEditorHandlers } from './externalEditor';
 
 protocol.registerSchemesAsPrivileged([
   { scheme: 'texture', privileges: { standard: true, secure: true } },
@@ -67,6 +68,7 @@ registerExportHandlers(ipcMain, projectsDir);
 registerNoExportHandlers(ipcMain);
 registerLayoutHandlers(ipcMain);
 registerTextureLabHandlers(ipcMain);
+registerExternalEditorHandlers(ipcMain);
 
 // Register file-related IPC handlers
 registerFileHandlers(ipcMain);

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -1,8 +1,8 @@
 import type { IpcMain } from 'electron';
 import Store from 'electron-store';
 
-const store = new Store<{ editorLayout: number[] }>({
-  defaults: { editorLayout: [20, 80] },
+const store = new Store<{ editorLayout: number[]; textureEditor: string }>({
+  defaults: { editorLayout: [20, 80], textureEditor: '' },
 });
 
 export function getEditorLayout(): number[] {
@@ -13,9 +13,19 @@ export function setEditorLayout(layout: number[]): void {
   store.set('editorLayout', layout);
 }
 
+export function getTextureEditor(): string {
+  return store.get('textureEditor');
+}
+
+export function setTextureEditor(path: string): void {
+  store.set('textureEditor', path);
+}
+
 export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-editor-layout', () => getEditorLayout());
   ipc.handle('set-editor-layout', (_e, layout: number[]) =>
     setEditorLayout(layout)
   );
+  ipc.handle('get-texture-editor', () => getTextureEditor());
+  ipc.handle('set-texture-editor', (_e, p: string) => setTextureEditor(p));
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,6 +46,7 @@ const api = {
   randomizeIcon: (project: string) => invoke('randomize-icon', project),
   openInFolder: (file: string) => invoke('open-in-folder', file),
   openFile: (file: string) => invoke('open-file', file),
+  openExternalEditor: (file: string) => invoke('open-external-editor', file),
   readFile: (file: string) => invoke('read-file', file),
   writeFile: (file: string, data: string) => invoke('write-file', file, data),
   renameFile: (oldPath: string, newPath: string) =>
@@ -62,6 +63,8 @@ const api = {
     invoke('set-no-export', project, files, flag),
   getEditorLayout: () => invoke('get-editor-layout'),
   setEditorLayout: (layout: number[]) => invoke('set-editor-layout', layout),
+  getTextureEditor: () => invoke('get-texture-editor'),
+  setTextureEditor: (path: string) => invoke('set-texture-editor', path),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -25,12 +25,17 @@ export default function App() {
     setView('manager');
   };
 
+  const toSettings = () => {
+    setProjectPath(null);
+    setView('settings');
+  }
+
   let content: React.ReactNode = null;
   switch (view) {
     case 'editor':
       content = projectPath ? (
         <Suspense fallback={<Spinner />}>
-          <EditorView projectPath={projectPath} onBack={toManager} />
+          <EditorView projectPath={projectPath} onBack={toManager} onSettings={toSettings} />
         </Suspense>
       ) : null;
       break;

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -98,12 +98,20 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
           </>
         )}
         {isPng && count === 1 && (
-          <button
-            className="btn btn-secondary btn-sm mt-2"
-            onClick={() => setLab(true)}
-          >
-            Open Texture Lab
-          </button>
+          <div className="flex flex-col gap-2 mt-2">
+            <button
+              className="btn btn-secondary btn-sm"
+              onClick={() => setLab(true)}
+            >
+              Open Texture Lab
+            </button>
+            <button
+              className="btn btn-secondary btn-sm"
+              onClick={() => window.electronAPI?.openExternalEditor(full)}
+            >
+              Edit Externally
+            </button>
+          </div>
         )}
         {lab && (
           <Suspense fallback={<Spinner />}>

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -6,12 +6,14 @@ interface Props {
   projectPath: string;
   onExport: () => void;
   onBack: () => void;
+  onSettings: () => void;
 }
 
 export default function ProjectInfoPanel({
   projectPath,
   onExport,
   onBack,
+  onSettings
 }: Props) {
   const [meta, setMeta] = useState<PackMeta | null>(null);
   const name = path.basename(projectPath);
@@ -25,6 +27,9 @@ export default function ProjectInfoPanel({
       <div className="card-body items-center gap-2 p-2">
         <button className="link link-primary self-start" onClick={onBack}>
           Back to Projects
+        </button>
+        <button className="link link-primary self-start" onClick={onSettings}>
+          Settings
         </button>
         <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
         <h2 className="card-title text-lg font-display">{name}</h2>

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -21,9 +21,10 @@ import {
 interface EditorViewProps {
   projectPath: string;
   onBack: () => void;
+  onSettings: () => void;
 }
 
-export default function EditorView({ projectPath, onBack }: EditorViewProps) {
+export default function EditorView({ projectPath, onBack, onSettings }: EditorViewProps) {
   const [selected, setSelected] = useState<string[]>([]);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
@@ -97,6 +98,7 @@ export default function EditorView({ projectPath, onBack }: EditorViewProps) {
             projectPath={projectPath}
             onExport={handleExport}
             onBack={onBack}
+            onSettings={onSettings}
           />
         </Panel>
         <PanelResizeHandle className="flex items-center" tagName="div">

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -1,7 +1,16 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import ExternalLink from '../components/ExternalLink';
 
 export default function SettingsView() {
+  const [editor, setEditor] = useState('');
+
+  useEffect(() => {
+    window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
+  }, []);
+
+  const saveEditor = () => {
+    window.electronAPI?.setTextureEditor(editor);
+  };
   return (
     <section className="p-4" data-testid="settings-view">
       <div className="flex items-center mb-2 gap-2">
@@ -14,7 +23,21 @@ export default function SettingsView() {
           ?
         </ExternalLink>
       </div>
-      <p>Coming soon...</p>
+      <div className="form-control max-w-md">
+        <label className="label" htmlFor="editor-path">
+          <span className="label-text">External texture editor</span>
+        </label>
+        <input
+          id="editor-path"
+          className="input input-bordered"
+          type="text"
+          value={editor}
+          onChange={(e) => setEditor(e.target.value)}
+        />
+        <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
+          Save
+        </button>
+      </div>
     </section>
   );
 }

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -43,6 +43,9 @@ declare global {
       setNoExport: IpcInvoke<'set-no-export'>;
       getEditorLayout: IpcInvoke<'get-editor-layout'>;
       setEditorLayout: IpcInvoke<'set-editor-layout'>;
+      getTextureEditor: IpcInvoke<'get-texture-editor'>;
+      setTextureEditor: IpcInvoke<'set-texture-editor'>;
+      openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;
       onFileRemoved: IpcListener<'file-removed'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -22,6 +22,7 @@ export interface IpcRequestMap {
   'export-projects': [string[]];
   'open-in-folder': [string];
   'open-file': [string];
+  'open-external-editor': [string];
   'read-file': [string];
   'write-file': [string, string];
   'rename-file': [string, string];
@@ -33,6 +34,8 @@ export interface IpcRequestMap {
   'set-no-export': [string, string[], boolean];
   'get-editor-layout': [];
   'set-editor-layout': [number[]];
+  'get-texture-editor': [];
+  'set-texture-editor': [string];
 }
 
 export interface IpcResponseMap {
@@ -54,6 +57,7 @@ export interface IpcResponseMap {
   'export-projects': void;
   'open-in-folder': void;
   'open-file': void;
+  'open-external-editor': void;
   'read-file': string;
   'write-file': void;
   'rename-file': void;
@@ -65,6 +69,8 @@ export interface IpcResponseMap {
   'set-no-export': void;
   'get-editor-layout': number[];
   'set-editor-layout': void;
+  'get-texture-editor': string;
+  'set-texture-editor': void;
 }
 
 export interface IpcEventMap {


### PR DESCRIPTION
## Summary
- add external editing support via new IPC and external editor settings
- show Edit Externally button in Asset Info
- allow configuration of editor path in Settings view
- document external editor configuration
- update tests
- check off TODO item

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ede776b648331a0e83aee7e8fdc0a