### PR TITLE
Introduce Project context for renderer

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 
 import App from '../src/renderer/components/App';
+import { useProject } from '../src/renderer/components/ProjectProvider';
 
 const fire = vi.fn();
 
@@ -26,21 +27,16 @@ vi.mock('../src/renderer/views/ProjectManagerView', () => ({
   default: () => <div>manager</div>,
 }));
 vi.mock('../src/renderer/components/ProjectInfoPanel', () => ({
-  default: ({
-    onExport,
-    onBack,
-    projectPath,
-  }: {
-    onExport: () => void;
-    onBack: () => void;
-    projectPath: string;
-  }) => (
-    <div>
-      <button onClick={onExport}>Export Pack</button>
-      <button onClick={onBack}>Back to Projects</button>
-      <span>{projectPath}</span>
-    </div>
-  ),
+  default: ({ onExport, onBack }: { onExport: () => void; onBack: () => void }) => {
+    const { path } = useProject();
+    return (
+      <div>
+        <button onClick={onExport}>Export Pack</button>
+        <button onClick={onBack}>Back to Projects</button>
+        <span>{path}</span>
+      </div>
+    );
+  },
 }));
 vi.mock('../src/renderer/components/AssetSelectorInfoPanel', () => ({
   default: () => <div>info</div>,

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 import path from 'path';
 
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
@@ -10,6 +14,22 @@ const unwatchProject = vi.fn();
 const onFileAdded = vi.fn();
 const onFileRemoved = vi.fn();
 const onFileRenamed = vi.fn();
+
+function SetPath({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactNode;
+}) {
+  const { setPath } = useProject();
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setPath(path);
+    setReady(true);
+  }, [path]);
+  return ready ? <>{children}</> : null;
+}
 
 describe('AssetBrowser', () => {
   beforeEach(() => {
@@ -39,7 +59,13 @@ describe('AssetBrowser', () => {
   });
 
   it('renders files from directory', async () => {
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     expect(watchProject).toHaveBeenCalledWith('/proj');
     expect((await screen.findAllByText('a.txt'))[0]).toBeInTheDocument();
     const img = screen.getByAltText('B') as HTMLImageElement;
@@ -50,7 +76,13 @@ describe('AssetBrowser', () => {
   });
 
   it('is scrollable', async () => {
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     await screen.findAllByText('a.txt');
     const wrapper = screen.getByTestId('asset-browser');
     expect(wrapper.className).toMatch(/overflow-auto/);
@@ -90,7 +122,13 @@ describe('AssetBrowser', () => {
       getNoExport: vi.fn(async () => []),
       setNoExport: vi.fn(),
     };
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     const item = (await screen.findAllByText('a.txt'))[0];
     fireEvent.contextMenu(item);
     const revealBtn = (
@@ -141,7 +179,13 @@ describe('AssetBrowser', () => {
       renamed = cb;
     });
 
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     await screen.findAllByText('a.txt');
 
     added?.({}, 'c.txt');
@@ -179,7 +223,13 @@ describe('AssetBrowser', () => {
       getNoExport: vi.fn(async () => []),
       setNoExport: vi.fn(),
     };
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     const a = (await screen.findAllByText('a.txt'))[0];
     const b = screen.getAllByText('b.png')[0];
     fireEvent.click(a);
@@ -210,7 +260,13 @@ describe('AssetBrowser', () => {
       onFileRemoved,
       onFileRenamed,
     };
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     const a = (await screen.findAllByText('a.txt'))[0];
     const b = screen.getAllByText('b.png')[0];
     fireEvent.click(a);
@@ -245,7 +301,13 @@ describe('AssetBrowser', () => {
       onFileRemoved,
       onFileRenamed,
     };
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     const el = (await screen.findAllByText('a.txt'))[0];
     const container = el.closest('div[tabindex="0"]') as HTMLElement;
     expect(container.className).toMatch(/border-gray-400/);
@@ -254,7 +316,13 @@ describe('AssetBrowser', () => {
   });
 
   it('filters by search and adjusts zoom', async () => {
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     await screen.findAllByText('a.txt');
     const search = screen.getByPlaceholderText('Search files');
     fireEvent.change(search, { target: { value: 'b.png' } });
@@ -272,7 +340,13 @@ describe('AssetBrowser', () => {
       'assets/minecraft/textures/block/stone.png',
       'assets/minecraft/textures/item/apple.png',
     ]);
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     await screen.findAllByText('stone.png');
     const itemsChip = screen.getByText('Items');
     fireEvent.click(itemsChip);
@@ -282,7 +356,13 @@ describe('AssetBrowser', () => {
   });
 
   it('renders grid and tree together', async () => {
-    render(<AssetBrowser path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
     await screen.findAllByText('a.txt');
     expect(screen.getByTestId('file-tree')).toBeInTheDocument();
     expect(screen.getAllByText('a.txt')[0]).toBeInTheDocument();

--- a/__tests__/AssetSelector.filters.test.tsx
+++ b/__tests__/AssetSelector.filters.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 import AssetSelector from '../src/renderer/components/AssetSelector';
 
 describe('AssetSelector filters', () => {
@@ -27,8 +31,30 @@ describe('AssetSelector filters', () => {
     vi.clearAllMocks();
   });
 
+  function SetPath({
+    path,
+    children,
+  }: {
+    path: string;
+    children: React.ReactNode;
+  }) {
+    const { setPath } = useProject();
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+      setPath(path);
+      setReady(true);
+    }, [path]);
+    return ready ? <>{children}</> : null;
+  }
+
   it('filters textures by category chip and supports keyboard toggle', async () => {
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'png' } });
     await screen.findByText('blocks');

--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 
 import AssetSelector from '../src/renderer/components/AssetSelector';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 
 describe('AssetSelector', () => {
   const listTextures = vi.fn();
@@ -29,9 +37,31 @@ describe('AssetSelector', () => {
     vi.clearAllMocks();
   });
 
+  function SetPath({
+    path,
+    children,
+  }: {
+    path: string;
+    children: React.ReactNode;
+  }) {
+    const { setPath } = useProject();
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+      setPath(path);
+      setReady(true);
+    }, [path]);
+    return ready ? <>{children}</> : null;
+  }
+
   it('lists textures and handles selection', async () => {
     const onSelect = vi.fn();
-    render(<AssetSelector path="/proj" onAssetSelect={onSelect} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector onAssetSelect={onSelect} />
+        </SetPath>
+      </ProjectProvider>
+    );
     expect(listTextures).toHaveBeenCalledWith('/proj');
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
@@ -50,7 +80,13 @@ describe('AssetSelector', () => {
   });
 
   it('shows items in the items category', async () => {
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'axe' } });
     const section = await screen.findByText('items');
@@ -64,7 +100,13 @@ describe('AssetSelector', () => {
   });
 
   it('puts uncategorized textures into misc', async () => {
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'custom' } });
     const section = await screen.findByText('misc');
@@ -78,7 +120,13 @@ describe('AssetSelector', () => {
   });
 
   it('adjusts zoom level with slider', async () => {
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
     const img = (await screen.findByAltText('Grass')) as HTMLImageElement;
@@ -93,7 +141,13 @@ describe('AssetSelector', () => {
     listTextures.mockResolvedValue(
       Array.from({ length: 50 }, (_, i) => `block/test${i}.png`)
     );
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'test' } });
     await screen.findByText('blocks');
@@ -103,7 +157,13 @@ describe('AssetSelector', () => {
   });
 
   it('shows tree view', async () => {
-    render(<AssetSelector path="/proj" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
     const input = screen.getByPlaceholderText('Search texture');
     fireEvent.change(input, { target: { value: 'grass' } });
     await screen.findByText('blocks');

--- a/__tests__/AssetSelectorInfoPanel.test.tsx
+++ b/__tests__/AssetSelectorInfoPanel.test.tsx
@@ -1,16 +1,47 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 import AssetSelectorInfoPanel from '../src/renderer/components/AssetSelectorInfoPanel';
 
 describe('AssetSelectorInfoPanel', () => {
+  function SetPath({
+    path,
+    children,
+  }: {
+    path: string;
+    children: React.ReactNode;
+  }) {
+    const { setPath } = useProject();
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+      setPath(path);
+      setReady(true);
+    }, [path]);
+    return ready ? <>{children}</> : null;
+  }
   it('shows placeholder when no asset', () => {
-    render(<AssetSelectorInfoPanel projectPath="/p" asset={null} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <AssetSelectorInfoPanel asset={null} />
+        </SetPath>
+      </ProjectProvider>
+    );
     expect(screen.getByText('No asset selected')).toBeInTheDocument();
   });
 
   it('displays asset name', () => {
-    render(<AssetSelectorInfoPanel projectPath="/p" asset="block/a.png" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <AssetSelectorInfoPanel asset="block/a.png" />
+        </SetPath>
+      </ProjectProvider>
+    );
     expect(screen.getByText('block/a.png')).toBeInTheDocument();
   });
 
@@ -20,7 +51,13 @@ describe('AssetSelectorInfoPanel', () => {
       addTexture: typeof addTexture;
     }
     (window as unknown as { electronAPI: API }).electronAPI = { addTexture };
-    render(<AssetSelectorInfoPanel projectPath="/p" asset="block/a.png" />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <AssetSelectorInfoPanel asset="block/a.png" />
+        </SetPath>
+      </ProjectProvider>
+    );
     screen.getByText('Add').click();
     expect(addTexture).toHaveBeenCalledWith('/p', 'block/a.png');
   });

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 
 // eslint-disable-next-line no-var
 var openExternalMock: ReturnType<typeof vi.fn>;
@@ -21,21 +25,16 @@ vi.mock('../src/renderer/components/AssetBrowser', () => ({
   default: () => <div>browser</div>,
 }));
 vi.mock('../src/renderer/components/ProjectInfoPanel', () => ({
-  default: ({
-    onExport,
-    onBack,
-    projectPath,
-  }: {
-    onExport: () => void;
-    onBack: () => void;
-    projectPath: string;
-  }) => (
-    <div>
-      <button onClick={onExport}>Export Pack</button>
-      <button onClick={onBack}>Back to Projects</button>
-      <span>{projectPath}</span>
-    </div>
-  ),
+  default: ({ onExport, onBack }: { onExport: () => void; onBack: () => void }) => {
+    const { path } = useProject();
+    return (
+      <div>
+        <button onClick={onExport}>Export Pack</button>
+        <button onClick={onBack}>Back to Projects</button>
+        <span>{path}</span>
+      </div>
+    );
+  },
 }));
 vi.mock('../src/renderer/components/AssetSelectorInfoPanel', () => ({
   default: () => <div>info</div>,
@@ -47,6 +46,22 @@ const summary = {
   durationMs: 1000,
   warnings: [],
 };
+
+function SetPath({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactNode;
+}) {
+  const { setPath } = useProject();
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setPath(path);
+    setReady(true);
+  }, [path]);
+  return ready ? <>{children}</> : null;
+}
 
 describe('EditorView', () => {
   const exportProject = vi.fn();
@@ -74,7 +89,13 @@ describe('EditorView', () => {
   });
 
   it('shows project path and exports pack', async () => {
-    render(<EditorView projectPath="/tmp/proj" onBack={() => undefined} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/tmp/proj">
+          <EditorView onBack={() => undefined} />
+        </SetPath>
+      </ProjectProvider>
+    );
     expect(screen.getByText('/tmp/proj')).toBeInTheDocument();
     const btn = screen.getByText('Export Pack');
     await act(async () => {
@@ -87,13 +108,25 @@ describe('EditorView', () => {
 
   it('calls onBack when Back clicked', () => {
     const back = vi.fn();
-    render(<EditorView projectPath="/tmp" onBack={back} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/tmp">
+          <EditorView onBack={back} />
+        </SetPath>
+      </ProjectProvider>
+    );
     fireEvent.click(screen.getByText('Back to Projects'));
     expect(back).toHaveBeenCalled();
   });
 
   it('opens help link externally', () => {
-    render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/tmp">
+          <EditorView onBack={() => undefined} />
+        </SetPath>
+      </ProjectProvider>
+    );
     const link = screen.getByRole('link', { name: 'Help' });
     link.dispatchEvent(
       new MouseEvent('click', { bubbles: true, cancelable: true })
@@ -104,7 +137,13 @@ describe('EditorView', () => {
   });
 
   it('opens asset selector modal', () => {
-    render(<EditorView projectPath="/tmp" onBack={() => undefined} />);
+    render(
+      <ProjectProvider>
+        <SetPath path="/tmp">
+          <EditorView onBack={() => undefined} />
+        </SetPath>
+      </ProjectProvider>
+    );
     fireEvent.click(screen.getByRole('button', { name: 'Add From Vanilla' }));
     expect(screen.getByTestId('asset-selector-modal')).toBeInTheDocument();
   });

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 import ProjectInfoPanel from '../src/renderer/components/ProjectInfoPanel';
 
 const meta = {
@@ -30,14 +34,33 @@ describe('ProjectInfoPanel', () => {
     vi.clearAllMocks();
   });
 
+  function SetPath({
+    path,
+    children,
+  }: {
+    path: string;
+    children: React.ReactNode;
+  }) {
+    const { setPath } = useProject();
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+      setPath(path);
+      setReady(true);
+    }, [path]);
+    return ready ? <>{children}</> : null;
+  }
+
   it('loads metadata and triggers export', async () => {
     render(
-      <ProjectInfoPanel
-        projectPath="/p/Pack"
-        onExport={onExport}
-        onBack={onBack}
-        onSettings={vi.fn()}
-      />
+      <ProjectProvider>
+        <SetPath path="/p/Pack">
+          <ProjectInfoPanel
+            onExport={onExport}
+            onBack={onBack}
+            onSettings={vi.fn()}
+          />
+        </SetPath>
+      </ProjectProvider>
     );
     expect(load).toHaveBeenCalledWith('Pack');
     await screen.findByText('desc');
@@ -52,12 +75,15 @@ describe('ProjectInfoPanel', () => {
 
   it('falls back to default icon when pack.png missing', async () => {
     render(
-      <ProjectInfoPanel
-        projectPath="/p/Pack"
-        onExport={onExport}
-        onBack={onBack}
-        onSettings={vi.fn()}
-      />
+      <ProjectProvider>
+        <SetPath path="/p/Pack">
+          <ProjectInfoPanel
+            onExport={onExport}
+            onBack={onBack}
+            onSettings={vi.fn()}
+          />
+        </SetPath>
+      </ProjectProvider>
     );
     const img = screen.getByAltText('Pack icon') as HTMLImageElement;
     fireEvent.error(img);

--- a/__tests__/ProjectProvider.test.tsx
+++ b/__tests__/ProjectProvider.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
+
+function TestComp() {
+  const { path, setPath } = useProject();
+  return (
+    <div>
+      <span>{path ?? 'none'}</span>
+      <button onClick={() => setPath('/foo')}>set</button>
+    </div>
+  );
+}
+
+describe('ProjectProvider', () => {
+  it('provides path state and updater', () => {
+    render(
+      <ProjectProvider>
+        <TestComp />
+      </ProjectProvider>
+    );
+    expect(screen.getByText('none')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('set'));
+    expect(screen.getByText('/foo')).toBeInTheDocument();
+  });
+});

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -2,11 +2,34 @@ import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import TextureLab from '../src/renderer/components/TextureLab';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
 
 describe('TextureLab', () => {
+  function SetPath({
+    path,
+    children,
+  }: {
+    path: string;
+    children: React.ReactNode;
+  }) {
+    const { setPath } = useProject();
+    const [ready, setReady] = React.useState(false);
+    React.useEffect(() => {
+      setPath(path);
+      setReady(true);
+    }, [path]);
+    return ready ? <>{children}</> : null;
+  }
   it('renders modal with controls', () => {
     render(
-      <TextureLab file="/proj/foo.png" projectPath="/proj" onClose={() => {}} />
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <TextureLab file="/proj/foo.png" onClose={() => {}} />
+        </SetPath>
+      </ProjectProvider>
     );
     expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
     expect(screen.getByText('Texture Lab')).toBeInTheDocument();

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -12,10 +12,12 @@ const EditorView = lazy(() => import('../views/EditorView'));
 const SettingsView = lazy(() => import('../views/SettingsView'));
 const AboutView = lazy(() => import('../views/AboutView'));
 
+import { ProjectProvider, useProject } from './ProjectProvider';
+
 export type View = 'manager' | 'editor' | 'settings' | 'about';
 
-export default function App() {
-  const [projectPath, setProjectPath] = useState<string | null>(null);
+function AppContent() {
+  const { path: projectPath, setPath: setProjectPath } = useProject();
   const [view, setView] = useState<View>('manager');
 
   useEffect(() => {
@@ -40,11 +42,7 @@ export default function App() {
     case 'editor':
       content = projectPath ? (
         <Suspense fallback={<EditorViewSkeleton />}>
-          <EditorView
-            projectPath={projectPath}
-            onBack={toManager}
-            onSettings={toSettings}
-          />
+          <EditorView onBack={toManager} onSettings={toSettings} />
         </Suspense>
       ) : null;
       break;
@@ -80,5 +78,13 @@ export default function App() {
       />
       <div className="flex-1 flex flex-col">{content}</div>
     </div>
+  );
+}
+
+export default function App() {
+  return (
+    <ProjectProvider>
+      <AppContent />
+    </ProjectProvider>
   );
 }

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -4,11 +4,11 @@ import RenameModal from './RenameModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
 import FileTree from './FileTree';
+import { useProject } from './ProjectProvider';
 import { FilterBadge, InputField, Range } from './daisy/input';
 import { Accordion } from './daisy/display';
 
 interface Props {
-  path: string;
   onSelectionChange?: (sel: string[]) => void;
 }
 
@@ -39,11 +39,9 @@ const getCategory = (name: string): Filter | 'misc' => {
   return 'misc';
 };
 
-const AssetBrowser: React.FC<Props> = ({
-  path: projectPath,
-  onSelectionChange,
-}) => {
-  const { files, noExport, toggleNoExport } = useProjectFiles(projectPath);
+const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
+  const { path: projectPath } = useProject();
+  const { files, noExport, toggleNoExport } = useProjectFiles();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -170,7 +168,6 @@ const AssetBrowser: React.FC<Props> = ({
         </div>
         <div>
           <FileTree
-            projectPath={projectPath}
             files={visible}
             selected={selected}
             setSelected={setSelected}

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -4,17 +4,18 @@ import { useToast } from './ToastProvider';
 import { Skeleton } from './daisy/feedback';
 import { Textarea } from './daisy/input';
 import { Button } from './daisy/actions';
+import { useProject } from './ProjectProvider';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 const TextureLab = lazy(() => import('./TextureLab'));
 
 interface Props {
-  projectPath: string;
   asset: string | null;
   count?: number;
 }
 
-export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
+export default function AssetInfo({ asset, count = 1 }: Props) {
+  const { path: projectPath } = useProject();
   const toast = useToast();
   const [text, setText] = useState('');
   const [orig, setOrig] = useState('');
@@ -123,11 +124,7 @@ export default function AssetInfo({ projectPath, asset, count = 1 }: Props) {
         )}
         {lab && (
           <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-            <TextureLab
-              file={full}
-              projectPath={projectPath}
-              onClose={() => setLab(false)}
-            />
+            <TextureLab file={full} onClose={() => setLab(false)} />
           </Suspense>
         )}
       </div>

--- a/src/renderer/components/AssetSelector.tsx
+++ b/src/renderer/components/AssetSelector.tsx
@@ -4,9 +4,9 @@ import TextureTree from './TextureTree';
 import { FilterBadge, InputField, Range } from './daisy/input';
 import { Button } from './daisy/actions';
 import { Accordion } from './daisy/display';
+import { useProject } from './ProjectProvider';
 
 interface Props {
-  path: string;
   onAssetSelect?: (name: string) => void;
 }
 
@@ -27,10 +27,8 @@ const getCategory = (name: string): Filter | 'misc' => {
   return 'misc';
 };
 
-const AssetSelector: React.FC<Props> = ({
-  path: projectPath,
-  onAssetSelect,
-}) => {
+const AssetSelector: React.FC<Props> = ({ onAssetSelect }) => {
+  const { path: projectPath } = useProject();
   const [all, setAll] = useState<TextureInfo[]>([]);
   const [query, setQuery] = useState('');
   const [zoom, setZoom] = useState(64);

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import TextureThumb from './TextureThumb';
 import { Button } from './daisy/actions';
+import { useProject } from './ProjectProvider';
 
 interface Props {
-  projectPath: string;
   asset: string | null;
 }
 
-export default function AssetSelectorInfoPanel({ projectPath, asset }: Props) {
+export default function AssetSelectorInfoPanel({ asset }: Props) {
+  const { path: projectPath } = useProject();
   if (!asset) return <div className="p-2">No asset selected</div>;
   return (
     <div className="p-2" data-testid="selector-info">

--- a/src/renderer/components/FileTree.tsx
+++ b/src/renderer/components/FileTree.tsx
@@ -4,9 +4,9 @@ import path from 'path';
 import { buildTree, TreeItem } from '../utils/tree';
 import TextureThumb from './TextureThumb';
 import AssetContextMenu from './file/AssetContextMenu';
+import { useProject } from './ProjectProvider';
 
 interface Props {
-  projectPath: string;
   files: string[];
   selected: Set<string>;
   setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
@@ -17,7 +17,6 @@ interface Props {
 }
 
 export default function FileTree({
-  projectPath,
   files,
   selected,
   setSelected,
@@ -26,6 +25,7 @@ export default function FileTree({
   deleteFiles,
   openRename,
 }: Props) {
+  const { path: projectPath } = useProject();
   const data = React.useMemo<TreeItem[]>(() => buildTree(files), [files]);
   const [menuInfo, setMenuInfo] = useState<{
     file: string;

--- a/src/renderer/components/ProjectInfoPanel.tsx
+++ b/src/renderer/components/ProjectInfoPanel.tsx
@@ -6,19 +6,20 @@ import { Button } from './daisy/actions';
 // @ts-ignore - webpack replaces import with URL string
 import defaultIcon from '../../../resources/default_pack.png';
 
+import { useProject } from './ProjectProvider';
+
 interface Props {
-  projectPath: string;
   onExport: () => void;
   onBack: () => void;
   onSettings: () => void;
 }
 
 export default function ProjectInfoPanel({
-  projectPath,
   onExport,
   onBack,
   onSettings,
 }: Props) {
+  const { path: projectPath } = useProject();
   const [meta, setMeta] = useState<PackMeta | null>(null);
   const name = path.basename(projectPath);
 

--- a/src/renderer/components/ProjectProvider.tsx
+++ b/src/renderer/components/ProjectProvider.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react';
+
+interface ProjectContextValue {
+  path: string | null;
+  setPath: (p: string | null) => void;
+}
+
+const ProjectContext = createContext<ProjectContextValue>({
+  path: null,
+  setPath: () => {
+    /* noop */
+  },
+});
+
+export function useProject() {
+  return useContext(ProjectContext);
+}
+
+export function ProjectProvider({ children }: { children: React.ReactNode }) {
+  const [path, setPath] = useState<string | null>(null);
+  return (
+    <ProjectContext.Provider value={{ path, setPath }}>
+      {children}
+    </ProjectContext.Provider>
+  );
+}
+
+export { ProjectContext };

--- a/src/renderer/components/TextureLab.tsx
+++ b/src/renderer/components/TextureLab.tsx
@@ -4,16 +4,16 @@ import { Loading } from './daisy/feedback';
 import type { TextureEditOptions } from '../../shared/texture';
 import { Modal, Button } from './daisy/actions';
 import { Range, Select, Checkbox } from './daisy/input';
+import { useProject } from './ProjectProvider';
 
 export default function TextureLab({
   file,
-  projectPath,
   onClose,
 }: {
   file: string;
-  projectPath: string;
   onClose: () => void;
 }) {
+  const { path: projectPath } = useProject();
   const [hue, setHue] = useState(0);
   const [rotate, setRotate] = useState(0);
   const [gray, setGray] = useState(false);

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useToast } from '../ToastProvider';
+import { useProject } from '../ProjectProvider';
 
-export function useProjectFiles(projectPath: string) {
+export function useProjectFiles() {
+  const { path: projectPath } = useProject();
   const [files, setFiles] = useState<string[]>([]);
   const [noExport, setNoExport] = useState<Set<string>>(new Set());
   const toast = useToast();

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -22,16 +22,14 @@ import {
 /* eslint-enable import/no-unresolved */
 
 interface EditorViewProps {
-  projectPath: string;
   onBack: () => void;
   onSettings: () => void;
 }
 
-export default function EditorView({
-  projectPath,
-  onBack,
-  onSettings,
-}: EditorViewProps) {
+import { useProject } from '../components/ProjectProvider';
+
+export default function EditorView({ onBack, onSettings }: EditorViewProps) {
+  const { path: projectPath } = useProject();
   const [selected, setSelected] = useState<string[]>([]);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
@@ -110,7 +108,6 @@ export default function EditorView({
           className="bg-base-100 border border-base-300 rounded flex flex-col"
         >
           <ProjectInfoPanel
-            projectPath={projectPath}
             onExport={handleExport}
             onBack={onBack}
             onSettings={onSettings}
@@ -127,21 +124,14 @@ export default function EditorView({
           <PanelGroup direction="vertical" className="h-full">
             <Panel defaultSize={70} className="overflow-y-auto">
               <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-                <AssetBrowser
-                  path={projectPath}
-                  onSelectionChange={(sel) => setSelected(sel)}
-                />
+                <AssetBrowser onSelectionChange={(sel) => setSelected(sel)} />
               </Suspense>
             </Panel>
             <PanelResizeHandle className="flex items-center" tagName="div">
               <div className="w-full h-px bg-base-content"></div>
             </PanelResizeHandle>
             <Panel defaultSize={30} className="overflow-y-auto">
-              <AssetInfo
-                projectPath={projectPath}
-                asset={selected[0] ?? null}
-                count={selected.length}
-              />
+              <AssetInfo asset={selected[0] ?? null} count={selected.length} />
             </Panel>
           </PanelGroup>
         </Panel>
@@ -160,17 +150,11 @@ export default function EditorView({
             <div className="flex gap-4 max-h-[70vh]">
               <div className="flex-1 overflow-y-auto">
                 <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-                  <AssetSelector
-                    path={projectPath}
-                    onAssetSelect={(n) => setSelectorAsset(n)}
-                  />
+                  <AssetSelector onAssetSelect={(n) => setSelectorAsset(n)} />
                 </Suspense>
               </div>
               <div className="w-48 overflow-y-auto">
-                <AssetSelectorInfoPanel
-                  projectPath={projectPath}
-                  asset={selectorAsset}
-                />
+                <AssetSelectorInfoPanel asset={selectorAsset} />
               </div>
             </div>
             <div className="modal-action">


### PR DESCRIPTION
## Summary
- add ProjectProvider and useProject hook
- wrap App with provider and use context for project path
- refactor editor components/hooks to consume context
- update tests for new context
- add ProjectProvider tests

## Testing
- `npm run lint`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684fdd3d64108331bd9e093293dcd0d9