### PR TITLE
Add confetti preference

### DIFF
--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -53,17 +53,20 @@ describe('EditorView', () => {
 
   const getLayout = vi.fn(async () => [20, 80]);
   const setLayout = vi.fn();
+  const getConfetti = vi.fn(async () => true);
 
   beforeEach(() => {
     interface API {
       exportProject: (path: string) => Promise<typeof summary>;
       getEditorLayout: () => Promise<number[]>;
       setEditorLayout: (l: number[]) => void;
+      getConfetti: () => Promise<boolean>;
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       exportProject,
       getEditorLayout: getLayout,
       setEditorLayout: setLayout,
+      getConfetti,
     };
     exportProject.mockResolvedValue(summary);
     openExternalMock.mockResolvedValue(undefined);

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -10,6 +10,8 @@ const getTextureEditor = vi.fn();
 const setTextureEditor = vi.fn();
 const getTheme = vi.fn();
 const setTheme = vi.fn();
+const getConfetti = vi.fn();
+const setConfetti = vi.fn();
 vi.mock('electron', () => ({
   shell: { openExternal: (openExternalMock = vi.fn()) },
 }));
@@ -24,6 +26,8 @@ describe('SettingsView', () => {
           setTextureEditor: typeof setTextureEditor;
           getTheme: typeof getTheme;
           setTheme: typeof setTheme;
+          getConfetti: typeof getConfetti;
+          setConfetti: typeof setConfetti;
         };
       }
     ).electronAPI = {
@@ -31,11 +35,15 @@ describe('SettingsView', () => {
       setTextureEditor,
       getTheme,
       setTheme,
+      getConfetti,
+      setConfetti,
     } as never;
     getTextureEditor.mockResolvedValue('/usr/bin/gimp');
     setTextureEditor.mockResolvedValue(undefined);
     getTheme.mockResolvedValue('system');
     setTheme.mockResolvedValue(undefined);
+    getConfetti.mockResolvedValue(true);
+    setConfetti.mockResolvedValue(undefined);
   });
 
   it('renders placeholder heading', () => {
@@ -73,5 +81,13 @@ describe('SettingsView', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe(
       'minecraft'
     );
+  });
+
+  it('toggles confetti preference', async () => {
+    render(<SettingsView />);
+    const toggle = await screen.findByLabelText('Confetti effects');
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(setConfetti).toHaveBeenCalledWith(false);
   });
 });

--- a/__tests__/confettiPersistence.test.ts
+++ b/__tests__/confettiPersistence.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { setConfetti } from '../src/main/layout';
+
+describe('confetti persistence', () => {
+  it('persists across reloads', async () => {
+    setConfetti(false);
+    vi.resetModules();
+    const { getConfetti: reloadGet } = await import('../src/main/layout');
+    expect(reloadGet()).toBe(false);
+  });
+});

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -7,8 +7,14 @@ const store = new Store<{
   editorLayout: number[];
   textureEditor: string;
   theme: ThemePref;
+  confetti: boolean;
 }>({
-  defaults: { editorLayout: [20, 80], textureEditor: '', theme: 'system' },
+  defaults: {
+    editorLayout: [20, 80],
+    textureEditor: '',
+    theme: 'system',
+    confetti: true,
+  },
 });
 
 export function getEditorLayout(): number[] {
@@ -35,6 +41,14 @@ export function setTheme(pref: ThemePref): void {
   store.set('theme', pref);
 }
 
+export function getConfetti(): boolean {
+  return store.get('confetti');
+}
+
+export function setConfetti(flag: boolean): void {
+  store.set('confetti', flag);
+}
+
 export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-editor-layout', () => getEditorLayout());
   ipc.handle('set-editor-layout', (_e, layout: number[]) =>
@@ -44,4 +58,6 @@ export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('set-texture-editor', (_e, p: string) => setTextureEditor(p));
   ipc.handle('get-theme', () => getTheme());
   ipc.handle('set-theme', (_e, t: ThemePref) => setTheme(t));
+  ipc.handle('get-confetti', () => getConfetti());
+  ipc.handle('set-confetti', (_e, c: boolean) => setConfetti(c));
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,8 @@ const api = {
   setTextureEditor: (path: string) => invoke('set-texture-editor', path),
   getTheme: () => invoke('get-theme'),
   setTheme: (t: 'light' | 'dark' | 'system') => invoke('set-theme', t),
+  getConfetti: () => invoke('get-confetti'),
+  setConfetti: (c: boolean) => invoke('set-confetti', c),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -24,12 +24,17 @@ interface EditorViewProps {
   onSettings: () => void;
 }
 
-export default function EditorView({ projectPath, onBack, onSettings }: EditorViewProps) {
+export default function EditorView({
+  projectPath,
+  onBack,
+  onSettings,
+}: EditorViewProps) {
   const [selected, setSelected] = useState<string[]>([]);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
   const [summary, setSummary] = useState<ExportSummary | null>(null);
   const [selectorOpen, setSelectorOpen] = useState(false);
+  const [allowConfetti, setAllowConfetti] = useState(true);
   const confetti = useRef<((opts: unknown) => void) | null>(null);
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
 
@@ -40,6 +45,7 @@ export default function EditorView({ projectPath, onBack, onSettings }: EditorVi
         else if (l.length === 3) setLayout([l[0], l[1] + l[2]]);
       }
     });
+    window.electronAPI?.getConfetti().then((c) => setAllowConfetti(c));
   }, []);
 
   const handleExport = () => {
@@ -47,7 +53,10 @@ export default function EditorView({ projectPath, onBack, onSettings }: EditorVi
       ?.exportProject(projectPath)
       .then((s) => {
         if (s) setSummary(s);
-        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        if (
+          allowConfetti &&
+          !window.matchMedia('(prefers-reduced-motion: reduce)').matches
+        ) {
           confetti.current?.({
             particleCount: 150,
             spread: 70,

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -5,12 +5,14 @@ import { applyTheme, Theme } from '../utils/theme';
 export default function SettingsView() {
   const [editor, setEditor] = useState('');
   const [theme, setTheme] = useState<Theme>('system');
+  const [confetti, setConfetti] = useState(true);
 
   useEffect(() => {
     window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
     window.electronAPI?.getTheme().then((t) => {
       setTheme(t);
     });
+    window.electronAPI?.getConfetti().then((c) => setConfetti(c));
   }, []);
 
   const saveEditor = () => {
@@ -21,6 +23,12 @@ export default function SettingsView() {
     setTheme(t);
     await window.electronAPI?.setTheme(t);
     applyTheme(t);
+  };
+
+  const toggleConfetti = async () => {
+    const next = !confetti;
+    setConfetti(next);
+    await window.electronAPI?.setConfetti(next);
   };
   return (
     <section className="p-4" data-testid="settings-view">
@@ -63,6 +71,18 @@ export default function SettingsView() {
           <option value="dark">Dark</option>
           <option value="system">System</option>
         </select>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="cursor-pointer label" htmlFor="confetti-toggle">
+          <span className="label-text">Confetti effects</span>
+          <input
+            id="confetti-toggle"
+            type="checkbox"
+            className="toggle"
+            checked={confetti}
+            onChange={toggleConfetti}
+          />
+        </label>
       </div>
     </section>
   );

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -48,6 +48,8 @@ declare global {
       setTextureEditor: IpcInvoke<'set-texture-editor'>;
       getTheme: IpcInvoke<'get-theme'>;
       setTheme: IpcInvoke<'set-theme'>;
+      getConfetti: IpcInvoke<'get-confetti'>;
+      setConfetti: IpcInvoke<'set-confetti'>;
       openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -39,6 +39,8 @@ export interface IpcRequestMap {
   'set-texture-editor': [string];
   'get-theme': [];
   'set-theme': ['light' | 'dark' | 'system'];
+  'get-confetti': [];
+  'set-confetti': [boolean];
 }
 
 export interface IpcResponseMap {
@@ -77,6 +79,8 @@ export interface IpcResponseMap {
   'set-texture-editor': void;
   'get-theme': 'light' | 'dark' | 'system';
   'set-theme': void;
+  'get-confetti': boolean;
+  'set-confetti': void;
 }
 
 export interface IpcEventMap {


### PR DESCRIPTION
## Summary
- persist confetti setting via electron-store
- expose IPC hooks for confetti preference
- respect setting in EditorView when firing confetti
- toggle confetti effects in Settings
- test confetti persistence and new preference behavior

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684efb852a6c8331b92652e313c3176d