### PR TITLE
Add confetti toggle

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -67,6 +67,7 @@ describe('App', () => {
       getEditorLayout: () => Promise<number[]>;
       setEditorLayout: (l: number[]) => void;
       loadPackMeta: () => Promise<unknown>;
+      getConfettiEnabled: () => Promise<boolean>;
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       onOpenProject: (cb) => {
@@ -76,6 +77,7 @@ describe('App', () => {
       getEditorLayout: vi.fn(async () => [20, 40, 40]),
       setEditorLayout: vi.fn(),
       loadPackMeta: vi.fn(async () => ({ description: '' })),
+      getConfettiEnabled: vi.fn(async () => true),
     };
   });
 

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -59,11 +59,13 @@ describe('EditorView', () => {
       exportProject: (path: string) => Promise<typeof summary>;
       getEditorLayout: () => Promise<number[]>;
       setEditorLayout: (l: number[]) => void;
+      getConfettiEnabled: () => Promise<boolean>;
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       exportProject,
       getEditorLayout: getLayout,
       setEditorLayout: setLayout,
+      getConfettiEnabled: vi.fn(async () => true),
     };
     exportProject.mockResolvedValue(summary);
     openExternalMock.mockResolvedValue(undefined);

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -8,6 +8,8 @@ import SettingsView from '../src/renderer/views/SettingsView';
 var openExternalMock: ReturnType<typeof vi.fn>;
 const getTextureEditor = vi.fn();
 const setTextureEditor = vi.fn();
+const getConfettiEnabled = vi.fn();
+const setConfettiEnabled = vi.fn();
 vi.mock('electron', () => ({
   shell: { openExternal: (openExternalMock = vi.fn()) },
 }));
@@ -20,11 +22,20 @@ describe('SettingsView', () => {
         electronAPI: {
           getTextureEditor: typeof getTextureEditor;
           setTextureEditor: typeof setTextureEditor;
+          getConfettiEnabled: typeof getConfettiEnabled;
+          setConfettiEnabled: typeof setConfettiEnabled;
         };
       }
-    ).electronAPI = { getTextureEditor, setTextureEditor } as never;
+    ).electronAPI = {
+      getTextureEditor,
+      setTextureEditor,
+      getConfettiEnabled,
+      setConfettiEnabled,
+    } as never;
     getTextureEditor.mockResolvedValue('/usr/bin/gimp');
     setTextureEditor.mockResolvedValue(undefined);
+    getConfettiEnabled.mockResolvedValue(true);
+    setConfettiEnabled.mockResolvedValue(undefined);
   });
 
   it('renders placeholder heading', () => {
@@ -51,5 +62,13 @@ describe('SettingsView', () => {
     fireEvent.change(input, { target: { value: '/opt/editor' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
+  });
+
+  it('toggles confetti setting', async () => {
+    render(<SettingsView />);
+    const toggle = await screen.findByLabelText('Show confetti on export');
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(setConfettiEnabled).toHaveBeenCalledWith(false);
   });
 });

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -1,8 +1,16 @@
 import type { IpcMain } from 'electron';
 import Store from 'electron-store';
 
-const store = new Store<{ editorLayout: number[]; textureEditor: string }>({
-  defaults: { editorLayout: [20, 80], textureEditor: '' },
+const store = new Store<{
+  editorLayout: number[];
+  textureEditor: string;
+  confettiEnabled: boolean;
+}>({
+  defaults: {
+    editorLayout: [20, 80],
+    textureEditor: '',
+    confettiEnabled: true,
+  },
 });
 
 export function getEditorLayout(): number[] {
@@ -21,6 +29,14 @@ export function setTextureEditor(path: string): void {
   store.set('textureEditor', path);
 }
 
+export function getConfettiEnabled(): boolean {
+  return store.get('confettiEnabled');
+}
+
+export function setConfettiEnabled(flag: boolean): void {
+  store.set('confettiEnabled', flag);
+}
+
 export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-editor-layout', () => getEditorLayout());
   ipc.handle('set-editor-layout', (_e, layout: number[]) =>
@@ -28,4 +44,8 @@ export function registerLayoutHandlers(ipc: IpcMain): void {
   );
   ipc.handle('get-texture-editor', () => getTextureEditor());
   ipc.handle('set-texture-editor', (_e, p: string) => setTextureEditor(p));
+  ipc.handle('get-confetti-enabled', () => getConfettiEnabled());
+  ipc.handle('set-confetti-enabled', (_e, flag: boolean) =>
+    setConfettiEnabled(flag)
+  );
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -67,6 +67,8 @@ const api = {
   setEditorLayout: (layout: number[]) => invoke('set-editor-layout', layout),
   getTextureEditor: () => invoke('get-texture-editor'),
   setTextureEditor: (path: string) => invoke('set-texture-editor', path),
+  getConfettiEnabled: () => invoke('get-confetti-enabled'),
+  setConfettiEnabled: (flag: boolean) => invoke('set-confetti-enabled', flag),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -24,12 +24,17 @@ interface EditorViewProps {
   onSettings: () => void;
 }
 
-export default function EditorView({ projectPath, onBack, onSettings }: EditorViewProps) {
+export default function EditorView({
+  projectPath,
+  onBack,
+  onSettings,
+}: EditorViewProps) {
   const [selected, setSelected] = useState<string[]>([]);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
   const [summary, setSummary] = useState<ExportSummary | null>(null);
   const [selectorOpen, setSelectorOpen] = useState(false);
+  const [confettiEnabled, setConfettiEnabled] = useState(true);
   const confetti = useRef<((opts: unknown) => void) | null>(null);
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
 
@@ -40,6 +45,7 @@ export default function EditorView({ projectPath, onBack, onSettings }: EditorVi
         else if (l.length === 3) setLayout([l[0], l[1] + l[2]]);
       }
     });
+    window.electronAPI?.getConfettiEnabled().then((v) => setConfettiEnabled(v));
   }, []);
 
   const handleExport = () => {
@@ -47,7 +53,10 @@ export default function EditorView({ projectPath, onBack, onSettings }: EditorVi
       ?.exportProject(projectPath)
       .then((s) => {
         if (s) setSummary(s);
-        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        if (
+          confettiEnabled &&
+          !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ) {
           confetti.current?.({
             particleCount: 150,
             spread: 70,

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -3,9 +3,11 @@ import ExternalLink from '../components/ExternalLink';
 
 export default function SettingsView() {
   const [editor, setEditor] = useState('');
+  const [confettiEnabled, setConfettiEnabled] = useState(true);
 
   useEffect(() => {
     window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
+    window.electronAPI?.getConfettiEnabled().then((v) => setConfettiEnabled(v));
   }, []);
 
   const saveEditor = () => {
@@ -37,6 +39,22 @@ export default function SettingsView() {
         <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
           Save
         </button>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="label cursor-pointer" htmlFor="confetti-toggle">
+          <span className="label-text">Show confetti on export</span>
+          <input
+            id="confetti-toggle"
+            type="checkbox"
+            className="toggle"
+            checked={confettiEnabled}
+            onChange={(e) => {
+              const flag = e.target.checked;
+              setConfettiEnabled(flag);
+              window.electronAPI?.setConfettiEnabled(flag);
+            }}
+          />
+        </label>
       </div>
     </section>
   );

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -46,6 +46,8 @@ declare global {
       setEditorLayout: IpcInvoke<'set-editor-layout'>;
       getTextureEditor: IpcInvoke<'get-texture-editor'>;
       setTextureEditor: IpcInvoke<'set-texture-editor'>;
+      getConfettiEnabled: IpcInvoke<'get-confetti-enabled'>;
+      setConfettiEnabled: IpcInvoke<'set-confetti-enabled'>;
       openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -37,6 +37,8 @@ export interface IpcRequestMap {
   'set-editor-layout': [number[]];
   'get-texture-editor': [];
   'set-texture-editor': [string];
+  'get-confetti-enabled': [];
+  'set-confetti-enabled': [boolean];
 }
 
 export interface IpcResponseMap {
@@ -73,6 +75,8 @@ export interface IpcResponseMap {
   'set-editor-layout': void;
   'get-texture-editor': string;
   'set-texture-editor': void;
+  'get-confetti-enabled': boolean;
+  'set-confetti-enabled': void;
 }
 
 export interface IpcEventMap {


### PR DESCRIPTION
## Summary
- persist `confettiEnabled` in settings store
- expose IPC methods to read/write that flag
- respect the value when firing confetti
- allow users to toggle the flag in settings
- update unit tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef074006c83318a2725fdae2ad8e0