### PR TITLE
Add daisy display components

### DIFF
--- a/__tests__/daisy/display/Accordion.test.tsx
+++ b/__tests__/daisy/display/Accordion.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Accordion from '../../../src/renderer/components/daisy/display/Accordion';
+
+describe('Accordion', () => {
+  it('renders', () => {
+    render(<Accordion title="Title">Content</Accordion>);
+    expect(screen.getByTestId('accordion')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Avatar.test.tsx
+++ b/__tests__/daisy/display/Avatar.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Avatar from '../../../src/renderer/components/daisy/display/Avatar';
+
+describe('Avatar', () => {
+  it('renders', () => {
+    render(<Avatar src="a.png" />);
+    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Badge.test.tsx
+++ b/__tests__/daisy/display/Badge.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Badge from '../../../src/renderer/components/daisy/display/Badge';
+
+describe('Badge', () => {
+  it('renders', () => {
+    render(<Badge>Hi</Badge>);
+    expect(screen.getByTestId('badge')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Card.test.tsx
+++ b/__tests__/daisy/display/Card.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Card from '../../../src/renderer/components/daisy/display/Card';
+
+describe('Card', () => {
+  it('renders', () => {
+    render(<Card title="Title">Body</Card>);
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Carousel.test.tsx
+++ b/__tests__/daisy/display/Carousel.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Carousel from '../../../src/renderer/components/daisy/display/Carousel';
+
+describe('Carousel', () => {
+  it('renders', () => {
+    render(
+      <Carousel>
+        <div>Item</div>
+      </Carousel>
+    );
+    expect(screen.getByTestId('carousel')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/ChatBubble.test.tsx
+++ b/__tests__/daisy/display/ChatBubble.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ChatBubble from '../../../src/renderer/components/daisy/display/ChatBubble';
+
+describe('ChatBubble', () => {
+  it('renders', () => {
+    render(<ChatBubble>Hi</ChatBubble>);
+    expect(screen.getByTestId('chat-bubble')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Collapse.test.tsx
+++ b/__tests__/daisy/display/Collapse.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Collapse from '../../../src/renderer/components/daisy/display/Collapse';
+
+describe('Collapse', () => {
+  it('renders', () => {
+    render(<Collapse title="Title">Content</Collapse>);
+    expect(screen.getByTestId('collapse')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Countdown.test.tsx
+++ b/__tests__/daisy/display/Countdown.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Countdown from '../../../src/renderer/components/daisy/display/Countdown';
+
+describe('Countdown', () => {
+  it('renders', () => {
+    render(<Countdown value={10} />);
+    expect(screen.getByTestId('countdown')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Diff.test.tsx
+++ b/__tests__/daisy/display/Diff.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Diff from '../../../src/renderer/components/daisy/display/Diff';
+
+describe('Diff', () => {
+  it('renders', () => {
+    render(<Diff before="a" after="b" />);
+    expect(screen.getByTestId('diff')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Kbd.test.tsx
+++ b/__tests__/daisy/display/Kbd.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Kbd from '../../../src/renderer/components/daisy/display/Kbd';
+
+describe('Kbd', () => {
+  it('renders', () => {
+    render(<Kbd>A</Kbd>);
+    expect(screen.getByTestId('kbd')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/List.test.tsx
+++ b/__tests__/daisy/display/List.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import List from '../../../src/renderer/components/daisy/display/List';
+
+describe('List', () => {
+  it('renders', () => {
+    render(
+      <List>
+        <li>Item</li>
+      </List>
+    );
+    expect(screen.getByTestId('list')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Stat.test.tsx
+++ b/__tests__/daisy/display/Stat.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Stat from '../../../src/renderer/components/daisy/display/Stat';
+
+describe('Stat', () => {
+  it('renders', () => {
+    render(<Stat title="T" value="V" />);
+    expect(screen.getByTestId('stat')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Status.test.tsx
+++ b/__tests__/daisy/display/Status.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Status from '../../../src/renderer/components/daisy/display/Status';
+
+describe('Status', () => {
+  it('renders', () => {
+    render(<Status />);
+    expect(screen.getByTestId('status')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Table.test.tsx
+++ b/__tests__/daisy/display/Table.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Table from '../../../src/renderer/components/daisy/display/Table';
+
+describe('Table', () => {
+  it('renders', () => {
+    render(
+      <Table
+        head={
+          <tr>
+            <th>H</th>
+          </tr>
+        }
+      >
+        <tr>
+          <td>A</td>
+        </tr>
+      </Table>
+    );
+    expect(screen.getByTestId('table')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/display/Timeline.test.tsx
+++ b/__tests__/daisy/display/Timeline.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Timeline from '../../../src/renderer/components/daisy/display/Timeline';
+
+describe('Timeline', () => {
+  it('renders', () => {
+    render(
+      <Timeline>
+        <li>Step</li>
+      </Timeline>
+    );
+    expect(screen.getByTestId('timeline')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/daisy/display/Accordion.tsx
+++ b/src/renderer/components/daisy/display/Accordion.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface AccordionProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function Accordion({ title, children }: AccordionProps) {
+  return (
+    <div
+      className="collapse collapse-arrow rounded-box border border-base-300"
+      data-testid="accordion"
+    >
+      <input type="checkbox" />
+      <div className="collapse-title text-lg font-medium">{title}</div>
+      <div className="collapse-content">{children}</div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Avatar.tsx
+++ b/src/renderer/components/daisy/display/Avatar.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface AvatarProps {
+  src: string;
+  alt?: string;
+  size?: number;
+}
+
+export default function Avatar({ src, alt, size = 64 }: AvatarProps) {
+  const style = {
+    width: `${size}px`,
+    height: `${size}px`,
+  } as React.CSSProperties;
+  return (
+    <div className="avatar" data-testid="avatar">
+      <div className="rounded" style={style}>
+        <img src={src} alt={alt} />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Badge.tsx
+++ b/src/renderer/components/daisy/display/Badge.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Badge({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="badge" data-testid="badge">
+      {children}
+    </span>
+  );
+}

--- a/src/renderer/components/daisy/display/Card.tsx
+++ b/src/renderer/components/daisy/display/Card.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface CardProps {
+  title?: React.ReactNode;
+  children?: React.ReactNode;
+}
+
+export default function Card({ title, children }: CardProps) {
+  return (
+    <div className="card bg-base-100 shadow" data-testid="card">
+      <div className="card-body">
+        {title && <h2 className="card-title">{title}</h2>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Carousel.tsx
+++ b/src/renderer/components/daisy/display/Carousel.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Carousel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="carousel" data-testid="carousel">
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/ChatBubble.tsx
+++ b/src/renderer/components/daisy/display/ChatBubble.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function ChatBubble({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="chat-bubble" data-testid="chat-bubble">
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Collapse.tsx
+++ b/src/renderer/components/daisy/display/Collapse.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface CollapseProps {
+  title: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function Collapse({ title, children }: CollapseProps) {
+  return (
+    <div
+      className="collapse rounded-box border border-base-300"
+      data-testid="collapse"
+    >
+      <input type="checkbox" />
+      <div className="collapse-title text-lg font-medium">{title}</div>
+      <div className="collapse-content">{children}</div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Countdown.tsx
+++ b/src/renderer/components/daisy/display/Countdown.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Countdown({ value }: { value: number }) {
+  return (
+    <span className="countdown font-mono text-2xl" data-testid="countdown">
+      <span style={{ '--value': value } as React.CSSProperties} />
+    </span>
+  );
+}

--- a/src/renderer/components/daisy/display/Diff.tsx
+++ b/src/renderer/components/daisy/display/Diff.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface DiffProps {
+  before: React.ReactNode;
+  after: React.ReactNode;
+}
+
+export default function Diff({ before, after }: DiffProps) {
+  return (
+    <div className="diff" data-testid="diff">
+      <div className="diff-item-1">{before}</div>
+      <div className="diff-item-2">{after}</div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Kbd.tsx
+++ b/src/renderer/components/daisy/display/Kbd.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="kbd" data-testid="kbd">
+      {children}
+    </kbd>
+  );
+}

--- a/src/renderer/components/daisy/display/List.tsx
+++ b/src/renderer/components/daisy/display/List.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function List({ children }: { children: React.ReactNode }) {
+  return (
+    <ul className="list list-disc" data-testid="list">
+      {children}
+    </ul>
+  );
+}

--- a/src/renderer/components/daisy/display/Stat.tsx
+++ b/src/renderer/components/daisy/display/Stat.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface StatProps {
+  title: React.ReactNode;
+  value: React.ReactNode;
+  desc?: React.ReactNode;
+}
+
+export default function Stat({ title, value, desc }: StatProps) {
+  return (
+    <div className="stat" data-testid="stat">
+      <div className="stat-title">{title}</div>
+      <div className="stat-value">{value}</div>
+      {desc && <div className="stat-desc">{desc}</div>}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Status.tsx
+++ b/src/renderer/components/daisy/display/Status.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function Status({ color = 'primary' }: { color?: string }) {
+  return <span className={`status status-${color}`} data-testid="status" />;
+}

--- a/src/renderer/components/daisy/display/Table.tsx
+++ b/src/renderer/components/daisy/display/Table.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface TableProps {
+  head?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export default function Table({ head, children }: TableProps) {
+  return (
+    <div className="overflow-x-auto" data-testid="table">
+      <table className="table">
+        {head && <thead>{head}</thead>}
+        <tbody>{children}</tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/display/Timeline.tsx
+++ b/src/renderer/components/daisy/display/Timeline.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function Timeline({ children }: { children: React.ReactNode }) {
+  return (
+    <ul className="timeline" data-testid="timeline">
+      {children}
+    </ul>
+  );
+}

--- a/src/renderer/components/daisy/display/index.ts
+++ b/src/renderer/components/daisy/display/index.ts
@@ -1,0 +1,15 @@
+export { default as Accordion } from './Accordion';
+export { default as Avatar } from './Avatar';
+export { default as Badge } from './Badge';
+export { default as Card } from './Card';
+export { default as Carousel } from './Carousel';
+export { default as ChatBubble } from './ChatBubble';
+export { default as Collapse } from './Collapse';
+export { default as Countdown } from './Countdown';
+export { default as Diff } from './Diff';
+export { default as Kbd } from './Kbd';
+export { default as List } from './List';
+export { default as Stat } from './Stat';
+export { default as Status } from './Status';
+export { default as Table } from './Table';
+export { default as Timeline } from './Timeline';


### PR DESCRIPTION
## Summary
- add DaisyUI display components under `src/renderer/components/daisy/display`
- export the components via an index file
- test each component renders correctly

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef90ced308331ae4a84de4e5bc1e6