### PR TITLE
Update texture protocols to asset:// and vanilla://

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Electron-based tool for creating Minecraft resource packs. The interface is d
 ## Features
 
 - **Asset Selection** – textures are pulled from Mojang's version manifest and cached locally for quick searching.
-- **Secure Previews** – images load through custom `texture://` and `ptex://` protocols so `file://` access is never required.
+- **Secure Previews** – images load through custom `vanilla://` and `asset://` protocols so `file://` access is never required.
 - **Asset Editing** – when an asset is added it is copied into the correct folder structure inside the project. Files can be opened in Explorer/Finder or with the default program for that type. Any changes on disk instantly appear in the UI.
 - **Live Asset Browser** – the Editor view lists all files in the project directory and automatically reloads when something changes.
 - **Random pack icon** – new packs start with a pastel background and random item image; you can regenerate from pack settings.

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -43,7 +43,7 @@ describe('AssetBrowser', () => {
     expect(watchProject).toHaveBeenCalledWith('/proj');
     expect((await screen.findAllByText('a.txt'))[0]).toBeInTheDocument();
     const img = screen.getByAltText('B') as HTMLImageElement;
-    expect(img.src).toContain('ptex://b.png');
+    expect(img.src).toContain('asset://b.png');
     expect(screen.getByText('B')).toBeInTheDocument();
     expect(screen.getAllByText('b.png')[0]).toBeInTheDocument();
     expect(img.style.imageRendering).toBe('pixelated');

--- a/__tests__/AssetSelector.filters.test.tsx
+++ b/__tests__/AssetSelector.filters.test.tsx
@@ -23,7 +23,7 @@ describe('AssetSelector filters', () => {
       'item/apple.png',
       'entity/zombie.png',
     ]);
-    getTextureUrl.mockImplementation((_p, n) => `texture://${n}`);
+    getTextureUrl.mockImplementation((_p, n) => `vanilla://${n}`);
     vi.clearAllMocks();
   });
 

--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -25,7 +25,7 @@ describe('AssetSelector', () => {
       'item/axe.png',
       'other/custom.png',
     ]);
-    getTextureUrl.mockImplementation((_p, n) => `texture://${n}`);
+    getTextureUrl.mockImplementation((_p, n) => `vanilla://${n}`);
     vi.clearAllMocks();
   });
 
@@ -43,7 +43,7 @@ describe('AssetSelector', () => {
     });
     const img = within(sectionParent).getByAltText('Grass') as HTMLImageElement;
     expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/grass.png');
-    expect(img.src).toContain('texture://block/grass.png');
+    expect(img.src).toContain('vanilla://block/grass.png');
     fireEvent.click(button);
     expect(addTexture).not.toHaveBeenCalled();
     expect(onSelect).toHaveBeenCalledWith('block/grass.png');

--- a/__tests__/PreviewPane.test.tsx
+++ b/__tests__/PreviewPane.test.tsx
@@ -7,7 +7,7 @@ describe('PreviewPane', () => {
   it('renders with texture', () => {
     render(<PreviewPane texture="foo.png" />);
     const img = screen.getByRole('img');
-    expect(img).toHaveAttribute('src', 'ptex://foo.png');
+    expect(img).toHaveAttribute('src', 'asset://foo.png');
   });
 
   it('applies neutral lighting by default', () => {

--- a/__tests__/TextureGrid.test.tsx
+++ b/__tests__/TextureGrid.test.tsx
@@ -6,8 +6,8 @@ import TextureGrid, {
 } from '../src/renderer/components/TextureGrid';
 
 const textures: TextureInfo[] = [
-  { name: 'block/stone.png', url: 'texture://stone' },
-  { name: 'block/dirt.png', url: 'texture://dirt' },
+  { name: 'block/stone.png', url: 'vanilla://stone' },
+  { name: 'block/dirt.png', url: 'vanilla://dirt' },
 ];
 
 describe('TextureGrid', () => {

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -11,6 +11,6 @@ describe('TextureLab', () => {
     expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
     expect(screen.getByText('Texture Lab')).toBeInTheDocument();
     const img = screen.getByAltText('preview');
-    expect(img).toHaveAttribute('src', 'ptex://foo.png');
+    expect(img).toHaveAttribute('src', 'asset://foo.png');
   });
 });

--- a/__tests__/TextureThumb.test.tsx
+++ b/__tests__/TextureThumb.test.tsx
@@ -7,13 +7,13 @@ describe('TextureThumb', () => {
   it('renders image with default protocol', () => {
     render(<TextureThumb texture="foo.png" />);
     const img = screen.getByRole('img');
-    expect(img.getAttribute('src')).toBe('ptex://foo.png');
+    expect(img.getAttribute('src')).toBe('asset://foo.png');
   });
 
   it('supports custom protocol', () => {
-    render(<TextureThumb texture="foo.png" protocol="texture" simplified />);
+    render(<TextureThumb texture="foo.png" protocol="vanilla" simplified />);
     const img = screen.getByRole('img');
-    expect(img.getAttribute('src')).toBe('texture://foo.png');
+    expect(img.getAttribute('src')).toBe('vanilla://foo.png');
   });
 
   it('applies simplified mode size', () => {

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -95,9 +95,9 @@ The current theme is stored in Electron's settings store and applied by setting
 
 Two custom protocols simplify image previews:
 
-- `texture://` serves textures from the Minecraft client cache or the active
-  project. URLs use the form `texture://<relative-path>`.
-- `ptex://` serves files directly from the project directory and is used by the
+- `vanilla://` serves textures from the Minecraft client cache. URLs use the
+  form `vanilla://<relative-path>`.
+- `asset://` serves files directly from the project directory and is used by the
   asset browser to preview modified assets.
 
 Both protocols are registered in `src/main/index.ts` when Electron starts.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -28,9 +28,9 @@ const config: ForgeConfig = {
     new AutoUnpackNativesPlugin({}),
     new WebpackPlugin({
       mainConfig,
-      // Allow images from our custom texture:// protocol in development.
+      // Allow images from our custom vanilla:// and asset:// protocols in development.
       devContentSecurityPolicy:
-        "default-src 'self' data: texture: ptex: https://fonts.googleapis.com https://fonts.gstatic.com; " +
+        "default-src 'self' data: vanilla: asset: https://fonts.googleapis.com https://fonts.gstatic.com; " +
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
         "font-src 'self' https://fonts.gstatic.com; " +
         "script-src 'self' 'unsafe-eval' 'unsafe-inline' data:",

--- a/src/main/assets.ts
+++ b/src/main/assets.ts
@@ -18,12 +18,10 @@ const basePath = electronApp?.getPath
 /** Directory that contains one sub folder per Minecraft version. */
 const cacheDir = path.join(basePath, 'assets-cache');
 
-// Paths used by the custom texture protocol. These are updated when a project
-// is opened so the protocol can resolve relative texture URLs.
-let projectTexturesDir = '';
+// Paths used by the custom asset and vanilla protocols. These are updated when
+// a project is opened so the protocols can resolve relative texture URLs.
 let cacheTexturesDir = '';
-// Base path for the currently active project used by the project texture
-// protocol.
+// Base path for the currently active project used by the asset protocol.
 let activeProjectDir = '';
 
 /**
@@ -180,14 +178,6 @@ export async function addTexture(
   await fs.promises.copyFile(src, dest);
   meta.assets.push(`assets/minecraft/textures/${texture}`);
   await fs.promises.writeFile(metaPath, JSON.stringify(meta, null, 2));
-
-  // Update the cached project texture directory to ensure thumbnails work
-  projectTexturesDir = path.join(
-    projectPath,
-    'assets',
-    'minecraft',
-    'textures'
-  );
 }
 
 /**
@@ -205,7 +195,7 @@ export async function getTexturePath(
 }
 
 /**
- * Convert a texture path into a URL that uses the custom `texture://` protocol
+ * Convert a texture path into a URL that uses the custom `vanilla://` protocol
  * so the renderer can load the image without exposing file paths.
  */
 export async function getTextureURL(
@@ -218,55 +208,36 @@ export async function getTextureURL(
   const meta = ProjectMetadataSchema.parse(data);
   const cacheRoot = await ensureAssets(meta.version);
   cacheTexturesDir = path.join(cacheRoot, 'assets', 'minecraft', 'textures');
-  projectTexturesDir = path.join(
-    projectPath,
-    'assets',
-    'minecraft',
-    'textures'
-  );
-  return `texture://${texture}`;
+  return `vanilla://${texture}`;
 }
 
 /**
- * Register the `texture` protocol so it serves files directly from disk.
+ * Register the `vanilla` protocol so it serves files directly from disk.
  */
-export function registerTextureProtocol(protocol: Protocol) {
-  protocol.registerFileProtocol('texture', (request, callback) => {
-    const rel = decodeURI(request.url.replace('texture://', ''));
-    const projectFile = projectTexturesDir
-      ? path.join(projectTexturesDir, rel)
-      : '';
-    if (projectFile && fs.existsSync(projectFile)) {
-      callback(projectFile);
-      return;
-    }
+export function registerVanillaProtocol(protocol: Protocol) {
+  protocol.registerFileProtocol('vanilla', (request, callback) => {
+    const rel = decodeURI(request.url.replace('vanilla://', ''));
     const cacheFile = cacheTexturesDir ? path.join(cacheTexturesDir, rel) : '';
     callback(cacheFile);
   });
 }
 
-/** Register the `ptex` protocol to serve files from the active project. */
-export function registerProjectTextureProtocol(protocol: Protocol) {
-  protocol.registerFileProtocol('ptex', (request, callback) => {
-    const rel = decodeURI(request.url.replace('ptex://', ''));
+/** Register the `asset` protocol to serve files from the active project. */
+export function registerAssetProtocol(protocol: Protocol) {
+  protocol.registerFileProtocol('asset', (request, callback) => {
+    const rel = decodeURI(request.url.replace('asset://', ''));
     const file = activeProjectDir ? path.join(activeProjectDir, rel) : '';
     callback(file);
   });
 }
 
-/** Update the directories used by the texture protocol for the active project. */
+/** Update the directories used by the custom protocols for the active project. */
 export async function setActiveProject(projectPath: string): Promise<void> {
   const metaPath = path.join(projectPath, 'project.json');
   const data = JSON.parse(await fs.promises.readFile(metaPath, 'utf-8'));
   const meta = ProjectMetadataSchema.parse(data);
   const cacheRoot = await ensureAssets(meta.version);
   cacheTexturesDir = path.join(cacheRoot, 'assets', 'minecraft', 'textures');
-  projectTexturesDir = path.join(
-    projectPath,
-    'assets',
-    'minecraft',
-    'textures'
-  );
   activeProjectDir = projectPath;
 }
 

--- a/src/main/assets.ts
+++ b/src/main/assets.ts
@@ -226,7 +226,10 @@ export function registerVanillaProtocol(protocol: Protocol) {
 export function registerAssetProtocol(protocol: Protocol) {
   protocol.registerFileProtocol('asset', (request, callback) => {
     const rel = decodeURI(request.url.replace('asset://', ''));
-    const file = activeProjectDir ? path.join(activeProjectDir, rel) : '';
+    let file = activeProjectDir ? path.join(activeProjectDir, rel) : '';
+    if (/(\\|\/)$/.test(file)) {
+      file = file.substring(0, file.length-1);
+    }
     callback(file);
   });
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,8 +14,8 @@ import { registerProjectHandlers } from './projects';
 import { registerNoExportHandlers } from './noExport';
 import {
   registerAssetHandlers,
-  registerTextureProtocol,
-  registerProjectTextureProtocol,
+  registerVanillaProtocol,
+  registerAssetProtocol,
 } from './assets';
 import { registerIconHandlers } from './icon';
 import { registerTextureLabHandlers } from './textureLab';
@@ -23,8 +23,8 @@ import { registerLayoutHandlers } from './layout';
 import { registerExternalEditorHandlers } from './externalEditor';
 
 protocol.registerSchemesAsPrivileged([
-  { scheme: 'texture', privileges: { standard: true, secure: true } },
-  { scheme: 'ptex', privileges: { standard: true, secure: true } },
+  { scheme: 'vanilla', privileges: { standard: true, secure: true } },
+  { scheme: 'asset', privileges: { standard: true, secure: true } },
 ]);
 
 // Webpack's DefinePlugin in Electron Forge exposes entry point URLs as
@@ -77,8 +77,8 @@ registerFileHandlers(ipcMain);
 
 // Once Electron is ready register protocols and show the main window.
 app.whenReady().then(() => {
-  registerTextureProtocol(protocol);
-  registerProjectTextureProtocol(protocol);
+  registerVanillaProtocol(protocol);
+  registerAssetProtocol(protocol);
   createMainWindow();
 });
 

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -11,7 +11,7 @@ export default function AssetSelectorInfoPanel({ projectPath, asset }: Props) {
   if (!asset) return <div className="p-2">No asset selected</div>;
   return (
     <div className="p-2" data-testid="selector-info">
-      <TextureThumb texture={asset} protocol="texture" alt={asset} size={64} />
+      <TextureThumb texture={asset} protocol="vanilla" alt={asset} size={64} />
       <p className="break-all text-sm">{asset}</p>
       <Button
         className="btn-primary btn-sm mt-2"

--- a/src/renderer/components/PreviewPane.tsx
+++ b/src/renderer/components/PreviewPane.tsx
@@ -31,7 +31,7 @@ export default function PreviewPane({
       {texture ? (
         <>
           <img
-            src={`ptex://${texture}`}
+            src={`asset://${texture}`}
             alt={texture}
             style={{
               imageRendering: 'pixelated',

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -32,7 +32,7 @@ export default function ProjectInfoPanel({
         <Button className="link link-primary self-start" onClick={onSettings}>
           Settings
         </Button>
-        <img src="ptex://pack.png" alt="Pack icon" className="w-16 h-16" />
+        <img src="asset://pack.png" alt="Pack icon" className="w-16 h-16" />
         <h2 className="card-title text-lg font-display">{name}</h2>
         <p className="text-xs break-all">{projectPath}</p>
         <p className="text-sm text-center break-all flex-1">

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -50,7 +50,7 @@ export default function TextureLab({
         <h3 className="font-bold text-lg">Texture Lab</h3>
         <div style={{ height: '64px' }} className="flex justify-center">
           <img
-            src={`ptex://${rel}`}
+            src={`asset://${rel}`}
             alt="preview"
             style={{
               imageRendering: 'pixelated',

--- a/src/renderer/components/TextureThumb.tsx
+++ b/src/renderer/components/TextureThumb.tsx
@@ -9,7 +9,7 @@ interface Props {
   /** Size in pixels */
   size?: number;
   /** Protocol prefix for the texture URL */
-  protocol?: 'ptex' | 'texture';
+  protocol?: 'asset' | 'vanilla';
   /** Use simplified markup without border wrapper */
   simplified?: boolean;
 }
@@ -18,7 +18,7 @@ export default function TextureThumb({
   texture,
   alt,
   size = 64,
-  protocol = 'ptex',
+  protocol = 'asset',
   simplified = false,
 }: Props) {
   const url =


### PR DESCRIPTION
## Summary
- rename `texture://` → `vanilla://`
- rename `ptex://` → `asset://`
- adjust Electron protocol registration and handlers
- update components, tests, docs and CSP configuration

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f7027be508331a4ce732383272254