### PR TITLE
Add default export directory preference

### DIFF
--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -12,6 +12,8 @@ const getTheme = vi.fn();
 const setTheme = vi.fn();
 const getConfetti = vi.fn();
 const setConfetti = vi.fn();
+const getDefaultExportDir = vi.fn();
+const setDefaultExportDir = vi.fn();
 vi.mock('electron', () => ({
   shell: { openExternal: (openExternalMock = vi.fn()) },
 }));
@@ -28,6 +30,8 @@ describe('SettingsView', () => {
           setTheme: typeof setTheme;
           getConfetti: typeof getConfetti;
           setConfetti: typeof setConfetti;
+          getDefaultExportDir: typeof getDefaultExportDir;
+          setDefaultExportDir: typeof setDefaultExportDir;
         };
       }
     ).electronAPI = {
@@ -37,6 +41,8 @@ describe('SettingsView', () => {
       setTheme,
       getConfetti,
       setConfetti,
+      getDefaultExportDir,
+      setDefaultExportDir,
     } as never;
     getTextureEditor.mockResolvedValue('/usr/bin/gimp');
     setTextureEditor.mockResolvedValue(undefined);
@@ -44,6 +50,8 @@ describe('SettingsView', () => {
     setTheme.mockResolvedValue(undefined);
     getConfetti.mockResolvedValue(true);
     setConfetti.mockResolvedValue(undefined);
+    getDefaultExportDir.mockResolvedValue('/home');
+    setDefaultExportDir.mockResolvedValue(undefined);
   });
 
   it('renders placeholder heading', () => {
@@ -68,8 +76,18 @@ describe('SettingsView', () => {
     const input = await screen.findByLabelText('External texture editor');
     expect(input).toHaveValue('/usr/bin/gimp');
     fireEvent.change(input, { target: { value: '/opt/editor' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
     expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
+  });
+
+  it('loads and saves default export folder', async () => {
+    render(<SettingsView />);
+    const input = await screen.findByLabelText('Default export folder');
+    expect(input).toHaveValue('/home');
+    fireEvent.change(input, { target: { value: '/out' } });
+    const btn = screen.getAllByRole('button', { name: 'Save' })[1];
+    fireEvent.click(btn);
+    expect(setDefaultExportDir).toHaveBeenCalledWith('/out');
   });
 
   it('changes theme via dropdown', async () => {

--- a/__tests__/confettiPersistence.test.ts
+++ b/__tests__/confettiPersistence.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { setConfetti } from '../src/main/layout';
 
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+
 describe('confetti persistence', () => {
   it('persists across reloads', async () => {
     setConfetti(false);

--- a/__tests__/defaultExportDirPersistence.test.ts
+++ b/__tests__/defaultExportDirPersistence.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setDefaultExportDir } from '../src/main/layout';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+
+describe('default export dir persistence', () => {
+  it('persists across reloads', async () => {
+    setDefaultExportDir('/tmp');
+    vi.resetModules();
+    const { getDefaultExportDir } = await import('../src/main/layout');
+    expect(getDefaultExportDir()).toBe('/tmp');
+  });
+});

--- a/__tests__/exporter.test.ts
+++ b/__tests__/exporter.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
 import { exportPack } from '../src/main/exporter';
 import unzipper from 'unzipper';
 import os from 'os';

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi } from 'vitest';
 
 import { setTheme } from '../src/main/layout';
 
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+
 describe('theme persistence', () => {
   it('persists across reloads', async () => {
     setTheme('dark');

--- a/src/main/exporter.ts
+++ b/src/main/exporter.ts
@@ -7,6 +7,7 @@ import archiver from 'archiver';
 import { packFormatForVersion } from '../shared/packFormat';
 import type { IpcMain } from 'electron';
 import { dialog } from 'electron';
+import { getDefaultExportDir } from './layout';
 import { ProjectMetadataSchema } from '../shared/project';
 
 export interface ExportSummary {
@@ -106,6 +107,7 @@ export async function exportProjects(
 ): Promise<void> {
   const { canceled, filePaths } = await dialog.showOpenDialog({
     title: 'Select Export Folder',
+    defaultPath: getDefaultExportDir(),
     properties: ['openDirectory', 'createDirectory'],
   });
   if (canceled || filePaths.length === 0) return;
@@ -125,7 +127,10 @@ export function registerExportHandlers(ipc: IpcMain, baseDir: string) {
     async (_e, projectPath: string): Promise<ExportSummary | void> => {
       const { canceled, filePath } = await dialog.showSaveDialog({
         title: 'Export Pack',
-        defaultPath: `${projectPath}/pack.zip`,
+        defaultPath: path.join(
+          getDefaultExportDir(),
+          `${path.basename(projectPath)}.zip`
+        ),
         filters: [{ name: 'Zip Files', extensions: ['zip'] }],
       });
       if (canceled || !filePath) return;

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -1,4 +1,5 @@
 import type { IpcMain } from 'electron';
+import { app } from 'electron';
 import Store from 'electron-store';
 
 type ThemePref = 'light' | 'dark' | 'system';
@@ -8,12 +9,14 @@ const store = new Store<{
   textureEditor: string;
   theme: ThemePref;
   confetti: boolean;
+  defaultExportDir: string;
 }>({
   defaults: {
     editorLayout: [20, 80],
     textureEditor: '',
     theme: 'system',
     confetti: true,
+    defaultExportDir: app.getPath('downloads'),
   },
 });
 
@@ -49,6 +52,14 @@ export function setConfetti(flag: boolean): void {
   store.set('confetti', flag);
 }
 
+export function getDefaultExportDir(): string {
+  return store.get('defaultExportDir');
+}
+
+export function setDefaultExportDir(dir: string): void {
+  store.set('defaultExportDir', dir);
+}
+
 export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-editor-layout', () => getEditorLayout());
   ipc.handle('set-editor-layout', (_e, layout: number[]) =>
@@ -60,4 +71,8 @@ export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('set-theme', (_e, t: ThemePref) => setTheme(t));
   ipc.handle('get-confetti', () => getConfetti());
   ipc.handle('set-confetti', (_e, c: boolean) => setConfetti(c));
+  ipc.handle('get-default-export-dir', () => getDefaultExportDir());
+  ipc.handle('set-default-export-dir', (_e, d: string) =>
+    setDefaultExportDir(d)
+  );
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -71,6 +71,8 @@ const api = {
   setTheme: (t: 'light' | 'dark' | 'system') => invoke('set-theme', t),
   getConfetti: () => invoke('get-confetti'),
   setConfetti: (c: boolean) => invoke('set-confetti', c),
+  getDefaultExportDir: () => invoke('get-default-export-dir'),
+  setDefaultExportDir: (d: string) => invoke('set-default-export-dir', d),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -6,6 +6,7 @@ export default function SettingsView() {
   const [editor, setEditor] = useState('');
   const [theme, setTheme] = useState<Theme>('system');
   const [confetti, setConfetti] = useState(true);
+  const [exportDir, setExportDir] = useState('');
 
   useEffect(() => {
     window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
@@ -13,6 +14,7 @@ export default function SettingsView() {
       setTheme(t);
     });
     window.electronAPI?.getConfetti().then((c) => setConfetti(c));
+    window.electronAPI?.getDefaultExportDir().then((d) => setExportDir(d));
   }, []);
 
   const saveEditor = () => {
@@ -23,6 +25,10 @@ export default function SettingsView() {
     setTheme(t);
     await window.electronAPI?.setTheme(t);
     applyTheme(t);
+  };
+
+  const saveExportDir = () => {
+    window.electronAPI?.setDefaultExportDir(exportDir);
   };
 
   const toggleConfetti = async () => {
@@ -54,6 +60,21 @@ export default function SettingsView() {
           onChange={(e) => setEditor(e.target.value)}
         />
         <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
+          Save
+        </button>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="label" htmlFor="export-dir">
+          <span className="label-text">Default export folder</span>
+        </label>
+        <input
+          id="export-dir"
+          className="input input-bordered"
+          type="text"
+          value={exportDir}
+          onChange={(e) => setExportDir(e.target.value)}
+        />
+        <button className="btn btn-primary btn-sm mt-2" onClick={saveExportDir}>
           Save
         </button>
       </div>

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -50,6 +50,8 @@ declare global {
       setTheme: IpcInvoke<'set-theme'>;
       getConfetti: IpcInvoke<'get-confetti'>;
       setConfetti: IpcInvoke<'set-confetti'>;
+      getDefaultExportDir: IpcInvoke<'get-default-export-dir'>;
+      setDefaultExportDir: IpcInvoke<'set-default-export-dir'>;
       openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -41,6 +41,8 @@ export interface IpcRequestMap {
   'set-theme': ['light' | 'dark' | 'system'];
   'get-confetti': [];
   'set-confetti': [boolean];
+  'get-default-export-dir': [];
+  'set-default-export-dir': [string];
 }
 
 export interface IpcResponseMap {
@@ -81,6 +83,8 @@ export interface IpcResponseMap {
   'set-theme': void;
   'get-confetti': boolean;
   'set-confetti': void;
+  'get-default-export-dir': string;
+  'set-default-export-dir': void;
 }
 
 export interface IpcEventMap {


### PR DESCRIPTION
## Summary
- persist default export directory in the settings store
- expose `getDefaultExportDir` and `setDefaultExportDir` via IPC
- use configured directory when exporting packs
- allow changing the export folder in Settings
- add tests for new functionality

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684efe46ee8c833184d60b05c365c3f7