### PR TITLE
Add modal project creation and sorting persistence

### DIFF
--- a/__tests__/ProjectForm.test.tsx
+++ b/__tests__/ProjectForm.test.tsx
@@ -1,40 +1,46 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import ProjectForm from '../src/renderer/components/project/ProjectForm';
 
 describe('ProjectForm', () => {
-  it('submits name and version', () => {
+  it('submits name and version', async () => {
     const create = vi.fn();
     render(
       <ProjectForm versions={['1.20']} onCreate={create} onImport={() => {}} />
     );
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
-      target: { value: 'Pack' },
-    });
-    fireEvent.change(screen.getByRole('combobox'), {
+    fireEvent.click(screen.getByText('New Project'));
+    const modal = await screen.findByTestId('daisy-modal');
+    const input = within(modal).getByPlaceholderText('Name');
+    fireEvent.change(input, { target: { value: 'Pack' } });
+    fireEvent.change(within(modal).getByRole('combobox'), {
       target: { value: '1.20' },
     });
-    fireEvent.click(screen.getByText('Create'));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Create' }));
     expect(create).toHaveBeenCalledWith('Pack', '1.20');
   });
 
-  it('imports when button clicked', () => {
+  it('imports when button clicked', async () => {
     const imp = vi.fn();
     render(<ProjectForm versions={[]} onCreate={() => {}} onImport={imp} />);
-    fireEvent.click(screen.getByText('Import'));
+    fireEvent.click(screen.getByText('New Project'));
+    const modal = await screen.findByTestId('daisy-modal');
+    fireEvent.click(within(modal).getByRole('tab', { name: 'Import' }));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Import' }));
     expect(imp).toHaveBeenCalled();
   });
 
-  it('does not submit without version', () => {
+  it('does not submit without version', async () => {
     const create = vi.fn();
     render(
       <ProjectForm versions={['1.20']} onCreate={create} onImport={() => {}} />
     );
-    fireEvent.change(screen.getByPlaceholderText('Name'), {
+    fireEvent.click(screen.getByText('New Project'));
+    const modal = await screen.findByTestId('daisy-modal');
+    fireEvent.change(within(modal).getByPlaceholderText('Name'), {
       target: { value: 'Pack' },
     });
-    fireEvent.click(screen.getByText('Create'));
+    fireEvent.click(within(modal).getByRole('button', { name: 'Create' }));
     expect(create).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/ProjectManagerView.bulkExport.test.tsx
+++ b/__tests__/ProjectManagerView.bulkExport.test.tsx
@@ -7,6 +7,8 @@ describe('ProjectManagerView bulk export', () => {
   const listProjects = vi.fn();
   const listVersions = vi.fn();
   const exportProjects = vi.fn();
+  const getProjectSort = vi.fn();
+  const setProjectSort = vi.fn();
 
   beforeEach(() => {
     interface API {
@@ -25,6 +27,8 @@ describe('ProjectManagerView bulk export', () => {
       importProject: () => Promise<void>;
       duplicateProject: (name: string, newName: string) => Promise<void>;
       deleteProject: (name: string) => Promise<void>;
+      getProjectSort: () => Promise<{ key: keyof ProjectInfo; asc: boolean }>;
+      setProjectSort: (key: keyof ProjectInfo, asc: boolean) => Promise<void>;
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       listProjects,
@@ -35,6 +39,8 @@ describe('ProjectManagerView bulk export', () => {
       importProject: vi.fn(),
       duplicateProject: vi.fn(),
       deleteProject: vi.fn(),
+      getProjectSort,
+      setProjectSort,
     };
     listProjects.mockResolvedValue([
       { name: 'Alpha', version: '1.21', assets: 2, lastOpened: 0 },
@@ -42,6 +48,8 @@ describe('ProjectManagerView bulk export', () => {
     ]);
     listVersions.mockResolvedValue([]);
     exportProjects.mockResolvedValue(undefined);
+    getProjectSort.mockResolvedValue({ key: 'name', asc: true });
+    setProjectSort.mockResolvedValue(undefined);
     vi.clearAllMocks();
   });
 

--- a/__tests__/ProjectManagerView.helpLink.test.tsx
+++ b/__tests__/ProjectManagerView.helpLink.test.tsx
@@ -19,6 +19,8 @@ describe('ProjectManagerView help link', () => {
       importProject: () => Promise<void>;
       duplicateProject: (n: string, nn: string) => Promise<void>;
       deleteProject: (n: string) => Promise<void>;
+      getProjectSort: () => Promise<{ key: string; asc: boolean }>;
+      setProjectSort: (key: string, asc: boolean) => Promise<void>;
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       listProjects: vi.fn().mockResolvedValue([]),
@@ -28,6 +30,8 @@ describe('ProjectManagerView help link', () => {
       importProject: vi.fn(),
       duplicateProject: vi.fn(),
       deleteProject: vi.fn(),
+      getProjectSort: vi.fn().mockResolvedValue({ key: 'name', asc: true }),
+      setProjectSort: vi.fn(),
     } as ElectronAPI;
     openExternalMock.mockResolvedValue(undefined);
   });

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -107,4 +107,22 @@ describe('ProjectTable', () => {
     fireEvent.click(screen.getByText('Assets'));
     expect(sort).toHaveBeenCalledWith('assets');
   });
+
+  it('shows a default icon for each project', () => {
+    render(
+      <ProjectTable
+        projects={projects}
+        onSort={() => {}}
+        selected={new Set()}
+        onSelect={() => {}}
+        onSelectAll={() => {}}
+        onOpen={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        onRowClick={() => {}}
+      />
+    );
+    const imgs = screen.getAllByAltText('Pack icon');
+    expect(imgs.length).toBe(2);
+  });
 });

--- a/__tests__/projectSortPersistence.test.ts
+++ b/__tests__/projectSortPersistence.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest';
+import { setProjectSort } from '../src/main/layout';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+
+describe('project sort persistence', () => {
+  it('persists across reloads', async () => {
+    setProjectSort('assets', false);
+    vi.resetModules();
+    const { getProjectSort } = await import('../src/main/layout');
+    expect(getProjectSort()).toEqual({ key: 'assets', asc: false });
+  });
+});

--- a/src/main/layout.ts
+++ b/src/main/layout.ts
@@ -10,6 +10,8 @@ const store = new Store<{
   theme: ThemePref;
   confetti: boolean;
   defaultExportDir: string;
+  projectSortKey: keyof import('./projects').ProjectInfo;
+  projectSortAsc: boolean;
 }>({
   defaults: {
     editorLayout: [20, 80],
@@ -17,6 +19,8 @@ const store = new Store<{
     theme: 'system',
     confetti: true,
     defaultExportDir: app.getPath('downloads'),
+    projectSortKey: 'name',
+    projectSortAsc: true,
   },
 });
 
@@ -60,6 +64,21 @@ export function setDefaultExportDir(dir: string): void {
   store.set('defaultExportDir', dir);
 }
 
+export function getProjectSort(): {
+  key: keyof import('./projects').ProjectInfo;
+  asc: boolean;
+} {
+  return { key: store.get('projectSortKey'), asc: store.get('projectSortAsc') };
+}
+
+export function setProjectSort(
+  key: keyof import('./projects').ProjectInfo,
+  asc: boolean
+): void {
+  store.set('projectSortKey', key);
+  store.set('projectSortAsc', asc);
+}
+
 export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-editor-layout', () => getEditorLayout());
   ipc.handle('set-editor-layout', (_e, layout: number[]) =>
@@ -74,5 +93,11 @@ export function registerLayoutHandlers(ipc: IpcMain): void {
   ipc.handle('get-default-export-dir', () => getDefaultExportDir());
   ipc.handle('set-default-export-dir', (_e, d: string) =>
     setDefaultExportDir(d)
+  );
+  ipc.handle('get-project-sort', () => getProjectSort());
+  ipc.handle(
+    'set-project-sort',
+    (_e, k: keyof import('./projects').ProjectInfo, s: boolean) =>
+      setProjectSort(k, s)
   );
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -73,6 +73,11 @@ const api = {
   setConfetti: (c: boolean) => invoke('set-confetti', c),
   getDefaultExportDir: () => invoke('get-default-export-dir'),
   setDefaultExportDir: (d: string) => invoke('set-default-export-dir', d),
+  getProjectSort: () => invoke('get-project-sort'),
+  setProjectSort: (
+    k: keyof import('../main/projects').ProjectInfo,
+    asc: boolean
+  ) => invoke('set-project-sort', k, asc),
   onFileAdded: (listener: (e: unknown, path: string) => void) =>
     on('file-added', listener),
   onFileRemoved: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/components/daisy/actions/Modal.tsx
+++ b/src/renderer/components/daisy/actions/Modal.tsx
@@ -15,7 +15,7 @@ export default function Modal({
 }: ModalProps) {
   if (!open) return null;
   return (
-    <dialog className="modal modal-open" data-testid={testId}>
+    <dialog open className="modal modal-open" data-testid={testId}>
       <div className={`modal-box ${className}`.trim()}>{children}</div>
     </dialog>
   );

--- a/src/renderer/components/project/ProjectForm.tsx
+++ b/src/renderer/components/project/ProjectForm.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import { generateProjectName } from '../../utils/names';
 import { InputField, Select } from '../daisy/input';
-import { Button } from '../daisy/actions';
+import { Modal, Button } from '../daisy/actions';
+import Tab from '../daisy/navigation/Tab';
 import { PlusIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 
 export default function ProjectForm({
@@ -13,6 +14,8 @@ export default function ProjectForm({
   onCreate: (name: string, version: string) => void;
   onImport: () => void;
 }) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<'create' | 'import'>('create');
   const [name, setName] = useState(() => generateProjectName());
   const [version, setVersion] = useState('');
 
@@ -22,45 +25,96 @@ export default function ProjectForm({
     onCreate(name, version);
     setName(generateProjectName());
     setVersion('');
+    setOpen(false);
+  };
+
+  const handleImport = () => {
+    onImport();
+    setOpen(false);
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex gap-2 mb-4">
-      <InputField
-        className="input-sm"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Name"
-      />
-      <Select
-        className="select-bordered select-sm"
-        value={version}
-        onChange={(e) => setVersion(e.target.value)}
-      >
-        <option value="" disabled>
-          Select version
-        </option>
-        {versions.map((v) => (
-          <option key={v} value={v}>
-            {v}
-          </option>
-        ))}
-      </Select>
-      <Button
-        className="btn-primary btn-sm flex items-center gap-1"
-        type="submit"
-      >
-        <PlusIcon className="w-4 h-4" />
-        Create
-      </Button>
+    <>
       <Button
         type="button"
-        onClick={onImport}
-        className="btn-secondary btn-sm flex items-center gap-1"
+        onClick={() => {
+          setTab('create');
+          setOpen(true);
+        }}
+        className="btn-primary btn-sm mb-4 flex items-center gap-1"
       >
-        <ArrowDownTrayIcon className="w-4 h-4" />
-        Import
+        <PlusIcon className="w-4 h-4" /> New Project
       </Button>
-    </form>
+      <Modal open={open}>
+        <div className="flex flex-col gap-2 w-80">
+          <div role="tablist" className="tabs tabs-bordered">
+            <Tab
+              className={tab === 'create' ? 'tab-active' : ''}
+              onClick={() => setTab('create')}
+            >
+              Create
+            </Tab>
+            <Tab
+              className={tab === 'import' ? 'tab-active' : ''}
+              onClick={() => setTab('import')}
+            >
+              Import
+            </Tab>
+          </div>
+          {tab === 'create' ? (
+            <form
+              onSubmit={handleSubmit}
+              className="flex flex-col gap-2"
+              data-testid="create-form"
+            >
+              <InputField
+                className="input-sm"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Name"
+              />
+              <Select
+                className="select-bordered select-sm"
+                value={version}
+                onChange={(e) => setVersion(e.target.value)}
+              >
+                <option value="" disabled>
+                  Select version
+                </option>
+                {versions.map((v) => (
+                  <option key={v} value={v}>
+                    {v}
+                  </option>
+                ))}
+              </Select>
+              <div className="modal-action">
+                <Button type="button" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button type="submit" className="btn-primary">
+                  Create
+                </Button>
+              </div>
+            </form>
+          ) : (
+            <div className="flex flex-col gap-2" data-testid="import-pane">
+              <p>Select a project folder to import.</p>
+              <div className="modal-action">
+                <Button type="button" onClick={() => setOpen(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  onClick={handleImport}
+                  className="btn-secondary"
+                >
+                  <ArrowDownTrayIcon className="w-4 h-4" /> Import
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -6,6 +6,9 @@ import {
   DocumentDuplicateIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - webpack replaces import with URL string
+import defaultPack from '../../../../resources/default_pack.png';
 
 export interface ProjectInfo {
   name: string;
@@ -92,7 +95,14 @@ export default function ProjectTable({
                   className="checkbox-sm"
                 />
               </td>
-              <td>{p.name}</td>
+              <td className="flex items-center gap-2">
+                <img
+                  src={defaultPack as unknown as string}
+                  alt="Pack icon"
+                  className="w-6 h-6"
+                />
+                {p.name}
+              </td>
               <td>{p.version}</td>
               <td>{p.assets}</td>
               <td>{new Date(p.lastOpened).toLocaleDateString()}</td>

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -32,6 +32,12 @@ const ProjectManagerView: React.FC = () => {
   useEffect(() => {
     refresh();
     window.electronAPI?.listVersions().then(setVersions);
+    window.electronAPI?.getProjectSort().then((s) => {
+      if (s) {
+        setSortKey(s.key);
+        setAsc(s.asc);
+      }
+    });
   }, []);
 
   const { modals, openDuplicate, openDelete } = useProjectModals(
@@ -56,10 +62,13 @@ const ProjectManagerView: React.FC = () => {
 
   const handleSort = (key: keyof ProjectInfo) => {
     if (sortKey === key) {
-      setAsc(!asc);
+      const next = !asc;
+      setAsc(next);
+      window.electronAPI?.setProjectSort(sortKey, next);
     } else {
       setSortKey(key);
       setAsc(true);
+      window.electronAPI?.setProjectSort(key, true);
     }
   };
 

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -52,6 +52,8 @@ declare global {
       setConfetti: IpcInvoke<'set-confetti'>;
       getDefaultExportDir: IpcInvoke<'get-default-export-dir'>;
       setDefaultExportDir: IpcInvoke<'set-default-export-dir'>;
+      getProjectSort: IpcInvoke<'get-project-sort'>;
+      setProjectSort: IpcInvoke<'set-project-sort'>;
       openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
       onFileAdded: IpcListener<'file-added'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -43,6 +43,8 @@ export interface IpcRequestMap {
   'set-confetti': [boolean];
   'get-default-export-dir': [];
   'set-default-export-dir': [string];
+  'get-project-sort': [];
+  'set-project-sort': [keyof ProjectInfo, boolean];
 }
 
 export interface IpcResponseMap {
@@ -85,6 +87,8 @@ export interface IpcResponseMap {
   'set-confetti': void;
   'get-default-export-dir': string;
   'set-default-export-dir': void;
+  'get-project-sort': { key: keyof ProjectInfo; asc: boolean };
+  'set-project-sort': void;
 }
 
 export interface IpcEventMap {


### PR DESCRIPTION
## Summary
- add default icon column to project table
- migrate project creation/import to a modal with tabs
- remember project table sorting using electron-store
- expose project sort IPC methods
- update tests for new modal behaviour and add persistence test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f9bfdb1d883319f98d393ef4ba496