### PR TITLE
Add DaisyUI feedback components

### DIFF
--- a/__tests__/daisy/feedback/Alert.test.tsx
+++ b/__tests__/daisy/feedback/Alert.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Alert from '../../../src/renderer/components/daisy/feedback/Alert';
+
+describe('Alert', () => {
+  it('renders with type and children', () => {
+    render(<Alert type="success">done</Alert>);
+    const el = screen.getByRole('alert');
+    expect(el).toHaveTextContent('done');
+    expect(el).toHaveClass('alert-success');
+  });
+});

--- a/__tests__/daisy/feedback/Loading.test.tsx
+++ b/__tests__/daisy/feedback/Loading.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Loading from '../../../src/renderer/components/daisy/feedback/Loading';
+
+describe('Loading', () => {
+  it('renders spinner by default', () => {
+    render(<Loading />);
+    const el = screen.getByTestId('loading');
+    expect(el).toHaveClass('loading-spinner');
+  });
+
+  it('supports other styles', () => {
+    render(<Loading style="dots" size="lg" />);
+    const el = screen.getByTestId('loading');
+    expect(el).toHaveClass('loading-dots');
+    expect(el).toHaveClass('loading-lg');
+  });
+});

--- a/__tests__/daisy/feedback/Progress.test.tsx
+++ b/__tests__/daisy/feedback/Progress.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Progress from '../../../src/renderer/components/daisy/feedback/Progress';
+
+describe('Progress', () => {
+  it('renders progress bar', () => {
+    render(<Progress value={30} max={100} color="accent" />);
+    const bar = screen.getByTestId('progress') as HTMLProgressElement;
+    expect(bar.value).toBe(30);
+    expect(bar.max).toBe(100);
+    expect(bar).toHaveClass('progress-accent');
+  });
+});

--- a/__tests__/daisy/feedback/RadialProgress.test.tsx
+++ b/__tests__/daisy/feedback/RadialProgress.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import RadialProgress from '../../../src/renderer/components/daisy/feedback/RadialProgress';
+
+describe('RadialProgress', () => {
+  it('renders radial progress', () => {
+    render(<RadialProgress value={70} size="4rem" />);
+    const el = screen.getByTestId('radial-progress');
+    expect(el).toHaveTextContent('70%');
+    expect(el).toHaveAttribute('aria-valuenow', '70');
+  });
+});

--- a/__tests__/daisy/feedback/Skeleton.test.tsx
+++ b/__tests__/daisy/feedback/Skeleton.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Skeleton from '../../../src/renderer/components/daisy/feedback/Skeleton';
+
+describe('Skeleton', () => {
+  it('renders skeleton with size', () => {
+    render(<Skeleton width="2rem" height="1rem" />);
+    const el = screen.getByTestId('skeleton');
+    expect(el).toHaveStyle({ width: '2rem', height: '1rem' });
+  });
+});

--- a/__tests__/daisy/feedback/Toast.test.tsx
+++ b/__tests__/daisy/feedback/Toast.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Toast from '../../../src/renderer/components/daisy/feedback/Toast';
+
+describe('Toast', () => {
+  it('renders with position', () => {
+    render(
+      <Toast position="top">
+        <span>hello</span>
+      </Toast>
+    );
+    const el = screen.getByText('hello').parentElement;
+    expect(el).toHaveClass('toast-top');
+  });
+});

--- a/__tests__/daisy/feedback/Tooltip.test.tsx
+++ b/__tests__/daisy/feedback/Tooltip.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import Tooltip from '../../../src/renderer/components/daisy/feedback/Tooltip';
+
+describe('Tooltip', () => {
+  it('renders tooltip wrapper', () => {
+    render(
+      <Tooltip tip="info" position="bottom">
+        <button>btn</button>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('btn').parentElement;
+    expect(wrapper).toHaveClass('tooltip-bottom');
+    expect(wrapper).toHaveAttribute('data-tip', 'info');
+  });
+});

--- a/src/renderer/components/daisy/feedback/Alert.tsx
+++ b/src/renderer/components/daisy/feedback/Alert.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export type AlertType = 'info' | 'success' | 'warning' | 'error';
+
+export default function Alert({
+  children,
+  type = 'info',
+}: {
+  children: React.ReactNode;
+  type?: AlertType;
+}) {
+  return (
+    <div role="alert" className={`alert alert-${type}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/feedback/Loading.tsx
+++ b/src/renderer/components/daisy/feedback/Loading.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export type LoadingStyle =
+  | 'spinner'
+  | 'dots'
+  | 'ring'
+  | 'ball'
+  | 'bars'
+  | 'infinity';
+export type LoadingSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export default function Loading({
+  style = 'spinner',
+  size = 'md',
+}: {
+  style?: LoadingStyle;
+  size?: LoadingSize;
+}) {
+  return (
+    <span
+      className={`loading loading-${style} loading-${size}`}
+      aria-label="loading"
+      data-testid="loading"
+    />
+  );
+}

--- a/src/renderer/components/daisy/feedback/Progress.tsx
+++ b/src/renderer/components/daisy/feedback/Progress.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+export type ProgressColor =
+  | 'neutral'
+  | 'primary'
+  | 'secondary'
+  | 'accent'
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export default function Progress({
+  value,
+  max,
+  color = 'primary',
+}: {
+  value: number;
+  max: number;
+  color?: ProgressColor;
+}) {
+  return (
+    <progress
+      className={`progress progress-${color}`}
+      value={value}
+      max={max}
+      data-testid="progress"
+    />
+  );
+}

--- a/src/renderer/components/daisy/feedback/RadialProgress.tsx
+++ b/src/renderer/components/daisy/feedback/RadialProgress.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+export default function RadialProgress({
+  value,
+  size = '5rem',
+  thickness,
+}: {
+  value: number;
+  size?: string;
+  thickness?: string;
+}) {
+  return (
+    <div
+      className="radial-progress"
+      style={
+        {
+          '--value': value.toString(),
+          '--size': size,
+          ...(thickness ? { '--thickness': thickness } : {}),
+        } as React.CSSProperties
+      }
+      role="progressbar"
+      aria-valuenow={value}
+      data-testid="radial-progress"
+    >
+      {value}%
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/feedback/Skeleton.tsx
+++ b/src/renderer/components/daisy/feedback/Skeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Skeleton({
+  width,
+  height,
+}: {
+  width?: string;
+  height?: string;
+}) {
+  return (
+    <div
+      className="skeleton"
+      style={{ width, height }}
+      data-testid="skeleton"
+    />
+  );
+}

--- a/src/renderer/components/daisy/feedback/Toast.tsx
+++ b/src/renderer/components/daisy/feedback/Toast.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export type ToastPosition =
+  | 'start'
+  | 'center'
+  | 'end'
+  | 'top'
+  | 'middle'
+  | 'bottom';
+
+export default function Toast({
+  children,
+  position = 'end',
+}: {
+  children: React.ReactNode;
+  position?: ToastPosition;
+}) {
+  return <div className={`toast toast-${position}`}>{children}</div>;
+}

--- a/src/renderer/components/daisy/feedback/Tooltip.tsx
+++ b/src/renderer/components/daisy/feedback/Tooltip.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export type TooltipPosition =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'top-start'
+  | 'top-end'
+  | 'bottom-start'
+  | 'bottom-end'
+  | 'left-start'
+  | 'left-end'
+  | 'right-start'
+  | 'right-end';
+
+export default function Tooltip({
+  tip,
+  children,
+  position,
+}: {
+  tip: string;
+  children: React.ReactNode;
+  position?: TooltipPosition;
+}) {
+  const posClass = position ? `tooltip-${position}` : '';
+  return (
+    <div className={`tooltip ${posClass}`.trim()} data-tip={tip}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/feedback/index.ts
+++ b/src/renderer/components/daisy/feedback/index.ts
@@ -1,0 +1,7 @@
+export { default as Alert } from './Alert';
+export { default as Loading } from './Loading';
+export { default as Progress } from './Progress';
+export { default as RadialProgress } from './RadialProgress';
+export { default as Skeleton } from './Skeleton';
+export { default as Toast } from './Toast';
+export { default as Tooltip } from './Tooltip';


### PR DESCRIPTION
## Summary
- add `Alert`, `Loading`, `Progress`, `RadialProgress`, `Skeleton`, `Toast`, and `Tooltip` components
- export them via `index.ts`
- provide unit tests for each new component

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684ef919d2f0833182253740068b2f83