### PR TITLE
Add Daisy typography components

### DIFF
--- a/__tests__/daisy/typography/Blockquote.test.tsx
+++ b/__tests__/daisy/typography/Blockquote.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Blockquote } from '../../../src/renderer/components/daisy/typography';
+
+describe('Blockquote', () => {
+  it('renders', () => {
+    render(<Blockquote>Quote</Blockquote>);
+    expect(screen.getByTestId('blockquote')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/Code.test.tsx
+++ b/__tests__/daisy/typography/Code.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Code } from '../../../src/renderer/components/daisy/typography';
+
+describe('Code', () => {
+  it('renders', () => {
+    render(<Code>const x=1;</Code>);
+    expect(screen.getByTestId('code')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/H1.test.tsx
+++ b/__tests__/daisy/typography/H1.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { H1 } from '../../../src/renderer/components/daisy/typography';
+
+describe('H1', () => {
+  it('renders', () => {
+    render(<H1>Title</H1>);
+    expect(screen.getByTestId('h1')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/H2.test.tsx
+++ b/__tests__/daisy/typography/H2.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { H2 } from '../../../src/renderer/components/daisy/typography';
+
+describe('H2', () => {
+  it('renders', () => {
+    render(<H2>Subtitle</H2>);
+    expect(screen.getByTestId('h2')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/H3.test.tsx
+++ b/__tests__/daisy/typography/H3.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { H3 } from '../../../src/renderer/components/daisy/typography';
+
+describe('H3', () => {
+  it('renders', () => {
+    render(<H3>Heading</H3>);
+    expect(screen.getByTestId('h3')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/Paragraph.test.tsx
+++ b/__tests__/daisy/typography/Paragraph.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Paragraph } from '../../../src/renderer/components/daisy/typography';
+
+describe('Paragraph', () => {
+  it('renders', () => {
+    render(<Paragraph>Text</Paragraph>);
+    expect(screen.getByTestId('paragraph')).toBeInTheDocument();
+  });
+});

--- a/__tests__/daisy/typography/Prose.test.tsx
+++ b/__tests__/daisy/typography/Prose.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Prose } from '../../../src/renderer/components/daisy/typography';
+
+describe('Prose', () => {
+  it('renders', () => {
+    render(
+      <Prose>
+        <p>text</p>
+      </Prose>
+    );
+    expect(screen.getByTestId('prose')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/daisy/typography/Blockquote.tsx
+++ b/src/renderer/components/daisy/typography/Blockquote.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Blockquote({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLQuoteElement>) {
+  return (
+    <blockquote
+      className={`border-l-4 pl-4 italic ${className}`.trim()}
+      data-testid="blockquote"
+      {...rest}
+    >
+      {children}
+    </blockquote>
+  );
+}

--- a/src/renderer/components/daisy/typography/Code.tsx
+++ b/src/renderer/components/daisy/typography/Code.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function Code({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLElement>) {
+  return (
+    <code
+      className={`font-mono ${className}`.trim()}
+      data-testid="code"
+      {...rest}
+    >
+      {children}
+    </code>
+  );
+}

--- a/src/renderer/components/daisy/typography/H1.tsx
+++ b/src/renderer/components/daisy/typography/H1.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function H1({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h1
+      className={`text-3xl font-bold ${className}`.trim()}
+      data-testid="h1"
+      {...rest}
+    >
+      {children}
+    </h1>
+  );
+}

--- a/src/renderer/components/daisy/typography/H2.tsx
+++ b/src/renderer/components/daisy/typography/H2.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function H2({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h2
+      className={`text-2xl font-bold ${className}`.trim()}
+      data-testid="h2"
+      {...rest}
+    >
+      {children}
+    </h2>
+  );
+}

--- a/src/renderer/components/daisy/typography/H3.tsx
+++ b/src/renderer/components/daisy/typography/H3.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function H3({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLHeadingElement>) {
+  return (
+    <h3
+      className={`text-xl font-bold ${className}`.trim()}
+      data-testid="h3"
+      {...rest}
+    >
+      {children}
+    </h3>
+  );
+}

--- a/src/renderer/components/daisy/typography/Paragraph.tsx
+++ b/src/renderer/components/daisy/typography/Paragraph.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Paragraph({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLParagraphElement>) {
+  return (
+    <p className={`mb-2 ${className}`.trim()} data-testid="paragraph" {...rest}>
+      {children}
+    </p>
+  );
+}

--- a/src/renderer/components/daisy/typography/Prose.tsx
+++ b/src/renderer/components/daisy/typography/Prose.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Prose({
+  children,
+  className = '',
+  ...rest
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={`prose ${className}`.trim()} data-testid="prose" {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/src/renderer/components/daisy/typography/index.ts
+++ b/src/renderer/components/daisy/typography/index.ts
@@ -1,0 +1,7 @@
+export { default as Blockquote } from './Blockquote';
+export { default as Code } from './Code';
+export { default as H1 } from './H1';
+export { default as H2 } from './H2';
+export { default as H3 } from './H3';
+export { default as Paragraph } from './Paragraph';
+export { default as Prose } from './Prose';


### PR DESCRIPTION
## Summary
- add typography components for daisyUI
- export new typography components
- test typography components

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fb051a11883318ac26dedf5274940