### PR TITLE
Swap view loading spinners for skeletons

### DIFF
--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense, useEffect, useState, lazy } from 'react';
 import Navbar from './Navbar';
-import { Loading } from './daisy/feedback';
+import { Skeleton } from './daisy/feedback';
 
 const ProjectManagerView = lazy(() => import('../views/ProjectManagerView'));
 const EditorView = lazy(() => import('../views/EditorView'));
@@ -34,7 +34,7 @@ export default function App() {
   switch (view) {
     case 'editor':
       content = projectPath ? (
-        <Suspense fallback={<Loading />}>
+        <Suspense fallback={<Skeleton width="100%" height="20rem" />}>
           <EditorView
             projectPath={projectPath}
             onBack={toManager}
@@ -45,21 +45,21 @@ export default function App() {
       break;
     case 'settings':
       content = (
-        <Suspense fallback={<Loading />}>
+        <Suspense fallback={<Skeleton width="100%" height="20rem" />}>
           <SettingsView />
         </Suspense>
       );
       break;
     case 'about':
       content = (
-        <Suspense fallback={<Loading />}>
+        <Suspense fallback={<Skeleton width="100%" height="20rem" />}>
           <AboutView />
         </Suspense>
       );
       break;
     default:
       content = (
-        <Suspense fallback={<Loading />}>
+        <Suspense fallback={<Skeleton width="100%" height="20rem" />}>
           <ProjectManagerView />
         </Suspense>
       );

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -1,7 +1,7 @@
 import React, { Suspense, lazy, useEffect, useState } from 'react';
 import path from 'path';
 import { useToast } from './ToastProvider';
-import { Loading } from './daisy/feedback';
+import { Skeleton } from './daisy/feedback';
 import { Textarea } from './daisy/input';
 import { Button } from './daisy/actions';
 
@@ -122,7 +122,7 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
           </div>
         )}
         {lab && (
-          <Suspense fallback={<Loading />}>
+          <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
             <TextureLab
               file={full}
               projectPath={projectPath}

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -5,7 +5,7 @@ import AssetSelector from '../components/AssetSelector';
 import AssetInfo from '../components/AssetInfo';
 import ProjectInfoPanel from '../components/ProjectInfoPanel';
 import AssetSelectorInfoPanel from '../components/AssetSelectorInfoPanel';
-import { Loading } from '../components/daisy/feedback';
+import { Skeleton } from '../components/daisy/feedback';
 import ExportWizardModal, {
   BulkProgress,
 } from '../components/ExportWizardModal';
@@ -126,7 +126,7 @@ export default function EditorView({
         >
           <PanelGroup direction="vertical" className="h-full">
             <Panel defaultSize={70} className="overflow-y-auto">
-              <Suspense fallback={<Loading />}>
+              <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
                 <AssetBrowser
                   path={projectPath}
                   onSelectionChange={(sel) => setSelected(sel)}
@@ -159,7 +159,7 @@ export default function EditorView({
             <h3 className="font-bold text-lg mb-2">Add Assets</h3>
             <div className="flex gap-4 max-h-[70vh]">
               <div className="flex-1 overflow-y-auto">
-                <Suspense fallback={<Loading />}>
+                <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
                   <AssetSelector
                     path={projectPath}
                     onAssetSelect={(n) => setSelectorAsset(n)}


### PR DESCRIPTION
## Summary
- use skeleton components as suspense fallbacks
- show skeletons when loading asset browser, selector and texture lab

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc75dc6508331ba9393ef2ee1a351