### PR TITLE
Switch to react-router for navigation

### DIFF
--- a/__tests__/Navbar.test.tsx
+++ b/__tests__/Navbar.test.tsx
@@ -1,8 +1,25 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import Navbar from '../src/renderer/components/Navbar';
+
+function HashSync() {
+  const location = useLocation();
+  React.useEffect(() => {
+    window.location.hash = `#${location.pathname}`;
+  }, [location]);
+  return null;
+}
+
+const renderNav = () =>
+  render(
+    <MemoryRouter>
+      <HashSync />
+      <Navbar />
+    </MemoryRouter>
+  );
 
 // Ensure consistent DOM for each test
 let getTheme: ReturnType<typeof vi.fn>;
@@ -21,14 +38,14 @@ beforeEach(() => {
 
 describe('Navbar', () => {
   it('displays app title', () => {
-    render(<Navbar onNavigate={vi.fn()} />);
+    renderNav();
     expect(screen.getByTestId('app-title')).toHaveTextContent(
       'Minecraft Resource Packer'
     );
   });
 
   it('toggles theme and calls setTheme', async () => {
-    render(<Navbar onNavigate={vi.fn()} />);
+    renderNav();
     const button = screen.getByLabelText('Toggle theme');
     await fireEvent.click(button);
     await Promise.resolve();
@@ -36,14 +53,13 @@ describe('Navbar', () => {
     expect(document.documentElement.getAttribute('data-theme')).toBe('light');
   });
 
-  it('calls onNavigate when nav buttons clicked', () => {
-    const nav = vi.fn();
-    render(<Navbar onNavigate={nav} />);
+  it('updates hash when nav buttons clicked', () => {
+    renderNav();
     fireEvent.click(screen.getByText('Projects'));
-    expect(nav).toHaveBeenCalledWith('manager');
+    expect(window.location.hash).toBe('#/');
     fireEvent.click(screen.getByText('Settings'));
-    expect(nav).toHaveBeenCalledWith('settings');
+    expect(window.location.hash).toBe('#/settings');
     fireEvent.click(screen.getByText('About'));
-    expect(nav).toHaveBeenCalledWith('about');
+    expect(window.location.hash).toBe('#/about');
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -56,6 +56,9 @@ The renderer separates the interface into four top‑level views found under
   [minecraft.wiki](https://minecraft.wiki/). The button uses `ExternalLink` and shows
   a toast if the link fails to open.
 
+Navigation is handled by `react-router-dom` using a `HashRouter`, so each view
+corresponds to a URL fragment: `#/`, `#/editor`, `#/settings` and `#/about`.
+
 ## Adding Functionality
 
 When adding features that need access to Node APIs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-canvas-confetti": "^2.0.7",
         "react-dom": "^19.1.0",
         "react-resizable-panels": "^3.0.3",
+        "react-router-dom": "^7.6.2",
         "react-virtualized-auto-sizer": "^1.0.26",
         "react-window": "^1.8.11",
         "sharp": "^0.34.2",
@@ -13199,6 +13200,53 @@
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
+      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
@@ -14142,6 +14190,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-canvas-confetti": "^2.0.7",
     "react-dom": "^19.1.0",
     "react-resizable-panels": "^3.0.3",
+    "react-router-dom": "^7.6.2",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "sharp": "^0.34.2",

--- a/src/renderer/components/Navbar.tsx
+++ b/src/renderer/components/Navbar.tsx
@@ -1,37 +1,24 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { toggleTheme } from '../utils/theme';
 import { Button } from './daisy/actions';
-import type { View } from './App';
 
-interface Props {
-  onNavigate: (v: View) => void;
-}
-
-export default function Navbar({ onNavigate }: Props) {
+export default function Navbar() {
   return (
     <header className="navbar bg-primary text-primary-content">
       <div className="flex-1 px-2 font-display text-lg" data-testid="app-title">
         Minecraft Resource Packer
       </div>
       <nav className="flex gap-2 mr-2">
-        <Button
-          className="btn-ghost btn-sm"
-          onClick={() => onNavigate('manager')}
-        >
+        <Link to="/" className="btn btn-ghost btn-sm">
           Projects
-        </Button>
-        <Button
-          className="btn-ghost btn-sm"
-          onClick={() => onNavigate('settings')}
-        >
+        </Link>
+        <Link to="/settings" className="btn btn-ghost btn-sm">
           Settings
-        </Button>
-        <Button
-          className="btn-ghost btn-sm"
-          onClick={() => onNavigate('about')}
-        >
+        </Link>
+        <Link to="/about" className="btn btn-ghost btn-sm">
           About
-        </Button>
+        </Link>
       </nav>
       <Button
         className="btn-square btn-ghost"

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './components/App';
 import ToastProvider from './components/ToastProvider';
+import { HashRouter } from 'react-router-dom';
 import './styles/index.css';
 import { applyTheme } from './utils/theme';
 
@@ -16,8 +17,10 @@ const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
   root.render(
-    <ToastProvider>
-      <App />
-    </ToastProvider>
+    <HashRouter>
+      <ToastProvider>
+        <App />
+      </ToastProvider>
+    </HashRouter>
   );
 }


### PR DESCRIPTION
## Summary
- add `react-router-dom`
- route renderer using `HashRouter`
- convert `App` and `Navbar` to use React Router
- adjust tests for router-based navigation
- document router usage in the handbook

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe5841e10833194d5d8078c026e9e