### PR TITLE
Add pack icon editor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -67,7 +67,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 - [ ] Editable `pack.mcmeta` (description, `pack_format`, language)
 - [x] Randomly generated pack icon (pastel bg + border + random Minecraft item texture Sharp)
-- [ ] Pack Icon Editor modal (randomise, colour, border, upload custom)
+- [x] Pack Icon Editor modal (randomise, colour, border, upload custom)
 - [ ] Target resolution radio (16×/32×/64×)
 - [ ] License & authors
 - [ ] Validation checklist (missing textures, duplicates)

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -102,7 +102,7 @@ describe('EditorView', () => {
 
   it('opens asset selector modal', () => {
     render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
-    fireEvent.click(screen.getByRole('button', { name: 'Add Assets' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add From Vanilla' }));
     expect(screen.getByTestId('asset-selector-modal')).toBeInTheDocument();
   });
 });

--- a/__tests__/PackIconEditor.test.tsx
+++ b/__tests__/PackIconEditor.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PackIconEditor from '../src/renderer/components/PackIconEditor';
+
+describe('PackIconEditor', () => {
+  it('randomises icon on button click', () => {
+    const randomise = vi.fn();
+    (
+      window as unknown as {
+        electronAPI: {
+          randomizeIcon: typeof randomise;
+          savePackIcon: () => Promise<void>;
+        };
+      }
+    ).electronAPI = {
+      randomizeIcon: randomise,
+      savePackIcon: vi.fn(),
+    } as never;
+    render(<PackIconEditor project="/tmp/proj" onClose={() => undefined} />);
+    fireEvent.click(screen.getByText('Randomise'));
+    expect(randomise).toHaveBeenCalledWith('/tmp/proj');
+  });
+
+  it('saves uploaded file with border colour', () => {
+    const save = vi.fn().mockResolvedValue(undefined);
+    (
+      window as unknown as {
+        electronAPI: { randomizeIcon: () => void; savePackIcon: typeof save };
+      }
+    ).electronAPI = {
+      randomizeIcon: vi.fn(),
+      savePackIcon: save,
+    } as never;
+    render(<PackIconEditor project="/tmp/proj" onClose={() => undefined} />);
+    const file = new File(['a'], 'icon.png', { type: 'image/png' });
+    Object.defineProperty(file, 'path', { value: '/tmp/icon.png' });
+    fireEvent.change(screen.getByTestId('file-input'), {
+      target: { files: [file] },
+    });
+    fireEvent.change(screen.getByTestId('border-input'), {
+      target: { value: '#ff00ff' },
+    });
+    const form = screen
+      .getByTestId('file-input')
+      .closest('form') as HTMLFormElement;
+    fireEvent.submit(form);
+    expect(save).toHaveBeenCalledWith('/tmp/proj', '/tmp/icon.png', '#ff00ff');
+  });
+});

--- a/__tests__/packIconIPC.test.ts
+++ b/__tests__/packIconIPC.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import sharp from 'sharp';
+import { registerIconHandlers } from '../src/main/icon';
+
+let handler:
+  | ((
+      e: unknown,
+      project: string,
+      file: string,
+      border: string
+    ) => Promise<void>)
+  | undefined;
+const ipcMock = {
+  handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+    if (channel === 'save-pack-icon') handler = fn as typeof handler;
+  },
+};
+
+describe('save-pack-icon IPC', () => {
+  it('writes 128x128 png', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'icon-test-'));
+    const img = path.join(tmp, 'in.png');
+    await sharp({
+      create: { width: 16, height: 16, channels: 4, background: '#f00' },
+    })
+      .png()
+      .toFile(img);
+    const proj = path.join(tmp, 'proj');
+    fs.mkdirSync(proj);
+    registerIconHandlers(ipcMock as unknown as import('electron').IpcMain);
+    expect(handler).toBeTypeOf('function');
+    await handler?.({}, proj, img, '#00ff00');
+    const meta = await sharp(path.join(proj, 'pack.png')).metadata();
+    expect(meta.width).toBe(128);
+    expect(meta.height).toBe(128);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -133,6 +133,10 @@ It exposes hue shift, rotation, grayscale, saturation and brightness controls.
 Edits are processed in the main process via Sharp and the modal shows a spinner
 while the file is being updated.
 
+The **Pack Icon Editor** modal customises `pack.png` for a project. You can
+randomise the item and background, choose a border colour or upload a custom PNG.
+The image is processed with Sharp in the main process and saved at 128×128.
+
 ## Windows Paths
 
 When writing tests or other code that constructs file system paths, prefer

--- a/src/main/icon.ts
+++ b/src/main/icon.ts
@@ -39,3 +39,29 @@ export async function generatePackIcon(projectPath: string): Promise<void> {
     .composite([{ input: itemBuf, gravity: 'center' }])
     .toFile(path.join(projectPath, 'pack.png'));
 }
+
+/** Save a custom icon file to `projectPath/pack.png` with a coloured border. */
+export async function savePackIcon(
+  projectPath: string,
+  file: string,
+  border: string
+): Promise<void> {
+  const inner = await sharp(file)
+    .resize(120, 120, { fit: 'contain' })
+    .png()
+    .toBuffer();
+  await sharp({
+    create: { width: 128, height: 128, channels: 4, background: border },
+  })
+    .composite([{ input: inner, top: 4, left: 4 }])
+    .png()
+    .toFile(path.join(projectPath, 'pack.png'));
+}
+
+export function registerIconHandlers(ipc: import('electron').IpcMain): void {
+  ipc.handle(
+    'save-pack-icon',
+    (_e, project: string, file: string, border: string) =>
+      savePackIcon(project, file, border)
+  );
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -17,6 +17,7 @@ import {
   registerTextureProtocol,
   registerProjectTextureProtocol,
 } from './assets';
+import { registerIconHandlers } from './icon';
 import { registerTextureLabHandlers } from './textureLab';
 import { registerLayoutHandlers } from './layout';
 
@@ -67,6 +68,7 @@ registerExportHandlers(ipcMain, projectsDir);
 registerNoExportHandlers(ipcMain);
 registerLayoutHandlers(ipcMain);
 registerTextureLabHandlers(ipcMain);
+registerIconHandlers(ipcMain);
 
 // Register file-related IPC handlers
 registerFileHandlers(ipcMain);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -44,6 +44,8 @@ const api = {
   getTextureUrl: (project: string, name: string) =>
     invoke('get-texture-url', project, name),
   randomizeIcon: (project: string) => invoke('randomize-icon', project),
+  savePackIcon: (project: string, file: string, border: string) =>
+    invoke('save-pack-icon', project, file, border),
   openInFolder: (file: string) => invoke('open-in-folder', file),
   openFile: (file: string) => invoke('open-file', file),
   readFile: (file: string) => invoke('read-file', file),

--- a/src/renderer/components/PackIconEditor.tsx
+++ b/src/renderer/components/PackIconEditor.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import path from 'path';
+
+export default function PackIconEditor({
+  project,
+  onClose,
+}: {
+  project: string;
+  onClose: () => void;
+}) {
+  const [border, setBorder] = useState('#000000');
+  const [file, setFile] = useState<File | null>(null);
+
+  const save = (e: React.FormEvent) => {
+    e.preventDefault();
+    const src =
+      (file as unknown as { path: string } | null)?.path ||
+      path.join(project, 'pack.png');
+    window.electronAPI?.savePackIcon(project, src, border).then(onClose);
+  };
+
+  return (
+    <dialog className="modal modal-open" data-testid="icon-editor">
+      <form className="modal-box flex flex-col gap-2" onSubmit={save}>
+        <h3 className="font-bold text-lg">Pack Icon</h3>
+        <label className="flex items-center gap-2">
+          Border
+          <input
+            type="color"
+            value={border}
+            data-testid="border-input"
+            onChange={(e) => setBorder(e.target.value)}
+          />
+        </label>
+        <input
+          type="file"
+          accept="image/png"
+          data-testid="file-input"
+          onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+        />
+        <div className="modal-action">
+          <button
+            type="button"
+            className="btn"
+            onClick={() => window.electronAPI?.randomizeIcon(project)}
+          >
+            Randomise
+          </button>
+          <button type="button" className="btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button type="submit" className="btn btn-primary">
+            Save
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -28,6 +28,7 @@ declare global {
       getTexturePath: IpcInvoke<'get-texture-path'>;
       getTextureUrl: IpcInvoke<'get-texture-url'>;
       randomizeIcon: IpcInvoke<'randomize-icon'>;
+      savePackIcon: IpcInvoke<'save-pack-icon'>;
       exportProject: IpcInvoke<'export-project'>;
       exportProjects: IpcInvoke<'export-projects'>;
       openInFolder: IpcInvoke<'open-in-folder'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -18,6 +18,7 @@ export interface IpcRequestMap {
   'get-texture-path': [string, string];
   'get-texture-url': [string, string];
   'randomize-icon': [string];
+  'save-pack-icon': [string, string, string];
   'export-project': [string];
   'export-projects': [string[]];
   'open-in-folder': [string];
@@ -50,6 +51,7 @@ export interface IpcResponseMap {
   'get-texture-path': string;
   'get-texture-url': string;
   'randomize-icon': void;
+  'save-pack-icon': void;
   'export-project': ExportSummary | void;
   'export-projects': void;
   'open-in-folder': void;


### PR DESCRIPTION
## Summary
- implement `savePackIcon` IPC handler and registration
- expose `savePackIcon` via preload
- add PackIconEditor component
- test IPC workflow and UI logic
- document pack icon editor
- tick TODO list
- fix EditorView test label

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684edebac8a88331895271139ef80657