### PR TITLE
Replace react-loader-spinner with daisyUI skeleton

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,61 +58,73 @@ Use https://minecraft.wiki/ as the source of truth for up-to-date Minecraft info
 Minecraft version information can be found at: https://launchermeta.mojang.com/mc/game/version_manifest.json
 
 ## Task Context
-1. The repository root contains `TODO.md`, a list of unchecked feature bullets.  
-2. Each bullet is terse; the expanded requirements live in the glossary below.  
+
+1. The repository root contains `TODO.md`, a list of unchecked feature bullets.
+2. Each bullet is terse; the expanded requirements live in the glossary below.
 3. Every UI component and helper must ship with **Vitest + React-Testing-Library tests** and keep total coverage ≥ 90 %.
 
 ## Glossary of Definitions
 
 ### Global Shell & UX
-* **Drawer layout** – daisyUI `drawer`; collapses to icons < 768 px; toggled with hamburger.  
-* **Navbar** – title text, 🌓 theme switch persisted in `localStorage`.  
-* **Toast system** – daisyUI `toast`, ARIA live region.
-* **Loading indicators** – wrap async ops in `<Suspense>` with `react-loader-spinner`.
-* **Confetti** – `react-canvas-confetti`, auto-disabled by `prefers-reduced-motion`.
-* **Undo/Redo** – global queue (20 actions).
 
-### Projects Dashboard  
-* **Placeholder names** – generated via `unique-names-generator`; must be pronounceable.
-* Zebra table columns: Name · MC Version · Assets · Last opened; sortable.  
-* CRUD actions: New / Import / Duplicate / Delete / Open.  
-* Search + version filter chips.
-* Bulk export selected rows.  
-* Metadata sidebar: description, author, URLs, timestamps.
+- **Drawer layout** – daisyUI `drawer`; collapses to icons < 768 px; toggled with hamburger.
+- **Navbar** – title text, 🌓 theme switch persisted in `localStorage`.
+- **Toast system** – daisyUI `toast`, ARIA live region.
+- **Loading indicators** – wrap async ops in `<Suspense>` with `daisyUI skeletons or progress`.
+- **Confetti** – `react-canvas-confetti`, auto-disabled by `prefers-reduced-motion`.
+- **Undo/Redo** – global queue (20 actions).
 
-### Vanilla Asset Browser  
-* Categorized sections; grid with zoom 24–128 px; hover ring.  
-* Drag-or-click to add; quick filters (Blocks, Items, Entity, UI, Audio).  
-* Neutral-lighting preview pane.
+### Projects Dashboard
 
-### Project File Explorer  
-* **Chokidar watcher** for `assets/**`, < 200 ms refresh.  
-* Context menu: Reveal, Open, Rename, Delete.  
-* Dirty badge; 🔒 No-export toggle; custom namespaces (non-`minecraft`).  
+- **Placeholder names** – generated via `unique-names-generator`; must be pronounceable.
+- Zebra table columns: Name · MC Version · Assets · Last opened; sortable.
+- CRUD actions: New / Import / Duplicate / Delete / Open.
+- Search + version filter chips.
+- Bulk export selected rows.
+- Metadata sidebar: description, author, URLs, timestamps.
 
-### Texture Inspector  
-* 1 : 1 canvas preview + zoom.  
-* External edit; auto-reload; revision history (20).  
-* **Sharp mini-lab**: hue-shift, rotate 90°, gray-scale, ±saturation, ±brightness.
+### Vanilla Asset Browser
 
-### Pack Settings  
-* Editable `pack.mcmeta` (desc, `pack_format`, language).  
-* **Random icon seed** – Sharp composited 128×128 PNG (pastel BG, 4 px border, centered random Minecraft item texture).  
-* **Pack-Icon Editor** – modal to randomise item/background/border, or upload custom PNG; always outputs 128 × 128.  
-* Target resolution radio 16×/32×/64×; license; validation.
+- Categorized sections; grid with zoom 24–128 px; hover ring.
+- Drag-or-click to add; quick filters (Blocks, Items, Entity, UI, Audio).
+- Neutral-lighting preview pane.
 
-### Templates  
-* JSON files under `templates/` → `{name, mcVersion, assets[]}` (e.g., “Gold Tools & Armor”, “All Food Items”).
+### Project File Explorer
 
-### Import / Export  
-* Import wizard – use `adm-zip` to ingest `.zip`, read `pack.mcmeta` + optional `pack.json`.
-* Export – `archiver` with progress bar; embed `pack.json`; respect No-export flags; confetti on success.  
+- **Chokidar watcher** for `assets/**`, < 200 ms refresh.
+- Context menu: Reveal, Open, Rename, Delete.
+- Dirty badge; 🔒 No-export toggle; custom namespaces (non-`minecraft`).
 
-### Export Wizard  
-* Destination picker (Downloads default); compression ETA; archive name defaults to project name, a custom name can be saved and will be remembered; post-actions (Open folder, Copy to resourcepacks, Test-launch MC).  
+### Texture Inspector
 
-### Preferences / About  
-* Paths, theme, shortcuts, update channel, analytics opt-in, about pane.  
+- 1 : 1 canvas preview + zoom.
+- External edit; auto-reload; revision history (20).
+- **Sharp mini-lab**: hue-shift, rotate 90°, gray-scale, ±saturation, ±brightness.
 
-### Quality & Accessibility  
-* Full keyboard nav; daisyUI high-contrast theme; responsive grid; 8-pt spacing.
+### Pack Settings
+
+- Editable `pack.mcmeta` (desc, `pack_format`, language).
+- **Random icon seed** – Sharp composited 128×128 PNG (pastel BG, 4 px border, centered random Minecraft item texture).
+- **Pack-Icon Editor** – modal to randomise item/background/border, or upload custom PNG; always outputs 128 × 128.
+- Target resolution radio 16×/32×/64×; license; validation.
+
+### Templates
+
+- JSON files under `templates/` → `{name, mcVersion, assets[]}` (e.g., “Gold Tools & Armor”, “All Food Items”).
+
+### Import / Export
+
+- Import wizard – use `adm-zip` to ingest `.zip`, read `pack.mcmeta` + optional `pack.json`.
+- Export – `archiver` with progress bar; embed `pack.json`; respect No-export flags; confetti on success.
+
+### Export Wizard
+
+- Destination picker (Downloads default); compression ETA; archive name defaults to project name, a custom name can be saved and will be remembered; post-actions (Open folder, Copy to resourcepacks, Test-launch MC).
+
+### Preferences / About
+
+- Paths, theme, shortcuts, update channel, analytics opt-in, about pane.
+
+### Quality & Accessibility
+
+- Full keyboard nav; daisyUI high-contrast theme; responsive grid; 8-pt spacing.

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,8 @@ UI components **must** ship with Vitest + RTL tests; overall coverage 竕･窶ｯ90窶
 - [x] Drawer layout with hamburger toggle
 - [x] Navbar with title and 兼 theme switch (persists in `localStorage`)
 - [x] Toast/alert system via daisyUI `toast`
-- [x] Loading indicators for every async op (`react-loader-spinner`)
+- [x] Loading indicators for every async op (daisyUI components)
+- [ ] Replace react-loader-spinner with daisyUI skeleton/progress/radial-progress components (prefer skeleton)
 - [x] Confetti celebration on successful export (`react-canvas-confetti`)
 - [ ] Undo/Redo queue (last 20 actions)
 
@@ -127,6 +128,6 @@ UI components **must** ship with Vitest + RTL tests; overall coverage 竕･窶ｯ90窶
 - [`unique-names-generator`](https://www.npmjs.com/package/unique-names-generator)窶ビandom placeholder pack names
 - [`sharp`](https://www.npmjs.com/package/sharp)窶ナmage processing
 - [`react-canvas-confetti`](https://www.npmjs.com/package/react-canvas-confetti)窶テxport confetti
-- [`react-loader-spinner`](https://www.npmjs.com/package/react-loader-spinner)窶ネoading indicators
+- [daisyUI loading components](https://daisyui.com/components/loading/) loading indicators
 - [`chokidar`](https://www.npmjs.com/package/chokidar)窶デile watching
 - [`archiver`](https://www.npmjs.com/package/archiver)窶セIP export

--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -36,6 +36,7 @@ describe('AssetInfo', () => {
   it('renders asset name', async () => {
     render(<AssetInfo projectPath="/p" asset="foo.png" />);
     expect(screen.getByText('foo.png')).toBeInTheDocument();
+    expect(screen.getByTestId('preview-skeleton')).toBeInTheDocument();
     expect(await screen.findByTestId('preview-pane')).toBeInTheDocument();
   });
 

--- a/__tests__/BulkExportModal.test.tsx
+++ b/__tests__/BulkExportModal.test.tsx
@@ -7,6 +7,7 @@ describe('BulkExportModal', () => {
   it('shows spinner and progress', () => {
     render(<BulkExportModal progress={{ current: 1, total: 3 }} />);
     expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
     expect(screen.getByText('1/3')).toBeInTheDocument();
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -133,7 +133,7 @@ Beside the asset information panel, a **Preview Pane** shows the currently
 selected texture under neutral lighting. The pane renders textures at a 1:1
 pixel scale and includes a zoom slider (1–8×). Scrolling the mouse wheel over
 the pane adjusts the zoom. The pane is lazy loaded and displays a
-`react-loader-spinner` indicator while loading.
+daisyUI skeleton indicator while loading.
 
 The **Texture Lab** modal lets you adjust PNG textures without leaving the app.
 It exposes hue shift, rotation, grayscale, saturation and brightness controls.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react-arborist": "^3.4.3",
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.1.0",
-        "react-loader-spinner": "^6.1.6",
         "react-resizable-panels": "^3.0.3",
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-window": "^1.8.11",
@@ -1184,27 +1183,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@emotion/is-prop-valid": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-      "integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/memoize": "^0.8.1"
-      }
-    },
-    "node_modules/@emotion/memoize": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/unitless": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
-      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.5",
@@ -3540,7 +3518,7 @@
       "version": "24.0.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
       "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
@@ -3574,7 +3552,7 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3669,12 +3647,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/stylis": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@types/stylis/-/stylis-4.2.5.tgz",
-      "integrity": "sha512-1Xve+NMN7FWjY14vLoY5tL3BVEQ/n42YLwaqJIPYhotZ9uBHt87VceMwWQpzmdEt2TNXIorIFG+YeCUUW7RInw==",
-      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -5389,15 +5361,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001723",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
@@ -6049,15 +6012,6 @@
         "node": ">=12.10"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/css-loader": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
@@ -6111,17 +6065,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -6173,6 +6116,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/daisyui": {
@@ -11666,6 +11610,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12564,6 +12509,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -12875,6 +12821,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/postject": {
@@ -13240,29 +13187,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/react-loader-spinner": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/react-loader-spinner/-/react-loader-spinner-6.1.6.tgz",
-      "integrity": "sha512-x5h1Jcit7Qn03MuKlrWcMG9o12cp9SNDVHVJTNRi9TgtGPKcjKiXkou4NRfLAtXaFB3+Z8yZsVzONmPzhv2ErA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-is": "^18.2.0",
-        "styled-components": "^6.1.2"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/react-loader-spinner/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
     "node_modules/react-resizable-panels": {
@@ -14288,12 +14212,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
-    },
     "node_modules/sharp": {
       "version": "0.34.2",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.2.tgz",
@@ -14594,6 +14512,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15045,74 +14964,6 @@
       "peerDependencies": {
         "webpack": "^5.27.0"
       }
-    },
-    "node_modules/styled-components": {
-      "version": "6.1.19",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.19.tgz",
-      "integrity": "sha512-1v/e3Dl1BknC37cXMhwGomhO8AkYmN41CqyX9xhUDxry1ns3BFQy2lLDRQXJRdVVWB9OHemv/53xaStimvWyuA==",
-      "license": "MIT",
-      "dependencies": {
-        "@emotion/is-prop-valid": "1.2.2",
-        "@emotion/unitless": "0.8.1",
-        "@types/stylis": "4.2.5",
-        "css-to-react-native": "3.2.0",
-        "csstype": "3.1.3",
-        "postcss": "8.4.49",
-        "shallowequal": "1.1.0",
-        "stylis": "4.3.2",
-        "tslib": "2.6.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/styled-components"
-      },
-      "peerDependencies": {
-        "react": ">= 16.8.0",
-        "react-dom": ">= 16.8.0"
-      }
-    },
-    "node_modules/styled-components/node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.7",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/styled-components/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "license": "0BSD"
-    },
-    "node_modules/stylis": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.2.tgz",
-      "integrity": "sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==",
-      "license": "MIT"
     },
     "node_modules/sudo-prompt": {
       "version": "9.2.1",
@@ -15961,7 +15812,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "react-arborist": "^3.4.3",
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.1.0",
-    "react-loader-spinner": "^6.1.6",
     "react-resizable-panels": "^3.0.3",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -1,6 +1,5 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import path from 'path';
-import { Oval } from 'react-loader-spinner';
 import { useToast } from './ToastProvider';
 import Spinner from './Spinner';
 import { Textarea } from './daisy/input';
@@ -70,7 +69,10 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
       <Suspense
         fallback={
           <div className="flex items-center justify-center w-32 h-32">
-            <Oval height={32} width={32} color="#3b82f6" />
+            <div
+              className="skeleton w-32 h-32"
+              data-testid="preview-skeleton"
+            />
           </div>
         }
       >


### PR DESCRIPTION
## Summary
- swap react-loader-spinner usage with daisyUI components
- update AssetInfo preview fallback to a daisyUI skeleton
- drop react-loader-spinner dependency
- revise docs and TODO list for new loading indicator
- adjust tests for the new loading components

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fbcd911a88331ad20afce3015f810