### PR TITLE
Refactor renderer forms to daisy components

### DIFF
--- a/__tests__/daisy/actions/Modal.test.tsx
+++ b/__tests__/daisy/actions/Modal.test.tsx
@@ -4,12 +4,12 @@ import { render, screen } from '@testing-library/react';
 import Modal from '../../../src/renderer/components/daisy/actions/Modal';
 
 describe('daisy Modal', () => {
-  it('renders modal when open', () => {
+  it('renders modal when open and uses custom test id', () => {
     render(
-      <Modal open>
+      <Modal open testId="custom">
         <p>Content</p>
       </Modal>
     );
-    expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('custom')).toBeInTheDocument();
   });
 });

--- a/__tests__/daisy/display/Accordion.test.tsx
+++ b/__tests__/daisy/display/Accordion.test.tsx
@@ -4,8 +4,18 @@ import { render, screen } from '@testing-library/react';
 import Accordion from '../../../src/renderer/components/daisy/display/Accordion';
 
 describe('Accordion', () => {
-  it('renders', () => {
-    render(<Accordion title="Title">Content</Accordion>);
-    expect(screen.getByTestId('accordion')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(
+      <Accordion title="Title" className="extra" defaultOpen>
+        Content
+      </Accordion>
+    );
+    const acc = screen.getByTestId('accordion');
+    expect(acc).toBeInTheDocument();
+    expect(acc).toHaveClass('extra');
+    const checkbox = acc.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
   });
 });

--- a/__tests__/daisy/display/Collapse.test.tsx
+++ b/__tests__/daisy/display/Collapse.test.tsx
@@ -4,8 +4,18 @@ import { render, screen } from '@testing-library/react';
 import Collapse from '../../../src/renderer/components/daisy/display/Collapse';
 
 describe('Collapse', () => {
-  it('renders', () => {
-    render(<Collapse title="Title">Content</Collapse>);
-    expect(screen.getByTestId('collapse')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(
+      <Collapse title="Title" className="extra" defaultOpen>
+        Content
+      </Collapse>
+    );
+    const col = screen.getByTestId('collapse');
+    expect(col).toBeInTheDocument();
+    expect(col).toHaveClass('extra');
+    const checkbox = col.querySelector(
+      'input[type="checkbox"]'
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
   });
 });

--- a/__tests__/daisy/input/InputField.test.tsx
+++ b/__tests__/daisy/input/InputField.test.tsx
@@ -4,8 +4,10 @@ import { describe, it, expect } from 'vitest';
 import { InputField } from '../../../src/renderer/components/daisy/input';
 
 describe('InputField', () => {
-  it('renders', () => {
-    render(<InputField data-testid="inp" />);
-    expect(screen.getByTestId('inp')).toBeInTheDocument();
+  it('renders and accepts className', () => {
+    render(<InputField data-testid="inp" className="extra" />);
+    const el = screen.getByTestId('inp');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Range.test.tsx
+++ b/__tests__/daisy/input/Range.test.tsx
@@ -4,8 +4,10 @@ import { describe, it, expect } from 'vitest';
 import { Range } from '../../../src/renderer/components/daisy/input';
 
 describe('Range', () => {
-  it('renders', () => {
-    render(<Range data-testid="rng" />);
-    expect(screen.getByTestId('rng')).toBeInTheDocument();
+  it('renders and accepts className', () => {
+    render(<Range data-testid="rng" className="extra" />);
+    const el = screen.getByTestId('rng');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Select.test.tsx
+++ b/__tests__/daisy/input/Select.test.tsx
@@ -4,12 +4,14 @@ import { describe, it, expect } from 'vitest';
 import { Select } from '../../../src/renderer/components/daisy/input';
 
 describe('Select', () => {
-  it('renders', () => {
+  it('renders and accepts className', () => {
     render(
-      <Select data-testid="sel">
+      <Select data-testid="sel" className="extra">
         <option>1</option>
       </Select>
     );
-    expect(screen.getByTestId('sel')).toBeInTheDocument();
+    const el = screen.getByTestId('sel');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Textarea.test.tsx
+++ b/__tests__/daisy/input/Textarea.test.tsx
@@ -4,8 +4,10 @@ import { describe, it, expect } from 'vitest';
 import { Textarea } from '../../../src/renderer/components/daisy/input';
 
 describe('Textarea', () => {
-  it('renders', () => {
-    render(<Textarea data-testid="ta" />);
-    expect(screen.getByTestId('ta')).toBeInTheDocument();
+  it('renders and accepts className', () => {
+    render(<Textarea data-testid="ta" className="extra" />);
+    const el = screen.getByTestId('ta');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/useExternalLink.test.tsx
+++ b/__tests__/useExternalLink.test.tsx
@@ -7,7 +7,9 @@ import ToastProvider from '../src/renderer/components/ToastProvider';
 vi.useFakeTimers();
 // eslint-disable-next-line no-var
 var openExternal: ReturnType<typeof vi.fn>;
-vi.mock('electron', () => ({ shell: { openExternal: (openExternal = vi.fn()) } }));
+vi.mock('electron', () => ({
+  shell: { openExternal: (openExternal = vi.fn()) },
+}));
 
 beforeEach(() => {
   openExternal.mockResolvedValue(undefined);

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -28,14 +28,18 @@ export default function App() {
   const toSettings = () => {
     setProjectPath(null);
     setView('settings');
-  }
+  };
 
   let content: React.ReactNode = null;
   switch (view) {
     case 'editor':
       content = projectPath ? (
         <Suspense fallback={<Spinner />}>
-          <EditorView projectPath={projectPath} onBack={toManager} onSettings={toSettings} />
+          <EditorView
+            projectPath={projectPath}
+            onBack={toManager}
+            onSettings={toSettings}
+          />
         </Suspense>
       ) : null;
       break;

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -4,7 +4,9 @@ import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
 import FileTree from './FileTree';
-import { FilterBadge } from './daisy/input';
+import { FilterBadge, InputField, Range } from './daisy/input';
+import { Button } from './daisy/actions';
+import { Accordion } from './daisy/display';
 
 interface Props {
   path: string;
@@ -110,14 +112,13 @@ const AssetBrowser: React.FC<Props> = ({
       tabIndex={0}
     >
       <div className="flex items-center gap-2 mb-2">
-        <input
-          className="border px-1 flex-1"
+        <InputField
+          className="flex-1"
           placeholder="Search files"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-        <input
-          type="range"
+        <Range
           min={24}
           max={128}
           step={1}
@@ -125,21 +126,21 @@ const AssetBrowser: React.FC<Props> = ({
           aria-label="Zoom"
           data-testid="zoom-range"
           onChange={(e) => setZoom(Number(e.target.value))}
-          className="range range-xs w-32"
+          className="range-xs w-32"
         />
         <div className="btn-group">
-          <button
-            className={`btn btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
+          <Button
+            className={`btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
             onClick={() => setView('grid')}
           >
             Grid
-          </button>
-          <button
-            className={`btn btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
+          </Button>
+          <Button
+            className={`btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
             onClick={() => setView('tree')}
           >
             Tree
-          </button>
+          </Button>
         </div>
       </div>
       <div className="flex gap-1 mb-2">
@@ -159,30 +160,24 @@ const AssetBrowser: React.FC<Props> = ({
             const list = categories[key];
             if (list.length === 0) return null;
             return (
-              <div className="collapse collapse-arrow mb-2" key={key}>
-                <input type="checkbox" defaultChecked />
-                <div className="collapse-title font-medium capitalize">
-                  {key}
+              <Accordion key={key} title={key} className="mb-2" defaultOpen>
+                <div className="grid grid-cols-6 gap-2">
+                  {list.map((f) => (
+                    <AssetBrowserItem
+                      key={f}
+                      projectPath={projectPath}
+                      file={f}
+                      selected={selected}
+                      setSelected={setSelected}
+                      noExport={noExport}
+                      toggleNoExport={toggleNoExport}
+                      deleteFiles={deleteFiles}
+                      openRename={(file) => setRenameTarget(file)}
+                      zoom={zoom}
+                    />
+                  ))}
                 </div>
-                <div className="collapse-content">
-                  <div className="grid grid-cols-6 gap-2">
-                    {list.map((f) => (
-                      <AssetBrowserItem
-                        key={f}
-                        projectPath={projectPath}
-                        file={f}
-                        selected={selected}
-                        setSelected={setSelected}
-                        noExport={noExport}
-                        toggleNoExport={toggleNoExport}
-                        deleteFiles={deleteFiles}
-                        openRename={(file) => setRenameTarget(file)}
-                        zoom={zoom}
-                      />
-                    ))}
-                  </div>
-                </div>
-              </div>
+              </Accordion>
             );
           }
         )

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -3,6 +3,8 @@ import path from 'path';
 import { Oval } from 'react-loader-spinner';
 import { useToast } from './ToastProvider';
 import Spinner from './Spinner';
+import { Textarea } from './daisy/input';
+import { Button } from './daisy/actions';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 const TextureLab = lazy(() => import('./TextureLab'));
@@ -78,39 +80,36 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
         <h3 className="font-bold mb-1 break-all">{asset}</h3>
         {count === 1 && isText && (
           <>
-            <textarea
-              className="textarea textarea-bordered w-full mb-2"
+            <Textarea
+              className="textarea-bordered w-full mb-2"
               value={text}
               onChange={(e) => setText(e.target.value)}
             />
             {error && <div className="text-error mb-1">{error}</div>}
             <div className="flex gap-2">
-              <button className="btn btn-primary btn-sm" onClick={handleSave}>
+              <Button className="btn-primary btn-sm" onClick={handleSave}>
                 Save
-              </button>
-              <button
-                className="btn btn-secondary btn-sm"
-                onClick={handleReset}
-              >
+              </Button>
+              <Button className="btn-secondary btn-sm" onClick={handleReset}>
                 Reset
-              </button>
+              </Button>
             </div>
           </>
         )}
         {isPng && count === 1 && (
           <div className="flex flex-col gap-2 mt-2">
-            <button
-              className="btn btn-secondary btn-sm"
+            <Button
+              className="btn-secondary btn-sm"
               onClick={() => setLab(true)}
             >
               Open Texture Lab
-            </button>
-            <button
-              className="btn btn-secondary btn-sm"
+            </Button>
+            <Button
+              className="btn-secondary btn-sm"
               onClick={() => window.electronAPI?.openExternalEditor(full)}
             >
               Edit Externally
-            </button>
+            </Button>
           </div>
         )}
         {lab && (

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import TextureGrid, { TextureInfo } from './TextureGrid';
 import TextureTree from './TextureTree';
-import { FilterBadge } from './daisy/input';
+import { FilterBadge, InputField, Range } from './daisy/input';
+import { Button } from './daisy/actions';
+import { Accordion } from './daisy/display';
 
 interface Props {
   path: string;
@@ -94,14 +96,13 @@ const AssetSelector: React.FC<Props> = ({
   return (
     <div className="mb-4">
       <div className="flex items-center gap-2 mb-2">
-        <input
-          className="border px-1 flex-1"
+        <InputField
+          className="flex-1"
           placeholder="Search texture"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
-        <input
-          type="range"
+        <Range
           min={24}
           max={128}
           step={1}
@@ -109,21 +110,21 @@ const AssetSelector: React.FC<Props> = ({
           aria-label="Zoom"
           data-testid="zoom-range"
           onChange={(e) => setZoom(Number(e.target.value))}
-          className="range range-xs w-32"
+          className="range-xs w-32"
         />
         <div className="btn-group">
-          <button
-            className={`btn btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
+          <Button
+            className={`btn-xs ${view === 'grid' ? 'btn-primary' : ''}`}
             onClick={() => setView('grid')}
           >
             Grid
-          </button>
-          <button
-            className={`btn btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
+          </Button>
+          <Button
+            className={`btn-xs ${view === 'tree' ? 'btn-primary' : ''}`}
             onClick={() => setView('tree')}
           >
             Tree
-          </button>
+          </Button>
         </div>
       </div>
       <div className="flex gap-1 mb-2">
@@ -143,20 +144,14 @@ const AssetSelector: React.FC<Props> = ({
             const list = categories[key];
             if (list.length === 0) return null;
             return (
-              <div className="collapse collapse-arrow mb-2" key={key}>
-                <input type="checkbox" defaultChecked />
-                <div className="collapse-title font-medium capitalize">
-                  {key}
-                </div>
-                <div className="collapse-content">
-                  <TextureGrid
-                    testId="texture-grid"
-                    textures={list}
-                    zoom={zoom}
-                    onSelect={handleSelect}
-                  />
-                </div>
-              </div>
+              <Accordion key={key} title={key} className="mb-2" defaultOpen>
+                <TextureGrid
+                  testId="texture-grid"
+                  textures={list}
+                  zoom={zoom}
+                  onSelect={handleSelect}
+                />
+              </Accordion>
             );
           }
         )

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TextureThumb from './TextureThumb';
+import { Button } from './daisy/actions';
 
 interface Props {
   projectPath: string;
@@ -12,12 +13,12 @@ export default function AssetSelectorInfoPanel({ projectPath, asset }: Props) {
     <div className="p-2" data-testid="selector-info">
       <TextureThumb texture={asset} protocol="texture" alt={asset} size={64} />
       <p className="break-all text-sm">{asset}</p>
-      <button
-        className="btn btn-primary btn-sm mt-2"
+      <Button
+        className="btn-primary btn-sm mt-2"
         onClick={() => window.electronAPI?.addTexture(projectPath, asset)}
       >
         Add
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/renderer/components/ConfirmModal.tsx
+++ b/src/renderer/components/ConfirmModal.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
 
 export default function ConfirmModal({
   title,
@@ -19,12 +19,12 @@ export default function ConfirmModal({
       <h3 className="font-bold text-lg mb-2">{title}</h3>
       <div>{message}</div>
       <div className="modal-action">
-        <button className="btn" onClick={onCancel}>
+        <Button type="button" onClick={onCancel}>
           Cancel
-        </button>
-        <button className="btn btn-primary" onClick={onConfirm}>
+        </Button>
+        <Button className="btn-primary" onClick={onConfirm}>
           {confirmText}
-        </button>
+        </Button>
       </div>
     </Modal>
   );

--- a/src/renderer/components/ExportSummaryModal.tsx
+++ b/src/renderer/components/ExportSummaryModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ExportSummary } from '../../main/exporter';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
 
 export default function ExportSummaryModal({
   summary,
@@ -28,9 +28,7 @@ export default function ExportSummaryModal({
         </ul>
       )}
       <div className="modal-action">
-        <button className="btn" onClick={onClose}>
-          Close
-        </button>
+        <Button onClick={onClose}>Close</Button>
       </div>
     </Modal>
   );

--- a/src/renderer/components/Navbar.tsx
+++ b/src/renderer/components/Navbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { toggleTheme } from '../utils/theme';
+import { Button } from './daisy/actions';
 
 export default function Navbar() {
   return (
@@ -7,13 +8,13 @@ export default function Navbar() {
       <div className="flex-1 px-2 font-display text-lg" data-testid="app-title">
         Minecraft Resource Packer
       </div>
-      <button
-        className="btn btn-square btn-ghost"
+      <Button
+        className="btn-square btn-ghost"
         onClick={toggleTheme}
         aria-label="Toggle theme"
       >
         🌓
-      </button>
+      </Button>
     </header>
   );
 }

--- a/src/renderer/components/PackIconEditor.tsx
+++ b/src/renderer/components/PackIconEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import path from 'path';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
+import { InputField, FileInput } from './daisy/input';
 
 export default function PackIconEditor({
   project,
@@ -26,33 +27,31 @@ export default function PackIconEditor({
         <h3 className="font-bold text-lg">Pack Icon</h3>
         <label className="flex items-center gap-2">
           Border
-          <input
+          <InputField
             type="color"
             value={border}
             data-testid="border-input"
             onChange={(e) => setBorder(e.target.value)}
           />
         </label>
-        <input
-          type="file"
+        <FileInput
           accept="image/png"
           data-testid="file-input"
           onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
         />
         <div className="modal-action">
-          <button
+          <Button
             type="button"
-            className="btn"
             onClick={() => window.electronAPI?.randomizeIcon(project)}
           >
             Randomise
-          </button>
-          <button type="button" className="btn" onClick={onClose}>
+          </Button>
+          <Button type="button" onClick={onClose}>
             Cancel
-          </button>
-          <button type="submit" className="btn btn-primary">
+          </Button>
+          <Button type="submit" className="btn-primary">
             Save
-          </button>
+          </Button>
         </div>
       </form>
     </Modal>

--- a/src/renderer/components/PackMetaModal.tsx
+++ b/src/renderer/components/PackMetaModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { PackMeta } from '../../main/projects';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
+import { InputField, Textarea } from './daisy/input';
 
 export default function PackMetaModal({
   project,
@@ -35,38 +36,38 @@ export default function PackMetaModal({
         }}
       >
         <h3 className="font-bold text-lg">Edit Metadata</h3>
-        <textarea
-          className="textarea textarea-bordered"
+        <Textarea
+          className="textarea-bordered"
           value={desc}
           onChange={(e) => setDesc(e.target.value)}
           placeholder="Description"
         />
-        <input
-          className="input input-bordered"
+        <InputField
+          className="input-bordered"
           value={author}
           onChange={(e) => setAuthor(e.target.value)}
           placeholder="Author"
         />
-        <textarea
-          className="textarea textarea-bordered"
+        <Textarea
+          className="textarea-bordered"
           value={urls}
           onChange={(e) => setUrls(e.target.value)}
           placeholder="URLs (one per line)"
         />
         <div className="modal-action">
-          <button
+          <Button
             type="button"
-            className="btn btn-secondary"
+            className="btn-secondary"
             onClick={() => window.electronAPI?.randomizeIcon(project)}
           >
             Randomize Icon
-          </button>
-          <button type="button" className="btn" onClick={onCancel}>
+          </Button>
+          <Button type="button" onClick={onCancel}>
             Cancel
-          </button>
-          <button type="submit" className="btn btn-primary">
+          </Button>
+          <Button type="submit" className="btn-primary">
             Save
-          </button>
+          </Button>
         </div>
       </form>
     </Modal>

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import path from 'path';
 import type { PackMeta } from '../../main/projects';
+import { Button } from './daisy/actions';
 
 interface Props {
   projectPath: string;
@@ -13,7 +14,7 @@ export default function ProjectInfoPanel({
   projectPath,
   onExport,
   onBack,
-  onSettings
+  onSettings,
 }: Props) {
   const [meta, setMeta] = useState<PackMeta | null>(null);
   const name = path.basename(projectPath);
@@ -25,12 +26,12 @@ export default function ProjectInfoPanel({
   return (
     <div className="card bg-base-100 shadow" data-testid="project-info">
       <div className="card-body items-center gap-2 p-2">
-        <button className="link link-primary self-start" onClick={onBack}>
+        <Button className="link link-primary self-start" onClick={onBack}>
           Back to Projects
-        </button>
-        <button className="link link-primary self-start" onClick={onSettings}>
+        </Button>
+        <Button className="link link-primary self-start" onClick={onSettings}>
           Settings
-        </button>
+        </Button>
         <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
         <h2 className="card-title text-lg font-display">{name}</h2>
         <p className="text-xs break-all">{projectPath}</p>
@@ -38,15 +39,15 @@ export default function ProjectInfoPanel({
           {meta?.description}
         </p>
         <div className="card-actions justify-end w-full mt-auto">
-          <button
-            className="btn btn-neutral btn-sm"
+          <Button
+            className="btn-neutral btn-sm"
             onClick={() => window.electronAPI?.openInFolder(projectPath)}
           >
             Open Folder
-          </button>
-          <button className="btn btn-accent btn-sm" onClick={onExport}>
+          </Button>
+          <Button className="btn-accent btn-sm" onClick={onExport}>
             Export Pack
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/renderer/components/RenameModal.tsx
+++ b/src/renderer/components/RenameModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
+import { InputField } from './daisy/input';
 
 export default function RenameModal({
   current,
@@ -30,19 +31,19 @@ export default function RenameModal({
         }}
       >
         <h3 className="font-bold text-lg">{title}</h3>
-        <input
+        <InputField
           ref={inputRef}
-          className="input input-bordered"
+          className="input-bordered"
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
         <div className="modal-action">
-          <button type="button" className="btn" onClick={onCancel}>
+          <Button type="button" onClick={onCancel}>
             Cancel
-          </button>
-          <button type="submit" className="btn btn-primary">
+          </Button>
+          <Button type="submit" className="btn-primary">
             {confirmText}
-          </button>
+          </Button>
         </div>
       </form>
     </Modal>

--- a/src/renderer/components/TextureGrid.tsx
+++ b/src/renderer/components/TextureGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { FixedSizeGrid as Grid, GridChildComponentProps } from 'react-window';
+import { Button } from './daisy/actions';
 import { formatTextureName } from '../utils/textureNames';
 
 export interface TextureInfo {
@@ -37,7 +38,7 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
         className="text-center tooltip"
         data-tip={`${formatted} \n${tex.name}`}
       >
-        <button
+        <Button
           aria-label={tex.name}
           onClick={() => data.onSelect(tex.name)}
           className="p-1 hover:ring ring-accent rounded"
@@ -51,7 +52,7 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
               imageRendering: 'pixelated',
             }}
           />
-        </button>
+        </Button>
         <div className="text-xs leading-tight">
           <div>{formatted}</div>
           <div className="opacity-50">{tex.name}</div>

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -2,7 +2,8 @@ import React, { useState } from 'react';
 import path from 'path';
 import Spinner from './Spinner';
 import type { TextureEditOptions } from '../../shared/texture';
-import { Modal } from './daisy/actions';
+import { Modal, Button } from './daisy/actions';
+import { Range, Select, Checkbox } from './daisy/input';
 
 export default function TextureLab({
   file,
@@ -62,19 +63,18 @@ export default function TextureLab({
         </div>
         <label className="flex items-center gap-2">
           Hue
-          <input
-            type="range"
+          <Range
             min={-180}
             max={180}
             value={hue}
             onChange={(e) => setHue(Number(e.target.value))}
-            className="range range-xs flex-1"
+            className="range-xs flex-1"
           />
         </label>
         <label className="flex items-center gap-2">
           Rotation
-          <select
-            className="select select-sm"
+          <Select
+            className="select-sm"
             value={rotate}
             onChange={(e) => setRotate(Number(e.target.value))}
           >
@@ -82,12 +82,10 @@ export default function TextureLab({
             <option value={90}>90°</option>
             <option value={180}>180°</option>
             <option value={270}>270°</option>
-          </select>
+          </Select>
         </label>
         <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            className="checkbox"
+          <Checkbox
             checked={gray}
             onChange={(e) => setGray(e.target.checked)}
           />
@@ -95,35 +93,33 @@ export default function TextureLab({
         </label>
         <label className="flex items-center gap-2">
           Saturation
-          <input
-            type="range"
+          <Range
             min={0}
             max={2}
             step={0.1}
             value={sat}
             onChange={(e) => setSat(Number(e.target.value))}
-            className="range range-xs flex-1"
+            className="range-xs flex-1"
           />
         </label>
         <label className="flex items-center gap-2">
           Brightness
-          <input
-            type="range"
+          <Range
             min={0}
             max={2}
             step={0.1}
             value={bright}
             onChange={(e) => setBright(Number(e.target.value))}
-            className="range range-xs flex-1"
+            className="range-xs flex-1"
           />
         </label>
         <div className="modal-action">
-          <button type="button" className="btn" onClick={onClose}>
+          <Button type="button" onClick={onClose}>
             Close
-          </button>
-          <button type="submit" className="btn btn-primary" disabled={busy}>
+          </Button>
+          <Button type="submit" className="btn-primary" disabled={busy}>
             Apply
-          </button>
+          </Button>
         </div>
         {busy && <Spinner />}
       </form>

--- a/src/renderer/components/daisy/actions/Modal.tsx
+++ b/src/renderer/components/daisy/actions/Modal.tsx
@@ -4,16 +4,18 @@ interface ModalProps {
   open?: boolean;
   children: React.ReactNode;
   className?: string;
+  testId?: string;
 }
 
 export default function Modal({
   open = false,
   children,
   className = '',
+  testId = 'daisy-modal',
 }: ModalProps) {
   if (!open) return null;
   return (
-    <dialog className="modal modal-open" data-testid="daisy-modal">
+    <dialog className="modal modal-open" data-testid={testId}>
       <div className={`modal-box ${className}`.trim()}>{children}</div>
     </dialog>
   );

--- a/src/renderer/components/daisy/display/Accordion.tsx
+++ b/src/renderer/components/daisy/display/Accordion.tsx
@@ -3,15 +3,22 @@ import React from 'react';
 interface AccordionProps {
   title: React.ReactNode;
   children: React.ReactNode;
+  className?: string;
+  defaultOpen?: boolean;
 }
 
-export default function Accordion({ title, children }: AccordionProps) {
+export default function Accordion({
+  title,
+  children,
+  className = '',
+  defaultOpen = false,
+}: AccordionProps) {
   return (
     <div
-      className="collapse collapse-arrow rounded-box border border-base-300"
+      className={`collapse collapse-arrow rounded-box border border-base-300 ${className}`.trim()}
       data-testid="accordion"
     >
-      <input type="checkbox" />
+      <input type="checkbox" defaultChecked={defaultOpen} />
       <div className="collapse-title text-lg font-medium">{title}</div>
       <div className="collapse-content">{children}</div>
     </div>

--- a/src/renderer/components/daisy/display/Collapse.tsx
+++ b/src/renderer/components/daisy/display/Collapse.tsx
@@ -3,15 +3,22 @@ import React from 'react';
 interface CollapseProps {
   title: React.ReactNode;
   children: React.ReactNode;
+  className?: string;
+  defaultOpen?: boolean;
 }
 
-export default function Collapse({ title, children }: CollapseProps) {
+export default function Collapse({
+  title,
+  children,
+  className = '',
+  defaultOpen = false,
+}: CollapseProps) {
   return (
     <div
-      className="collapse rounded-box border border-base-300"
+      className={`collapse rounded-box border border-base-300 ${className}`.trim()}
       data-testid="collapse"
     >
-      <input type="checkbox" />
+      <input type="checkbox" defaultChecked={defaultOpen} />
       <div className="collapse-title text-lg font-medium">{title}</div>
       <div className="collapse-content">{children}</div>
     </div>

--- a/src/renderer/components/daisy/input/InputField.tsx
+++ b/src/renderer/components/daisy/input/InputField.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-export default function InputField(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input className="input input-bordered" {...props} />;
+export default function InputField({
+  className = '',
+  ...rest
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input className={`input input-bordered ${className}`.trim()} {...rest} />
+  );
 }

--- a/src/renderer/components/daisy/input/Range.tsx
+++ b/src/renderer/components/daisy/input/Range.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 
-export default function Range(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input type="range" className="range" {...props} />;
+export default function Range({
+  className = '',
+  ...rest
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <input type="range" className={`range ${className}`.trim()} {...rest} />
+  );
 }

--- a/src/renderer/components/daisy/input/Select.tsx
+++ b/src/renderer/components/daisy/input/Select.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 
 export default function Select({
   children,
-  ...props
+  className = '',
+  ...rest
 }: React.SelectHTMLAttributes<HTMLSelectElement>) {
   return (
-    <select className="select" {...props}>
+    <select className={`select ${className}`.trim()} {...rest}>
       {children}
     </select>
   );

--- a/src/renderer/components/daisy/input/Textarea.tsx
+++ b/src/renderer/components/daisy/input/Textarea.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-export default function Textarea(
-  props: React.TextareaHTMLAttributes<HTMLTextAreaElement>
-) {
-  return <textarea className="textarea" {...props} />;
+export default function Textarea({
+  className = '',
+  ...rest
+}: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+  return <textarea className={`textarea ${className}`.trim()} {...rest} />;
 }

--- a/src/renderer/components/file/AssetContextMenu.tsx
+++ b/src/renderer/components/file/AssetContextMenu.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Button } from '../daisy/actions';
+import { Checkbox } from '../daisy/input';
 
 interface Props {
   filePath: string;
@@ -32,43 +34,43 @@ export default function AssetContextMenu({
       role="menu"
     >
       <li>
-        <button
+        <Button
           ref={firstItemRef}
           role="menuitem"
           onClick={() => onReveal(filePath)}
         >
           Reveal
-        </button>
+        </Button>
       </li>
       <li>
-        <button role="menuitem" onClick={() => onOpen(filePath)}>
+        <Button role="menuitem" onClick={() => onOpen(filePath)}>
           Open
-        </button>
+        </Button>
       </li>
       <li>
-        <button
+        <Button
           role="menuitem"
           onClick={() => onRename(filePath)}
           disabled={selectionCount > 1}
         >
           Rename
-        </button>
+        </Button>
       </li>
       <li>
         <label className="flex gap-2 items-center cursor-pointer px-2">
           <span>No Export</span>
-          <input
+          <Checkbox
             type="checkbox"
-            className="toggle toggle-sm"
+            className="toggle-sm"
             checked={noExportChecked}
             onChange={(e) => onToggleNoExport(e.target.checked)}
           />
         </label>
       </li>
       <li>
-        <button role="menuitem" onClick={() => onDelete(filePath)}>
+        <Button role="menuitem" onClick={() => onDelete(filePath)}>
           {selectionCount > 1 ? 'Delete Selected' : 'Delete'}
-        </button>
+        </Button>
       </li>
     </ul>
   );

--- a/src/renderer/components/project/ProjectForm.tsx
+++ b/src/renderer/components/project/ProjectForm.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import { generateProjectName } from '../../utils/names';
+import { InputField, Select } from '../daisy/input';
+import { Button } from '../daisy/actions';
 
 export default function ProjectForm({
   versions,
@@ -23,14 +25,14 @@ export default function ProjectForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
-      <input
-        className="input input-bordered input-sm"
+      <InputField
+        className="input-sm"
         value={name}
         onChange={(e) => setName(e.target.value)}
         placeholder="Name"
       />
-      <select
-        className="select select-bordered select-sm"
+      <Select
+        className="select-bordered select-sm"
         value={version}
         onChange={(e) => setVersion(e.target.value)}
       >
@@ -42,17 +44,13 @@ export default function ProjectForm({
             {v}
           </option>
         ))}
-      </select>
-      <button className="btn btn-primary btn-sm" type="submit">
+      </Select>
+      <Button className="btn-primary btn-sm" type="submit">
         Create
-      </button>
-      <button
-        type="button"
-        onClick={onImport}
-        className="btn btn-secondary btn-sm"
-      >
+      </Button>
+      <Button type="button" onClick={onImport} className="btn-secondary btn-sm">
         Import
-      </button>
+      </Button>
     </form>
   );
 }

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Checkbox } from '../daisy/input';
+import { Button } from '../daisy/actions';
 
 export interface ProjectInfo {
   name: string;
@@ -37,13 +39,12 @@ export default function ProjectTable({
         <thead>
           <tr>
             <th>
-              <input
-                type="checkbox"
+              <Checkbox
                 aria-label="Select all"
                 checked={allSelected}
                 onClick={(e) => e.stopPropagation()}
                 onChange={(e) => onSelectAll(e.target.checked)}
-                className="checkbox checkbox-sm"
+                className="checkbox-sm"
               />
             </th>
             <th onClick={() => onSort('name')} className="cursor-pointer">
@@ -75,8 +76,7 @@ export default function ProjectTable({
               className="cursor-pointer"
             >
               <td>
-                <input
-                  type="checkbox"
+                <Checkbox
                   aria-label={`Select ${p.name}`}
                   checked={selected.has(p.name)}
                   onClick={(e) => e.stopPropagation()}
@@ -84,7 +84,7 @@ export default function ProjectTable({
                     e.stopPropagation();
                     onSelect(p.name, e.target.checked);
                   }}
-                  className="checkbox checkbox-sm"
+                  className="checkbox-sm"
                 />
               </td>
               <td>{p.name}</td>
@@ -92,33 +92,33 @@ export default function ProjectTable({
               <td>{p.assets}</td>
               <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
               <td className="flex gap-1">
-                <button
-                  className="btn btn-accent btn-sm"
+                <Button
+                  className="btn-accent btn-sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     onOpen(p.name);
                   }}
                 >
                   Open
-                </button>
-                <button
-                  className="btn btn-info btn-sm"
+                </Button>
+                <Button
+                  className="btn-info btn-sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDuplicate(p.name);
                   }}
                 >
                   Duplicate
-                </button>
-                <button
-                  className="btn btn-error btn-sm"
+                </Button>
+                <Button
+                  className="btn-error btn-sm"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDelete(p.name);
                   }}
                 >
                   Delete
-                </button>
+                </Button>
               </td>
             </tr>
           ))}

--- a/src/renderer/components/project/SearchToolbar.tsx
+++ b/src/renderer/components/project/SearchToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { FilterBadge } from '../daisy/input';
+import { FilterBadge, InputField } from '../daisy/input';
+import { Button } from '../daisy/actions';
 export default function SearchToolbar({
   search,
   onSearchChange,
@@ -19,8 +20,8 @@ export default function SearchToolbar({
 }) {
   return (
     <div className="flex items-center gap-2 mb-2">
-      <input
-        className="input input-bordered input-sm w-40"
+      <InputField
+        className="input-sm w-40"
         value={search}
         onChange={(e) => onSearchChange(e.target.value)}
         placeholder="Search"
@@ -36,13 +37,13 @@ export default function SearchToolbar({
           />
         ))}
       </div>
-      <button
-        className="btn btn-accent btn-sm"
+      <Button
+        className="btn-accent btn-sm"
         onClick={onBulkExport}
         disabled={disableExport}
       >
         Bulk Export
-      </button>
+      </Button>
     </div>
   );
 }

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -8,6 +8,7 @@ import AssetSelectorInfoPanel from '../components/AssetSelectorInfoPanel';
 import Spinner from '../components/Spinner';
 import ExportSummaryModal from '../components/ExportSummaryModal';
 import ExternalLink from '../components/ExternalLink';
+import { Modal, Button } from '../components/daisy/actions';
 import type { ExportSummary } from '../../main/exporter';
 /* eslint-disable import/no-unresolved */
 import {
@@ -75,12 +76,12 @@ export default function EditorView({
       data-testid="editor-view"
     >
       <div className="flex items-center justify-end mb-2 gap-2">
-        <button
-          className="btn btn-primary btn-sm"
+        <Button
+          className="btn-primary btn-sm"
           onClick={() => setSelectorOpen(true)}
         >
           Add From Vanilla
-        </button>
+        </Button>
         <ExternalLink
           href="https://minecraft.wiki/w/Resource_pack"
           aria-label="Help"
@@ -147,8 +148,8 @@ export default function EditorView({
         />
       )}
       {selectorOpen && (
-        <dialog className="modal modal-open" data-testid="asset-selector-modal">
-          <div className="modal-box w-11/12 max-w-5xl">
+        <Modal open testId="asset-selector-modal">
+          <div className="w-11/12 max-w-5xl">
             <h3 className="font-bold text-lg mb-2">Add Assets</h3>
             <div className="flex gap-4 max-h-[70vh]">
               <div className="flex-1 overflow-y-auto">
@@ -167,12 +168,10 @@ export default function EditorView({
               </div>
             </div>
             <div className="modal-action">
-              <button className="btn" onClick={() => setSelectorOpen(false)}>
-                Close
-              </button>
+              <Button onClick={() => setSelectorOpen(false)}>Close</Button>
             </div>
           </div>
-        </dialog>
+        </Modal>
       )}
       <ReactCanvasConfetti
         onInit={({ confetti: c }) => {


### PR DESCRIPTION
## Summary
- replace raw inputs, buttons and range sliders with daisy components
- add `className` and other props to daisy wrappers
- switch asset selector dialog to `Modal`
- update component tests for new props

## Testing
- `npm run lint`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f64c11e848331afa7ddfb944499bb