### PR TITLE
Add FilterBadge component

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -269,6 +269,7 @@ describe('AssetBrowser', () => {
     await screen.findAllByText('stone.png');
     const itemsChip = screen.getByText('Items');
     fireEvent.click(itemsChip);
+    expect(itemsChip).toHaveClass('badge-primary');
     expect(screen.queryByText('stone.png')).toBeNull();
     expect(screen.getAllByText('apple.png')[0]).toBeInTheDocument();
   });

--- a/__tests__/AssetSelector.filters.test.tsx
+++ b/__tests__/AssetSelector.filters.test.tsx
@@ -37,6 +37,7 @@ describe('AssetSelector filters', () => {
     ).toBeInTheDocument();
     const itemChip = screen.getByRole('button', { name: 'Items' });
     fireEvent.click(itemChip);
+    expect(itemChip).toHaveClass('badge-primary');
     expect(
       screen.queryByRole('button', { name: 'block/stone.png' })
     ).toBeNull();
@@ -47,5 +48,6 @@ describe('AssetSelector filters', () => {
     expect(
       screen.getByRole('button', { name: 'block/stone.png' })
     ).toBeInTheDocument();
+    expect(itemChip).not.toHaveClass('badge-primary');
   });
 });

--- a/__tests__/SearchToolbar.test.tsx
+++ b/__tests__/SearchToolbar.test.tsx
@@ -38,6 +38,7 @@ describe('SearchToolbar', () => {
       />
     );
     const chip = screen.getByRole('button', { name: '1.20' });
+    expect(chip).toHaveClass('badge-primary');
     fireEvent.click(chip);
     expect(toggle).toHaveBeenCalledWith('1.20');
     const btn = screen.getByRole('button', { name: 'Bulk Export' });
@@ -55,6 +56,9 @@ describe('SearchToolbar', () => {
         onBulkExport={bulk}
         disableExport={false}
       />
+    );
+    expect(screen.getByRole('button', { name: '1.20' })).not.toHaveClass(
+      'badge-primary'
     );
     fireEvent.click(screen.getByRole('button', { name: 'Bulk Export' }));
     expect(bulk).toHaveBeenCalled();

--- a/__tests__/daisy/input/FilterBadge.test.tsx
+++ b/__tests__/daisy/input/FilterBadge.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FilterBadge } from '../../../src/renderer/components/daisy/input';
+
+describe('FilterBadge', () => {
+  it('renders label and selected class', () => {
+    render(<FilterBadge label="Test" selected />);
+    const badge = screen.getByRole('button', { name: 'Test' });
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass('badge-primary');
+  });
+});

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -4,6 +4,7 @@ import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
 import FileTree from './FileTree';
+import { FilterBadge } from './daisy/input';
 
 interface Props {
   path: string;
@@ -143,18 +144,13 @@ const AssetBrowser: React.FC<Props> = ({
       </div>
       <div className="flex gap-1 mb-2">
         {FILTERS.map((f) => (
-          <span
+          <FilterBadge
             key={f}
-            role="button"
-            tabIndex={0}
+            label={f.charAt(0).toUpperCase() + f.slice(1)}
+            selected={filters.includes(f)}
             onClick={() => toggleFilter(f)}
             onKeyDown={(e) => e.key === 'Enter' && toggleFilter(f)}
-            className={`badge badge-outline cursor-pointer select-none ${
-              filters.includes(f) ? 'badge-primary' : ''
-            }`}
-          >
-            {f.charAt(0).toUpperCase() + f.slice(1)}
-          </span>
+          />
         ))}
       </div>
       {view === 'grid' ? (

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import TextureGrid, { TextureInfo } from './TextureGrid';
 import TextureTree from './TextureTree';
+import { FilterBadge } from './daisy/input';
 
 interface Props {
   path: string;
@@ -127,18 +128,13 @@ const AssetSelector: React.FC<Props> = ({
       </div>
       <div className="flex gap-1 mb-2">
         {FILTERS.map((f) => (
-          <span
+          <FilterBadge
             key={f}
-            role="button"
-            tabIndex={0}
+            label={f.charAt(0).toUpperCase() + f.slice(1)}
+            selected={filters.includes(f)}
             onClick={() => toggleFilter(f)}
             onKeyDown={(e) => e.key === 'Enter' && toggleFilter(f)}
-            className={`badge badge-outline cursor-pointer select-none ${
-              filters.includes(f) ? 'badge-primary' : ''
-            }`}
-          >
-            {f.charAt(0).toUpperCase() + f.slice(1)}
-          </span>
+          />
         ))}
       </div>
       {view === 'grid' ? (

--- a/src/renderer/components/daisy/input/FilterBadge.tsx
+++ b/src/renderer/components/daisy/input/FilterBadge.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export interface FilterBadgeProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  label: string;
+  selected?: boolean;
+}
+
+export default function FilterBadge({
+  label,
+  selected = false,
+  className = '',
+  ...rest
+}: FilterBadgeProps) {
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      className={`badge badge-outline cursor-pointer select-none ${
+        selected ? 'badge-primary' : ''
+      } ${className}`.trim()}
+      {...rest}
+    >
+      {label}
+    </span>
+  );
+}

--- a/src/renderer/components/daisy/input/index.ts
+++ b/src/renderer/components/daisy/input/index.ts
@@ -12,3 +12,4 @@ export { default as InputField } from './InputField';
 export { default as Textarea } from './Textarea';
 export { default as Toggle } from './Toggle';
 export { default as Validator } from './Validator';
+export { default as FilterBadge } from './FilterBadge';

--- a/src/renderer/components/project/SearchToolbar.tsx
+++ b/src/renderer/components/project/SearchToolbar.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FilterBadge } from '../daisy/input';
 export default function SearchToolbar({
   search,
   onSearchChange,
@@ -26,18 +27,13 @@ export default function SearchToolbar({
       />
       <div className="flex gap-1">
         {versions.map((v) => (
-          <span
+          <FilterBadge
             key={v}
-            role="button"
-            tabIndex={0}
+            label={v}
+            selected={activeVersion === v}
             onClick={() => onToggleVersion(v)}
             onKeyDown={(e) => e.key === 'Enter' && onToggleVersion(v)}
-            className={`badge badge-outline cursor-pointer select-none ${
-              activeVersion === v ? 'badge-primary' : ''
-            }`}
-          >
-            {v}
-          </span>
+          />
         ))}
       </div>
       <button


### PR DESCRIPTION
## Summary
- add `FilterBadge` component
- use it in `AssetBrowser`, `AssetSelector` and `SearchToolbar`
- export from input index
- add unit test for `FilterBadge`
- update filter tests to check selected badge state

## Testing
- `npm run format`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f61438ffc8331965b227075a14d88