### PR TITLE
Standardize texture thumbnails

### DIFF
--- a/__tests__/TextureThumb.test.tsx
+++ b/__tests__/TextureThumb.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TextureThumb from '../src/renderer/components/TextureThumb';
+
+describe('TextureThumb', () => {
+  it('renders image with default protocol', () => {
+    render(<TextureThumb texture="foo.png" />);
+    const img = screen.getByRole('img');
+    expect(img.getAttribute('src')).toBe('ptex://foo.png');
+  });
+
+  it('supports custom protocol', () => {
+    render(<TextureThumb texture="foo.png" protocol="texture" simplified />);
+    const img = screen.getByRole('img');
+    expect(img.getAttribute('src')).toBe('texture://foo.png');
+  });
+
+  it('applies simplified mode size', () => {
+    render(<TextureThumb texture="foo.png" simplified size={32} />);
+    const img = screen.getByRole('img') as HTMLImageElement;
+    expect(img.style.width).toBe('32px');
+  });
+});

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import path from 'path';
 import { formatTextureName } from '../utils/textureNames';
 import AssetContextMenu from './file/AssetContextMenu';
+import TextureThumb from './TextureThumb';
 
 interface Props {
   projectPath: string;
@@ -38,11 +39,8 @@ const AssetBrowserItem: React.FC<Props> = ({
   const full = path.join(projectPath, file);
   const name = path.basename(file);
   const formatted = file.endsWith('.png') ? formatTextureName(name) : name;
-  let thumb: string | null = null;
-  if (file.endsWith('.png')) {
-    const rel = file.split(path.sep).join('/');
-    thumb = `ptex://${rel}`;
-  }
+  const texPath = file.endsWith('.png') ? file : null;
+  const altText = texPath ? formatted : name;
 
   const isSelected = selected.has(file);
 
@@ -99,24 +97,7 @@ const AssetBrowserItem: React.FC<Props> = ({
       }}
     >
       <figure className={noExport.has(file) ? 'opacity-50' : ''}>
-        {thumb ? (
-          <img
-            src={thumb}
-            alt={formatted}
-            style={{
-              width: zoom,
-              height: zoom,
-              imageRendering: 'pixelated',
-            }}
-          />
-        ) : (
-          <div
-            style={{ width: zoom, height: zoom }}
-            className="bg-base-300 flex items-center justify-center"
-          >
-            {name}
-          </div>
-        )}
+        <TextureThumb texture={texPath} alt={altText} size={zoom} simplified />
       </figure>
       <div className="card-body p-1">
         <div className="text-xs leading-tight">

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import TextureThumb from './TextureThumb';
 
 interface Props {
   projectPath: string;
@@ -9,12 +10,7 @@ export default function AssetSelectorInfoPanel({ projectPath, asset }: Props) {
   if (!asset) return <div className="p-2">No asset selected</div>;
   return (
     <div className="p-2" data-testid="selector-info">
-      <img
-        src={`texture://${asset}`}
-        alt={asset}
-        className="w-16 h-16 mb-2"
-        style={{ imageRendering: 'pixelated' }}
-      />
+      <TextureThumb texture={asset} protocol="texture" alt={asset} size={64} />
       <p className="break-all text-sm">{asset}</p>
       <button
         className="btn btn-primary btn-sm mt-2"

--- a/src/renderer/components/TextureThumb.tsx
+++ b/src/renderer/components/TextureThumb.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import path from 'path';
+
+interface Props {
+  /** Relative texture path or null when no image */
+  texture: string | null;
+  /** Accessible label, defaults to texture name */
+  alt?: string;
+  /** Size in pixels */
+  size?: number;
+  /** Protocol prefix for the texture URL */
+  protocol?: 'ptex' | 'texture';
+  /** Use simplified markup without border wrapper */
+  simplified?: boolean;
+}
+
+export default function TextureThumb({
+  texture,
+  alt,
+  size = 64,
+  protocol = 'ptex',
+  simplified = false,
+}: Props) {
+  const url =
+    texture && texture.endsWith('.png')
+      ? `${protocol}://${texture.split(path.sep).join('/')}`
+      : null;
+
+  const content = url ? (
+    <img
+      src={url}
+      alt={alt ?? texture ?? ''}
+      style={{ width: size, height: size, imageRendering: 'pixelated' }}
+      data-testid={simplified ? 'texture-thumb' : undefined}
+    />
+  ) : (
+    <div
+      data-testid={simplified ? 'texture-thumb' : undefined}
+      style={{ width: size, height: size }}
+      className="bg-base-300 flex items-center justify-center text-xs"
+    >
+      {alt ?? 'No preview'}
+    </div>
+  );
+
+  if (simplified) return content;
+
+  return (
+    <div
+      data-testid="texture-thumb"
+      style={{ width: size, height: size }}
+      className="border p-2 flex items-center justify-center bg-gray-200"
+    >
+      {content}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable `TextureThumb` component for showing textures
- use `TextureThumb` in the asset browser and asset selector info panel
- add minimal tests for `TextureThumb`

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eefb183f48331aa40b55d8297b358