### PR TITLE
Add daisyUI action components

### DIFF
--- a/__tests__/daisy/actions/Button.test.tsx
+++ b/__tests__/daisy/actions/Button.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Button from '../../../src/renderer/components/daisy/actions/Button';
+describe('daisy Button', () => {
+  it('renders button', () => {
+    render(<Button>Click</Button>);
+    expect(screen.getByTestId('daisy-button')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/actions/Dropdown.test.tsx
+++ b/__tests__/daisy/actions/Dropdown.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Dropdown from '../../../src/renderer/components/daisy/actions/Dropdown';
+
+describe('daisy Dropdown', () => {
+  it('renders dropdown', () => {
+    render(
+      <Dropdown label="Menu">
+        <li>Item</li>
+      </Dropdown>
+    );
+    expect(screen.getByTestId('daisy-dropdown')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/actions/Modal.test.tsx
+++ b/__tests__/daisy/actions/Modal.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Modal from '../../../src/renderer/components/daisy/actions/Modal';
+
+describe('daisy Modal', () => {
+  it('renders modal when open', () => {
+    render(
+      <Modal open>
+        <p>Content</p>
+      </Modal>
+    );
+    expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/actions/Swap.test.tsx
+++ b/__tests__/daisy/actions/Swap.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Swap from '../../../src/renderer/components/daisy/actions/Swap';
+
+describe('daisy Swap', () => {
+  it('renders swap', () => {
+    render(<Swap onContent="On" offContent="Off" />);
+    expect(screen.getByTestId('daisy-swap')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/actions/ThemeController.test.tsx
+++ b/__tests__/daisy/actions/ThemeController.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ThemeController from '../../../src/renderer/components/daisy/actions/ThemeController';
+
+describe('daisy ThemeController', () => {
+  it('renders select', () => {
+    render(<ThemeController />);
+    expect(screen.getByTestId('theme-controller')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/daisy/actions/Button.tsx
+++ b/src/renderer/components/daisy/actions/Button.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Button({
+  children,
+  className = '',
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      className={`btn ${className}`.trim()}
+      {...rest}
+      data-testid="daisy-button"
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/renderer/components/daisy/actions/Dropdown.tsx
+++ b/src/renderer/components/daisy/actions/Dropdown.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface DropdownProps {
+  label: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Dropdown({
+  label,
+  children,
+  className = '',
+}: DropdownProps) {
+  return (
+    <div
+      className={`dropdown ${className}`.trim()}
+      data-testid="daisy-dropdown"
+    >
+      <div tabIndex={0} role="button" className="btn m-1">
+        {label}
+      </div>
+      <ul
+        tabIndex={0}
+        className="dropdown-content menu p-2 shadow bg-base-100 rounded-box w-52"
+      >
+        {children}
+      </ul>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/actions/Modal.tsx
+++ b/src/renderer/components/daisy/actions/Modal.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+interface ModalProps {
+  open?: boolean;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Modal({
+  open = false,
+  children,
+  className = '',
+}: ModalProps) {
+  if (!open) return null;
+  return (
+    <dialog className="modal modal-open" data-testid="daisy-modal">
+      <div className={`modal-box ${className}`.trim()}>{children}</div>
+    </dialog>
+  );
+}

--- a/src/renderer/components/daisy/actions/Swap.tsx
+++ b/src/renderer/components/daisy/actions/Swap.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface SwapProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onContent: React.ReactNode;
+  offContent: React.ReactNode;
+  className?: string;
+}
+
+export default function Swap({
+  onContent,
+  offContent,
+  className = '',
+  ...rest
+}: SwapProps) {
+  return (
+    <label className={`swap ${className}`.trim()} data-testid="daisy-swap">
+      <input type="checkbox" {...rest} />
+      <div className="swap-on">{onContent}</div>
+      <div className="swap-off">{offContent}</div>
+    </label>
+  );
+}

--- a/src/renderer/components/daisy/actions/ThemeController.tsx
+++ b/src/renderer/components/daisy/actions/ThemeController.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { applyTheme, Theme } from '../../../utils/theme';
+
+export default function ThemeController() {
+  const changeTheme = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    applyTheme(e.target.value as Theme);
+  };
+  return (
+    <select
+      className="select select-bordered"
+      onChange={changeTheme}
+      data-testid="theme-controller"
+    >
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="system">System</option>
+    </select>
+  );
+}

--- a/src/renderer/components/daisy/actions/index.ts
+++ b/src/renderer/components/daisy/actions/index.ts
@@ -1,0 +1,5 @@
+export { default as Button } from './Button';
+export { default as Dropdown } from './Dropdown';
+export { default as Modal } from './Modal';
+export { default as Swap } from './Swap';
+export { default as ThemeController } from './ThemeController';


### PR DESCRIPTION
## Summary
- add `Button`, `Dropdown`, `Modal`, `Swap` and `ThemeController` components
- re-export actions from an index file
- test that each daisyUI component renders

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684ef8f2b8e48331b9e3ee67394a9f4e