### PR TITLE
Add heroicons and layout tweaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "minecraft-resource-packer",
       "version": "1.0.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
         "electron-squirrel-startup": "^1.0.1",
@@ -1787,6 +1788,15 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
     "electron-squirrel-startup": "^1.0.1",

--- a/src/renderer/components/daisy/actions/Button.tsx
+++ b/src/renderer/components/daisy/actions/Button.tsx
@@ -6,18 +6,19 @@ export interface ButtonProps
   className?: string;
 }
 
-export default function Button({
-  children,
-  className = '',
-  ...rest
-}: ButtonProps) {
-  return (
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ children, className = '', ...rest }, ref) => (
     <button
+      ref={ref}
       className={`btn ${className}`.trim()}
       {...rest}
       data-testid="daisy-button"
     >
       {children}
     </button>
-  );
-}
+  )
+);
+
+Button.displayName = 'Button';
+
+export default Button;

--- a/src/renderer/components/daisy/input/InputField.tsx
+++ b/src/renderer/components/daisy/input/InputField.tsx
@@ -1,10 +1,16 @@
 import React from 'react';
 
-export default function InputField({
-  className = '',
-  ...rest
-}: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <input className={`input input-bordered ${className}`.trim()} {...rest} />
-  );
-}
+const InputField = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className = '', ...rest }, ref) => (
+  <input
+    ref={ref}
+    className={`input input-bordered ${className}`.trim()}
+    {...rest}
+  />
+));
+
+InputField.displayName = 'InputField';
+
+export default InputField;

--- a/src/renderer/components/project/ProjectForm.tsx
+++ b/src/renderer/components/project/ProjectForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { generateProjectName } from '../../utils/names';
 import { InputField, Select } from '../daisy/input';
 import { Button } from '../daisy/actions';
+import { PlusIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 
 export default function ProjectForm({
   versions,
@@ -45,10 +46,19 @@ export default function ProjectForm({
           </option>
         ))}
       </Select>
-      <Button className="btn-primary btn-sm" type="submit">
+      <Button
+        className="btn-primary btn-sm flex items-center gap-1"
+        type="submit"
+      >
+        <PlusIcon className="w-4 h-4" />
         Create
       </Button>
-      <Button type="button" onClick={onImport} className="btn-secondary btn-sm">
+      <Button
+        type="button"
+        onClick={onImport}
+        className="btn-secondary btn-sm flex items-center gap-1"
+      >
+        <ArrowDownTrayIcon className="w-4 h-4" />
         Import
       </Button>
     </form>

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Checkbox } from '../daisy/input';
 import { Button } from '../daisy/actions';
+import {
+  ArrowRightCircleIcon,
+  DocumentDuplicateIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
 
 export interface ProjectInfo {
   name: string;
@@ -93,30 +98,33 @@ export default function ProjectTable({
               <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
               <td className="flex gap-1">
                 <Button
-                  className="btn-accent btn-sm"
+                  className="btn-accent btn-sm flex items-center gap-1"
                   onClick={(e) => {
                     e.stopPropagation();
                     onOpen(p.name);
                   }}
                 >
+                  <ArrowRightCircleIcon className="w-4 h-4" />
                   Open
                 </Button>
                 <Button
-                  className="btn-info btn-sm"
+                  className="btn-info btn-sm flex items-center gap-1"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDuplicate(p.name);
                   }}
                 >
+                  <DocumentDuplicateIcon className="w-4 h-4" />
                   Duplicate
                 </Button>
                 <Button
-                  className="btn-error btn-sm"
+                  className="btn-error btn-sm flex items-center gap-1"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDelete(p.name);
                   }}
                 >
+                  <TrashIcon className="w-4 h-4" />
                   Delete
                 </Button>
               </td>

--- a/src/renderer/components/project/SearchToolbar.tsx
+++ b/src/renderer/components/project/SearchToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FilterBadge, InputField } from '../daisy/input';
 import { Button } from '../daisy/actions';
+import { ArrowUpTrayIcon } from '@heroicons/react/24/outline';
 export default function SearchToolbar({
   search,
   onSearchChange,
@@ -38,10 +39,11 @@ export default function SearchToolbar({
         ))}
       </div>
       <Button
-        className="btn-accent btn-sm"
+        className="btn-accent btn-sm flex items-center gap-1"
         onClick={onBulkExport}
         disabled={disableExport}
       >
+        <ArrowUpTrayIcon className="w-4 h-4" />
         Bulk Export
       </Button>
     </div>

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -149,7 +149,7 @@ export default function EditorView({
       )}
       {selectorOpen && (
         <Modal open testId="asset-selector-modal">
-          <div className="w-11/12 max-w-5xl">
+          <div className="w-[800px] h-[600px]">
             <h3 className="font-bold text-lg mb-2">Add Assets</h3>
             <div className="flex gap-4 max-h-[70vh]">
               <div className="flex-1 overflow-y-auto">

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -5,6 +5,7 @@ import ExternalLink from '../components/ExternalLink';
 import ProjectSidebar from '../components/ProjectSidebar';
 import ProjectForm from '../components/project/ProjectForm';
 import ProjectTable, { ProjectInfo } from '../components/project/ProjectTable';
+import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
 import { useProjectModals } from '../components/project/ProjectModals';
 import SearchToolbar from '../components/project/SearchToolbar';
 import BulkExportModal, { BulkProgress } from '../components/BulkExportModal';
@@ -113,7 +114,7 @@ const ProjectManagerView: React.FC = () => {
   };
 
   return (
-    <section className="flex gap-4">
+    <section className="flex gap-4 max-w-5xl mx-auto">
       <div className="flex-1">
         <div className="flex items-center mb-2 gap-2">
           <h2 className="font-display text-xl flex-1">Projects</h2>
@@ -122,7 +123,7 @@ const ProjectManagerView: React.FC = () => {
             aria-label="Help"
             className="btn btn-circle btn-ghost btn-sm"
           >
-            ?
+            <QuestionMarkCircleIcon className="w-5 h-5" />
           </ExternalLink>
         </div>
         <ProjectForm


### PR DESCRIPTION
## Summary
- install `@heroicons/react`
- forward refs through `Button` and `InputField`
- use Heroicons across the project manager buttons
- center the project manager layout
- fix asset selector modal size

## Testing
- `npm test --silent`
- `npm run lint --silent`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run format --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f6962b4188331985d325dd0f15f97