### PR TITLE
Improve project panels and navbar

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -49,6 +49,13 @@ describe('AssetBrowser', () => {
     expect(img.style.imageRendering).toBe('pixelated');
   });
 
+  it('is scrollable', async () => {
+    render(<AssetBrowser path="/proj" />);
+    await screen.findAllByText('a.txt');
+    const wrapper = screen.getByTestId('asset-browser');
+    expect(wrapper.className).toMatch(/overflow-auto/);
+  });
+
   it('context menu triggers IPC calls', async () => {
     const openInFolder = vi.fn();
     const openFile = vi.fn();

--- a/__tests__/Navbar.test.tsx
+++ b/__tests__/Navbar.test.tsx
@@ -21,18 +21,29 @@ beforeEach(() => {
 
 describe('Navbar', () => {
   it('displays app title', () => {
-    render(<Navbar />);
+    render(<Navbar onNavigate={vi.fn()} />);
     expect(screen.getByTestId('app-title')).toHaveTextContent(
       'Minecraft Resource Packer'
     );
   });
 
   it('toggles theme and calls setTheme', async () => {
-    render(<Navbar />);
+    render(<Navbar onNavigate={vi.fn()} />);
     const button = screen.getByLabelText('Toggle theme');
     await fireEvent.click(button);
     await Promise.resolve();
     expect(setTheme).toHaveBeenCalledWith('light');
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('calls onNavigate when nav buttons clicked', () => {
+    const nav = vi.fn();
+    render(<Navbar onNavigate={nav} />);
+    fireEvent.click(screen.getByText('Projects'));
+    expect(nav).toHaveBeenCalledWith('manager');
+    fireEvent.click(screen.getByText('Settings'));
+    expect(nav).toHaveBeenCalledWith('settings');
+    fireEvent.click(screen.getByText('About'));
+    expect(nav).toHaveBeenCalledWith('about');
   });
 });

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -30,6 +30,7 @@ describe('ProjectInfoPanel', () => {
         projectPath="/p/Pack"
         onExport={onExport}
         onBack={onBack}
+        onSettings={vi.fn()}
       />
     );
     expect(load).toHaveBeenCalledWith('Pack');
@@ -41,5 +42,19 @@ describe('ProjectInfoPanel', () => {
     fireEvent.click(screen.getByText('Back to Projects'));
     expect(onBack).toHaveBeenCalled();
     expect(screen.getByText('/p/Pack')).toBeInTheDocument();
+  });
+
+  it('falls back to default icon when pack.png missing', async () => {
+    render(
+      <ProjectInfoPanel
+        projectPath="/p/Pack"
+        onExport={onExport}
+        onBack={onBack}
+        onSettings={vi.fn()}
+      />
+    );
+    const img = screen.getByAltText('Pack icon') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(img.src).toContain('default_pack');
   });
 });

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -67,7 +67,12 @@ export default function App() {
 
   return (
     <div className="min-h-screen bg-base-200 flex flex-col">
-      <Navbar />
+      <Navbar
+        onNavigate={(v) => {
+          setProjectPath(null);
+          setView(v);
+        }}
+      />
       <div className="flex-1 flex flex-col">{content}</div>
     </div>
   );

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -103,6 +103,7 @@ const AssetBrowser: React.FC<Props> = ({
     <div
       data-testid="asset-browser"
       ref={wrapperRef}
+      className="overflow-auto"
       onKeyDown={(e) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();

--- a/src/renderer/components/Navbar.tsx
+++ b/src/renderer/components/Navbar.tsx
@@ -1,13 +1,38 @@
 import React from 'react';
 import { toggleTheme } from '../utils/theme';
 import { Button } from './daisy/actions';
+import type { View } from './App';
 
-export default function Navbar() {
+interface Props {
+  onNavigate: (v: View) => void;
+}
+
+export default function Navbar({ onNavigate }: Props) {
   return (
     <header className="navbar bg-primary text-primary-content">
       <div className="flex-1 px-2 font-display text-lg" data-testid="app-title">
         Minecraft Resource Packer
       </div>
+      <nav className="flex gap-2 mr-2">
+        <Button
+          className="btn-ghost btn-sm"
+          onClick={() => onNavigate('manager')}
+        >
+          Projects
+        </Button>
+        <Button
+          className="btn-ghost btn-sm"
+          onClick={() => onNavigate('settings')}
+        >
+          Settings
+        </Button>
+        <Button
+          className="btn-ghost btn-sm"
+          onClick={() => onNavigate('about')}
+        >
+          About
+        </Button>
+      </nav>
       <Button
         className="btn-square btn-ghost"
         onClick={toggleTheme}

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from 'react';
 import path from 'path';
 import type { PackMeta } from '../../main/projects';
 import { Button } from './daisy/actions';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - webpack replaces import with URL string
+import defaultIcon from '../../../resources/default_pack.png';
 
 interface Props {
   projectPath: string;
@@ -32,7 +35,15 @@ export default function ProjectInfoPanel({
         <Button className="link link-primary self-start" onClick={onSettings}>
           Settings
         </Button>
-        <img src="asset://pack.png" alt="Pack icon" className="w-16 h-16" />
+        <img
+          src="asset://pack.png"
+          alt="Pack icon"
+          className="w-24 h-24"
+          onError={(e) => {
+            (e.currentTarget as HTMLImageElement).src =
+              defaultIcon as unknown as string;
+          }}
+        />
         <h2 className="card-title text-lg font-display">{name}</h2>
         <p className="text-xs break-all">{projectPath}</p>
         <p className="text-sm text-center break-all flex-1">


### PR DESCRIPTION
## Summary
- show a fallback `default_pack.png` icon in `ProjectInfoPanel`
- enlarge the pack icon display
- make the AssetBrowser root scrollable
- add Projects/Settings/About navigation buttons to Navbar
- pass navigation handler from App
- test the new behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f9c5652388331a3f4c1917e755be6