### PR TITLE
Add Daisy navigation components

### DIFF
--- a/__tests__/daisy/navigation/Breadcrumbs.test.tsx
+++ b/__tests__/daisy/navigation/Breadcrumbs.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Breadcrumbs } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Breadcrumbs', () => {
+  it('renders breadcrumbs container', () => {
+    const { container } = render(
+      <Breadcrumbs>
+        <li>
+          <a>Home</a>
+        </li>
+      </Breadcrumbs>
+    );
+    expect(container.firstChild).toHaveClass('breadcrumbs');
+    expect(screen.getByText('Home')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/navigation/Dock.test.tsx
+++ b/__tests__/daisy/navigation/Dock.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Dock } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Dock', () => {
+  it('renders dock container', () => {
+    const { container } = render(
+      <Dock>
+        <button>One</button>
+      </Dock>
+    );
+    expect(container.firstChild).toHaveClass('dock');
+  });
+});

--- a/__tests__/daisy/navigation/Link.test.tsx
+++ b/__tests__/daisy/navigation/Link.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Link } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Link', () => {
+  it('renders anchor with link class', () => {
+    render(<Link href="#">Test</Link>);
+    const anchor = screen.getByText('Test');
+    expect(anchor).toHaveClass('link');
+    expect(anchor).toHaveAttribute('href', '#');
+  });
+});

--- a/__tests__/daisy/navigation/Menu.test.tsx
+++ b/__tests__/daisy/navigation/Menu.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Menu } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Menu', () => {
+  it('renders menu list', () => {
+    const { container } = render(
+      <Menu>
+        <li>Item</li>
+      </Menu>
+    );
+    expect(container.firstChild).toHaveClass('menu');
+    expect(screen.getByText('Item')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/navigation/Navbar.test.tsx
+++ b/__tests__/daisy/navigation/Navbar.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Navbar } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Navbar', () => {
+  it('renders navbar container', () => {
+    const { container } = render(
+      <Navbar>
+        <div>Content</div>
+      </Navbar>
+    );
+    expect(container.firstChild).toHaveClass('navbar');
+  });
+});

--- a/__tests__/daisy/navigation/Pagination.test.tsx
+++ b/__tests__/daisy/navigation/Pagination.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Pagination } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Pagination', () => {
+  it('renders join container', () => {
+    const { container } = render(
+      <Pagination>
+        <button className="btn">1</button>
+      </Pagination>
+    );
+    expect(container.firstChild).toHaveClass('join');
+  });
+});

--- a/__tests__/daisy/navigation/Steps.test.tsx
+++ b/__tests__/daisy/navigation/Steps.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Steps } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Steps', () => {
+  it('renders steps list', () => {
+    const { container } = render(
+      <Steps>
+        <li className="step">1</li>
+      </Steps>
+    );
+    expect(container.firstChild).toHaveClass('steps');
+  });
+});

--- a/__tests__/daisy/navigation/Tab.test.tsx
+++ b/__tests__/daisy/navigation/Tab.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Tab } from '../../../src/renderer/components/daisy/navigation';
+
+describe('Tab', () => {
+  it('renders button with role tab', () => {
+    render(<Tab>Tab 1</Tab>);
+    const btn = screen.getByRole('tab');
+    expect(btn).toHaveClass('tab');
+    expect(btn).toHaveTextContent('Tab 1');
+  });
+});

--- a/src/renderer/components/daisy/navigation/Breadcrumbs.tsx
+++ b/src/renderer/components/daisy/navigation/Breadcrumbs.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Breadcrumbs({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`breadcrumbs ${className}`.trim()} {...rest}>
+      <ul>{children}</ul>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Dock.tsx
+++ b/src/renderer/components/daisy/navigation/Dock.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Dock({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`dock ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Link.tsx
+++ b/src/renderer/components/daisy/navigation/Link.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Link({
+  children,
+  className = '',
+  ...rest
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a className={`link ${className}`.trim()} {...rest}>
+      {children}
+    </a>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Menu.tsx
+++ b/src/renderer/components/daisy/navigation/Menu.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Menu({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLUListElement>) {
+  return (
+    <ul className={`menu ${className}`.trim()} {...rest}>
+      {children}
+    </ul>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Navbar.tsx
+++ b/src/renderer/components/daisy/navigation/Navbar.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Navbar({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`navbar ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Pagination.tsx
+++ b/src/renderer/components/daisy/navigation/Pagination.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Pagination({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`join ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Steps.tsx
+++ b/src/renderer/components/daisy/navigation/Steps.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Steps({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLUListElement>) {
+  return (
+    <ul className={`steps ${className}`.trim()} {...rest}>
+      {children}
+    </ul>
+  );
+}

--- a/src/renderer/components/daisy/navigation/Tab.tsx
+++ b/src/renderer/components/daisy/navigation/Tab.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Tab({
+  children,
+  className = '',
+  ...rest
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button role="tab" className={`tab ${className}`.trim()} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/renderer/components/daisy/navigation/index.ts
+++ b/src/renderer/components/daisy/navigation/index.ts
@@ -1,0 +1,8 @@
+export { default as Breadcrumbs } from './Breadcrumbs';
+export { default as Dock } from './Dock';
+export { default as Link } from './Link';
+export { default as Menu } from './Menu';
+export { default as Navbar } from './Navbar';
+export { default as Pagination } from './Pagination';
+export { default as Steps } from './Steps';
+export { default as Tab } from './Tab';


### PR DESCRIPTION
## Summary
- implement DaisyUI navigation components
- export via index.ts
- add tests for each component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef914ef408331afc4bafda4ea88df