### PR TITLE
Add daisyUI layout components

### DIFF
--- a/__tests__/daisy/layout/Divider.test.tsx
+++ b/__tests__/daisy/layout/Divider.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Divider from '../../../src/renderer/components/daisy/layout/Divider';
+
+describe('Divider', () => {
+  it('renders divider', () => {
+    const { container } = render(<Divider>content</Divider>);
+    expect(container.firstChild).toHaveClass('divider');
+  });
+});

--- a/__tests__/daisy/layout/Drawer.test.tsx
+++ b/__tests__/daisy/layout/Drawer.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Drawer from '../../../src/renderer/components/daisy/layout/Drawer';
+
+describe('Drawer', () => {
+  it('renders drawer structure', () => {
+    const { container } = render(
+      <Drawer id="d1" side={<div>Side</div>}>
+        <div>Content</div>
+      </Drawer>
+    );
+    expect(container.querySelector('.drawer')).toBeInTheDocument();
+    expect(container.querySelector('.drawer-content')).toBeInTheDocument();
+    expect(container.querySelector('.drawer-side')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/layout/Footer.test.tsx
+++ b/__tests__/daisy/layout/Footer.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Footer from '../../../src/renderer/components/daisy/layout/Footer';
+
+describe('Footer', () => {
+  it('renders footer', () => {
+    const { container } = render(<Footer>foot</Footer>);
+    expect(container.firstChild).toHaveClass('footer');
+  });
+});

--- a/__tests__/daisy/layout/Hero.test.tsx
+++ b/__tests__/daisy/layout/Hero.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Hero from '../../../src/renderer/components/daisy/layout/Hero';
+
+describe('Hero', () => {
+  it('renders hero', () => {
+    const { container } = render(<Hero>hero</Hero>);
+    expect(container.firstChild).toHaveClass('hero');
+  });
+});

--- a/__tests__/daisy/layout/Indicator.test.tsx
+++ b/__tests__/daisy/layout/Indicator.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Indicator from '../../../src/renderer/components/daisy/layout/Indicator';
+
+describe('Indicator', () => {
+  it('renders indicator with item', () => {
+    const { container } = render(
+      <Indicator item={<span>!</span>}>child</Indicator>
+    );
+    expect(container.firstChild).toHaveClass('indicator');
+    expect(container.querySelector('.indicator-item')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/layout/Join.test.tsx
+++ b/__tests__/daisy/layout/Join.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Join from '../../../src/renderer/components/daisy/layout/Join';
+
+describe('Join', () => {
+  it('renders join group', () => {
+    const { container } = render(
+      <Join>
+        <input type="text" />
+      </Join>
+    );
+    expect(container.firstChild).toHaveClass('join');
+  });
+});

--- a/__tests__/daisy/layout/Mask.test.tsx
+++ b/__tests__/daisy/layout/Mask.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Mask from '../../../src/renderer/components/daisy/layout/Mask';
+
+describe('Mask', () => {
+  it('renders mask with type', () => {
+    const { container } = render(
+      <Mask type="mask-squircle">
+        <img src="test.png" alt="" />
+      </Mask>
+    );
+    expect(container.firstChild).toHaveClass('mask');
+    expect(container.firstChild).toHaveClass('mask-squircle');
+  });
+});

--- a/__tests__/daisy/layout/Stack.test.tsx
+++ b/__tests__/daisy/layout/Stack.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import Stack from '../../../src/renderer/components/daisy/layout/Stack';
+
+describe('Stack', () => {
+  it('renders stack', () => {
+    const { container } = render(
+      <Stack>
+        <div>One</div>
+        <div>Two</div>
+      </Stack>
+    );
+    expect(container.firstChild).toHaveClass('stack');
+  });
+});

--- a/src/renderer/components/daisy/layout/Divider.tsx
+++ b/src/renderer/components/daisy/layout/Divider.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Divider({
+  className = '',
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`divider ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Drawer.tsx
+++ b/src/renderer/components/daisy/layout/Drawer.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface DrawerProps {
+  id: string;
+  side: React.ReactNode;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Drawer({
+  id,
+  side,
+  children,
+  className = '',
+}: DrawerProps) {
+  return (
+    <div className={`drawer ${className}`.trim()}>
+      <input id={id} type="checkbox" className="drawer-toggle" />
+      <div className="drawer-content">{children}</div>
+      <div className="drawer-side">
+        <label htmlFor={id} className="drawer-overlay" />
+        {side}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Footer.tsx
+++ b/src/renderer/components/daisy/layout/Footer.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Footer({
+  className = '',
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLElement>) {
+  return (
+    <footer className={`footer ${className}`.trim()} {...rest}>
+      {children}
+    </footer>
+  );
+}

--- a/src/renderer/components/daisy/layout/Hero.tsx
+++ b/src/renderer/components/daisy/layout/Hero.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Hero({
+  className = '',
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`hero ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Indicator.tsx
+++ b/src/renderer/components/daisy/layout/Indicator.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+interface IndicatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  item?: React.ReactNode;
+}
+
+export default function Indicator({
+  item,
+  className = '',
+  children,
+  ...rest
+}: IndicatorProps) {
+  return (
+    <div className={`indicator ${className}`.trim()} {...rest}>
+      {item && <span className="indicator-item">{item}</span>}
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Join.tsx
+++ b/src/renderer/components/daisy/layout/Join.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Join({
+  className = '',
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`join ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Mask.tsx
+++ b/src/renderer/components/daisy/layout/Mask.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+interface MaskProps extends React.HTMLAttributes<HTMLDivElement> {
+  type?: string;
+}
+
+export default function Mask({
+  type = '',
+  className = '',
+  children,
+  ...rest
+}: MaskProps) {
+  return (
+    <div className={`mask ${type} ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/Stack.tsx
+++ b/src/renderer/components/daisy/layout/Stack.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Stack({
+  className = '',
+  children,
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`stack ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/layout/index.ts
+++ b/src/renderer/components/daisy/layout/index.ts
@@ -1,0 +1,8 @@
+export { default as Divider } from './Divider';
+export { default as Drawer } from './Drawer';
+export { default as Footer } from './Footer';
+export { default as Hero } from './Hero';
+export { default as Indicator } from './Indicator';
+export { default as Join } from './Join';
+export { default as Mask } from './Mask';
+export { default as Stack } from './Stack';


### PR DESCRIPTION
## Summary
- add Daisy layout wrappers for Divider, Drawer, Footer, Hero, Indicator, Join, Mask and Stack
- re-export them in an index file
- test layout components render correctly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef92558b08331be31bc6d8cb184af