### PR TITLE
Improve toast system

### DIFF
--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
 import SettingsView from '../src/renderer/views/SettingsView';
+import ToastProvider from '../src/renderer/components/ToastProvider';
 
 // eslint-disable-next-line no-var
 var openExternalMock: ReturnType<typeof vi.fn>;
@@ -55,13 +56,21 @@ describe('SettingsView', () => {
   });
 
   it('renders placeholder heading', () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const section = screen.getByTestId('settings-view');
     expect(section).toHaveTextContent('Settings');
   });
 
   it('opens help link externally', () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const link = screen.getByRole('link', { name: 'Help' });
     link.dispatchEvent(
       new MouseEvent('click', { bubbles: true, cancelable: true })
@@ -72,26 +81,42 @@ describe('SettingsView', () => {
   });
 
   it('loads and saves external editor path', async () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const input = await screen.findByLabelText('External texture editor');
     expect(input).toHaveValue('/usr/bin/gimp');
     fireEvent.change(input, { target: { value: '/opt/editor' } });
     fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
     expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
+    expect(await screen.findAllByText('Editor path saved')).toHaveLength(2);
   });
 
   it('loads and saves default export folder', async () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const input = await screen.findByLabelText('Default export folder');
     expect(input).toHaveValue('/home');
     fireEvent.change(input, { target: { value: '/out' } });
     const btn = screen.getAllByRole('button', { name: 'Save' })[1];
     fireEvent.click(btn);
     expect(setDefaultExportDir).toHaveBeenCalledWith('/out');
+    expect(await screen.findAllByText('Export directory saved')).toHaveLength(
+      2
+    );
   });
 
   it('changes theme via dropdown', async () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const select = await screen.findByLabelText('Theme');
     fireEvent.change(select, { target: { value: 'dark' } });
     await Promise.resolve();
@@ -99,13 +124,19 @@ describe('SettingsView', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe(
       'minecraft'
     );
+    expect(await screen.findAllByText('Theme updated')).toHaveLength(2);
   });
 
   it('toggles confetti preference', async () => {
-    render(<SettingsView />);
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
     const toggle = await screen.findByLabelText('Confetti effects');
     expect(toggle).toBeChecked();
     fireEvent.click(toggle);
     expect(setConfetti).toHaveBeenCalledWith(false);
+    expect(await screen.findAllByText('Preference saved')).toHaveLength(2);
   });
 });

--- a/__tests__/ToastProvider.test.tsx
+++ b/__tests__/ToastProvider.test.tsx
@@ -7,7 +7,11 @@ import ToastProvider, {
 
 function TestComp() {
   const toast = useToast();
-  return <button onClick={() => toast('hello')}>Show</button>;
+  return (
+    <button onClick={() => toast({ message: 'hello', closable: true })}>
+      Show
+    </button>
+  );
 }
 
 describe('ToastProvider', () => {
@@ -24,6 +28,41 @@ describe('ToastProvider', () => {
       vi.advanceTimersByTime(3000);
     });
     expect(screen.queryAllByText('hello')).toHaveLength(0);
+  });
+
+  it('allows closing a toast manually', () => {
+    render(
+      <ToastProvider>
+        <TestComp />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Show'));
+    const btn = screen.getByRole('button', { name: 'Close' });
+    fireEvent.click(btn);
+    expect(screen.queryByText('hello')).toBeNull();
+  });
+
+  it('respects custom duration', () => {
+    vi.useFakeTimers();
+    function ShortToast() {
+      const toast = useToast();
+      return (
+        <button onClick={() => toast({ message: 'short', duration: 1000 })}>
+          Short
+        </button>
+      );
+    }
+    render(
+      <ToastProvider>
+        <ShortToast />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('Short'));
+    expect(screen.getAllByText('short')).toHaveLength(2);
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(screen.queryAllByText('short')).toHaveLength(0);
   });
 
   it('provides aria live region', () => {

--- a/__tests__/useProjectFiles.test.tsx
+++ b/__tests__/useProjectFiles.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useProjectFiles } from '../src/renderer/components/file/useProjectFiles';
+import ToastProvider from '../src/renderer/components/ToastProvider';
 
 const watchProject = vi.fn(async () => ['a.txt', 'b.png']);
 const unwatchProject = vi.fn();
@@ -75,12 +76,15 @@ describe('useProjectFiles', () => {
   });
 
   it('toggles noExport state', async () => {
-    const { result } = renderHook(() => useProjectFiles('/proj'));
+    const { result } = renderHook(() => useProjectFiles('/proj'), {
+      wrapper: ToastProvider,
+    });
     await waitFor(() => expect(result.current.files.length).toBeGreaterThan(0));
     act(() => {
       result.current.toggleNoExport(['a.txt'], true);
     });
     expect(setNoExport).toHaveBeenCalledWith('/proj', ['a.txt'], true);
     expect(result.current.noExport.has('a.txt')).toBe(true);
+    expect(document.body.textContent).toContain('1 file(s) added to No Export');
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -68,6 +68,19 @@ Remember that the renderer runs in a browser-like sandbox, so heavy filesystem w
 
 Use spaces for indentation in `.ts` and `.tsx` files and keep React components functional.
 
+### Toasts
+
+Use the `useToast` hook to display brief notifications. Call it with an options
+object:
+
+```ts
+toast({ message: 'Saved!', type: 'success', duration: 5000, closable: true });
+```
+
+Types correspond to daisyUI alert variants (`info`, `success`, `warning`, `error`,
+`neutral`, `loading`). The toast automatically disappears after the specified
+duration unless closable.
+
 ## IPC Pattern
 
 Electron uses a main ↔ preload ↔ renderer pipeline. Functions are implemented in

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -50,14 +50,14 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
         JSON.parse(text);
       } catch {
         setError('Invalid JSON');
-        toast('Invalid JSON', 'error');
+        toast({ message: 'Invalid JSON', type: 'error' });
         return;
       }
     }
     setError(null);
     window.electronAPI?.writeFile(full, text).then(() => {
       setOrig(text);
-      toast('File saved', 'success');
+      toast({ message: 'File saved', type: 'success' });
     });
   };
 
@@ -108,7 +108,14 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
             </Button>
             <Button
               className="btn-secondary btn-sm"
-              onClick={() => window.electronAPI?.openExternalEditor(full)}
+              onClick={() =>
+                window.electronAPI?.openExternalEditor(full).catch(() =>
+                  toast({
+                    message: 'Failed to open external editor',
+                    type: 'error',
+                  })
+                )
+              }
             >
               Edit Externally
             </Button>

--- a/src/renderer/components/ToastProvider.tsx
+++ b/src/renderer/components/ToastProvider.tsx
@@ -1,17 +1,32 @@
 import React, { createContext, useContext, useState } from 'react';
 
-type ToastType = 'info' | 'success' | 'warning' | 'error';
+export type ToastType =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'error'
+  | 'neutral'
+  | 'loading';
 interface Toast {
   id: number;
   message: string;
   type: ToastType;
+  duration?: number;
+  closable?: boolean;
 }
 
 const noop = () => {
   /* noop */
 };
 const ToastContext =
-  createContext<(msg: string, type?: ToastType) => void>(noop);
+  createContext<
+    (opts: {
+      message: string;
+      type?: ToastType;
+      duration?: number;
+      closable?: boolean;
+    }) => void
+  >(noop);
 
 export const useToast = () => useContext(ToastContext);
 
@@ -22,12 +37,28 @@ export default function ToastProvider({
 }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const showToast = (message: string, type: ToastType = 'info') => {
+  const removeToast = (id: number) => {
+    setToasts((t) => t.filter((toast) => toast.id !== id));
+  };
+
+  const showToast = ({
+    message,
+    type = 'info',
+    duration = 3000,
+    closable = false,
+  }: {
+    message: string;
+    type?: ToastType;
+    duration?: number;
+    closable?: boolean;
+  }) => {
     const id = Date.now() + Math.random();
-    setToasts((t) => [...t, { id, message, type }]);
-    setTimeout(() => {
-      setToasts((t) => t.filter((toast) => toast.id !== id));
-    }, 3000);
+    setToasts((t) => [...t, { id, message, type, duration, closable }]);
+    if (duration > 0) {
+      setTimeout(() => {
+        removeToast(id);
+      }, duration);
+    }
   };
 
   return (
@@ -35,8 +66,34 @@ export default function ToastProvider({
       {children}
       <div className="toast toast-top toast-end z-50" aria-live="assertive">
         {toasts.map((t) => (
-          <div key={t.id} className={`alert alert-${t.type}`}>
+          <div key={t.id} className={`alert alert-${t.type} relative`}>
             {t.message}
+            {t.closable && (
+              <button
+                className="btn btn-xs btn-circle btn-ghost absolute right-1 top-1"
+                onClick={() => removeToast(t.id)}
+                aria-label="Close"
+              >
+                ✕
+              </button>
+            )}
+            {t.duration && t.duration > 0 && (
+              <div
+                className={`absolute bottom-0 left-0 h-1 w-full rounded-b ${
+                  {
+                    info: 'bg-info',
+                    success: 'bg-success',
+                    warning: 'bg-warning',
+                    error: 'bg-error',
+                    neutral: 'bg-neutral',
+                    loading: 'bg-primary',
+                  }[t.type]
+                }`}
+                style={{
+                  animation: `toast-progress linear ${t.duration}ms forwards`,
+                }}
+              />
+            )}
           </div>
         ))}
       </div>

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react';
+import { useToast } from '../ToastProvider';
 
 export function useProjectFiles(projectPath: string) {
   const [files, setFiles] = useState<string[]>([]);
   const [noExport, setNoExport] = useState<Set<string>>(new Set());
+  const toast = useToast();
 
   useEffect(() => {
     let alive = true;
@@ -47,6 +49,12 @@ export function useProjectFiles(projectPath: string) {
         else ns.delete(file);
       });
       return ns;
+    });
+    toast({
+      message: flag
+        ? `${list.length} file(s) added to No Export`
+        : `${list.length} file(s) removed from No Export`,
+      type: 'info',
     });
   };
 

--- a/src/renderer/components/project/ProjectModals.tsx
+++ b/src/renderer/components/project/ProjectModals.tsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import RenameModal from '../RenameModal';
 import ConfirmModal from '../ConfirmModal';
+import type { ToastType } from '../ToastProvider';
 
 export function useProjectModals(
   refresh: () => void,
-  toast: (msg: string, type: 'success' | 'info' | 'error') => void
+  toast: (opts: { message: string; type?: ToastType }) => void
 ) {
   const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -22,7 +23,7 @@ export function useProjectModals(
             setDuplicateTarget(null);
             window.electronAPI?.duplicateProject(src, newName).then(() => {
               refresh();
-              toast('Project duplicated', 'success');
+              toast({ message: 'Project duplicated', type: 'success' });
             });
           }}
         />
@@ -38,7 +39,7 @@ export function useProjectModals(
             setDeleteTarget(null);
             window.electronAPI?.deleteProject(target).then(() => {
               refresh();
-              toast('Project deleted', 'info');
+              toast({ message: 'Project deleted', type: 'info' });
             });
           }}
         />

--- a/src/renderer/hooks/useExternalLink.ts
+++ b/src/renderer/hooks/useExternalLink.ts
@@ -12,7 +12,7 @@ export function useExternalLink(url: string) {
       e.preventDefault();
       shell
         .openExternal(url)
-        .catch(() => toast('Failed to open link', 'error'));
+        .catch(() => toast({ message: 'Failed to open link', type: 'error' }));
     },
     [url, toast]
   );

--- a/src/renderer/styles/index.css
+++ b/src/renderer/styles/index.css
@@ -17,3 +17,12 @@
   --color-warning: #facc15;
   --color-error: #ff4d4f;
 }
+
+@keyframes toast-progress {
+  from {
+    width: 100%;
+  }
+  to {
+    width: 0%;
+  }
+}

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -56,7 +56,7 @@ const ProjectManagerView: React.FC = () => {
   const handleCreate = (name: string, version: string) => {
     window.electronAPI?.createProject(name, version).then(() => {
       refresh();
-      toast('Project created', 'success');
+      toast({ message: 'Project created', type: 'success' });
     });
   };
 
@@ -78,10 +78,10 @@ const ProjectManagerView: React.FC = () => {
     window.electronAPI
       ?.exportProjects(Array.from(selected))
       .then(() => {
-        toast('Bulk export complete', 'success');
+        toast({ message: 'Bulk export complete', type: 'success' });
         setSelected(new Set());
       })
-      .catch(() => toast('Bulk export failed', 'error'))
+      .catch(() => toast({ message: 'Bulk export failed', type: 'error' }))
       .finally(() => setProgress(null));
   };
 

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import ExternalLink from '../components/ExternalLink';
 import { applyTheme, Theme } from '../utils/theme';
+import { useToast } from '../components/ToastProvider';
 
 export default function SettingsView() {
   const [editor, setEditor] = useState('');
   const [theme, setTheme] = useState<Theme>('system');
   const [confetti, setConfetti] = useState(true);
   const [exportDir, setExportDir] = useState('');
+  const toast = useToast();
 
   useEffect(() => {
     window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
@@ -18,23 +20,35 @@ export default function SettingsView() {
   }, []);
 
   const saveEditor = () => {
-    window.electronAPI?.setTextureEditor(editor);
+    window.electronAPI
+      ?.setTextureEditor(editor)
+      .then(() => toast({ message: 'Editor path saved', type: 'success' }))
+      .catch(() =>
+        toast({ message: 'Failed to save editor path', type: 'error' })
+      );
   };
 
   const updateTheme = async (t: Theme) => {
     setTheme(t);
     await window.electronAPI?.setTheme(t);
     applyTheme(t);
+    toast({ message: 'Theme updated', type: 'success' });
   };
 
   const saveExportDir = () => {
-    window.electronAPI?.setDefaultExportDir(exportDir);
+    window.electronAPI
+      ?.setDefaultExportDir(exportDir)
+      .then(() => toast({ message: 'Export directory saved', type: 'success' }))
+      .catch(() =>
+        toast({ message: 'Failed to save export directory', type: 'error' })
+      );
   };
 
   const toggleConfetti = async () => {
     const next = !confetti;
     setConfetti(next);
     await window.electronAPI?.setConfetti(next);
+    toast({ message: 'Preference saved', type: 'success' });
   };
   return (
     <section className="p-4" data-testid="settings-view">


### PR DESCRIPTION
## Summary
- enhance `ToastProvider` with options, close button and progress indicator
- adapt toast API across the codebase
- notify on settings saves, external editor failures and No Export toggles
- update docs with new toast usage details
- expand unit tests for closing toasts and new notifications

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc220afcc8331bd817e5ec6af74f3