### PR TITLE
Add daisy input components

### DIFF
--- a/__tests__/daisy/input/Calendar.test.tsx
+++ b/__tests__/daisy/input/Calendar.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Calendar } from '../../../src/renderer/components/daisy/input';
+
+describe('Calendar', () => {
+  it('renders', () => {
+    render(<Calendar data-testid="cal" />);
+    expect(screen.getByTestId('cal')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Checkbox.test.tsx
+++ b/__tests__/daisy/input/Checkbox.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Checkbox } from '../../../src/renderer/components/daisy/input';
+
+describe('Checkbox', () => {
+  it('renders', () => {
+    render(<Checkbox data-testid="cb" />);
+    expect(screen.getByTestId('cb')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Fieldset.test.tsx
+++ b/__tests__/daisy/input/Fieldset.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Fieldset } from '../../../src/renderer/components/daisy/input';
+
+describe('Fieldset', () => {
+  it('renders', () => {
+    render(<Fieldset data-testid="fs">content</Fieldset>);
+    expect(screen.getByTestId('fs')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/FileInput.test.tsx
+++ b/__tests__/daisy/input/FileInput.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FileInput } from '../../../src/renderer/components/daisy/input';
+
+describe('FileInput', () => {
+  it('renders', () => {
+    render(<FileInput data-testid="file" />);
+    expect(screen.getByTestId('file')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Filter.test.tsx
+++ b/__tests__/daisy/input/Filter.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Filter } from '../../../src/renderer/components/daisy/input';
+
+describe('Filter', () => {
+  it('renders', () => {
+    render(<Filter data-testid="flt">f</Filter>);
+    expect(screen.getByTestId('flt')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/InputField.test.tsx
+++ b/__tests__/daisy/input/InputField.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InputField } from '../../../src/renderer/components/daisy/input';
+
+describe('InputField', () => {
+  it('renders', () => {
+    render(<InputField data-testid="inp" />);
+    expect(screen.getByTestId('inp')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Label.test.tsx
+++ b/__tests__/daisy/input/Label.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Label } from '../../../src/renderer/components/daisy/input';
+
+describe('Label', () => {
+  it('renders', () => {
+    render(<Label data-testid="lab">L</Label>);
+    expect(screen.getByTestId('lab')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Radio.test.tsx
+++ b/__tests__/daisy/input/Radio.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Radio } from '../../../src/renderer/components/daisy/input';
+
+describe('Radio', () => {
+  it('renders', () => {
+    render(<Radio data-testid="radio" />);
+    expect(screen.getByTestId('radio')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Range.test.tsx
+++ b/__tests__/daisy/input/Range.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Range } from '../../../src/renderer/components/daisy/input';
+
+describe('Range', () => {
+  it('renders', () => {
+    render(<Range data-testid="rng" />);
+    expect(screen.getByTestId('rng')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Rating.test.tsx
+++ b/__tests__/daisy/input/Rating.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Rating } from '../../../src/renderer/components/daisy/input';
+
+describe('Rating', () => {
+  it('renders', () => {
+    render(<Rating data-testid="rate">*</Rating>);
+    expect(screen.getByTestId('rate')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Select.test.tsx
+++ b/__tests__/daisy/input/Select.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Select } from '../../../src/renderer/components/daisy/input';
+
+describe('Select', () => {
+  it('renders', () => {
+    render(
+      <Select data-testid="sel">
+        <option>1</option>
+      </Select>
+    );
+    expect(screen.getByTestId('sel')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Textarea.test.tsx
+++ b/__tests__/daisy/input/Textarea.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Textarea } from '../../../src/renderer/components/daisy/input';
+
+describe('Textarea', () => {
+  it('renders', () => {
+    render(<Textarea data-testid="ta" />);
+    expect(screen.getByTestId('ta')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Toggle.test.tsx
+++ b/__tests__/daisy/input/Toggle.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Toggle } from '../../../src/renderer/components/daisy/input';
+
+describe('Toggle', () => {
+  it('renders', () => {
+    render(<Toggle data-testid="tog" />);
+    expect(screen.getByTestId('tog')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/input/Validator.test.tsx
+++ b/__tests__/daisy/input/Validator.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import {
+  Validator,
+  InputField,
+} from '../../../src/renderer/components/daisy/input';
+
+describe('Validator', () => {
+  it('renders with hint', () => {
+    render(
+      <Validator hint="error" data-testid="val">
+        <InputField required />
+      </Validator>
+    );
+    expect(screen.getByTestId('val')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/daisy/input/Calendar.tsx
+++ b/src/renderer/components/daisy/input/Calendar.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Calendar({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className="calendar" {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/input/Checkbox.tsx
+++ b/src/renderer/components/daisy/input/Checkbox.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Checkbox(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input type="checkbox" className="checkbox" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Fieldset.tsx
+++ b/src/renderer/components/daisy/input/Fieldset.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Fieldset({
+  children,
+  ...props
+}: React.FieldsetHTMLAttributes<HTMLFieldSetElement>) {
+  return (
+    <fieldset className="fieldset" {...props}>
+      {children}
+    </fieldset>
+  );
+}

--- a/src/renderer/components/daisy/input/FileInput.tsx
+++ b/src/renderer/components/daisy/input/FileInput.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function FileInput(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input type="file" className="file-input" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Filter.tsx
+++ b/src/renderer/components/daisy/input/Filter.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Filter({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className="filter" {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/input/InputField.tsx
+++ b/src/renderer/components/daisy/input/InputField.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function InputField(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input className="input input-bordered" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Label.tsx
+++ b/src/renderer/components/daisy/input/Label.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Label({
+  children,
+  ...props
+}: React.LabelHTMLAttributes<HTMLLabelElement>) {
+  return (
+    <label className="label" {...props}>
+      {children}
+    </label>
+  );
+}

--- a/src/renderer/components/daisy/input/Radio.tsx
+++ b/src/renderer/components/daisy/input/Radio.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Radio(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input type="radio" className="radio" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Range.tsx
+++ b/src/renderer/components/daisy/input/Range.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Range(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input type="range" className="range" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Rating.tsx
+++ b/src/renderer/components/daisy/input/Rating.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Rating({
+  children,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className="rating" {...props}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/input/Select.tsx
+++ b/src/renderer/components/daisy/input/Select.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Select({
+  children,
+  ...props
+}: React.SelectHTMLAttributes<HTMLSelectElement>) {
+  return (
+    <select className="select" {...props}>
+      {children}
+    </select>
+  );
+}

--- a/src/renderer/components/daisy/input/Textarea.tsx
+++ b/src/renderer/components/daisy/input/Textarea.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Textarea(
+  props: React.TextareaHTMLAttributes<HTMLTextAreaElement>
+) {
+  return <textarea className="textarea" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Toggle.tsx
+++ b/src/renderer/components/daisy/input/Toggle.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Toggle(
+  props: React.InputHTMLAttributes<HTMLInputElement>
+) {
+  return <input type="checkbox" className="toggle" {...props} />;
+}

--- a/src/renderer/components/daisy/input/Validator.tsx
+++ b/src/renderer/components/daisy/input/Validator.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  hint?: React.ReactNode;
+}
+
+export default function Validator({ children, hint, ...props }: Props) {
+  return (
+    <div {...props} className={`validator ${props.className ?? ''}`.trim()}>
+      {children}
+      {hint && <span className="validator-hint">{hint}</span>}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/input/index.ts
+++ b/src/renderer/components/daisy/input/index.ts
@@ -1,0 +1,14 @@
+export { default as Calendar } from './Calendar';
+export { default as Checkbox } from './Checkbox';
+export { default as Fieldset } from './Fieldset';
+export { default as FileInput } from './FileInput';
+export { default as Filter } from './Filter';
+export { default as Label } from './Label';
+export { default as Radio } from './Radio';
+export { default as Range } from './Range';
+export { default as Rating } from './Rating';
+export { default as Select } from './Select';
+export { default as InputField } from './InputField';
+export { default as Textarea } from './Textarea';
+export { default as Toggle } from './Toggle';
+export { default as Validator } from './Validator';


### PR DESCRIPTION
## Summary
- add daisy input component wrappers
- export all components from an index
- add rendering tests for each component

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef91ff8908331bfa446c289c645eb