### PR TITLE
Improve project manager selection

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 ## Project Manager
 
-- [ ] Better selection behavior in the project manager
+- [x] Better selection behavior in the project manager
 - [ ] Better bulk action detection when using hotkeys
 - [ ] Ability to edit a project's name
 

--- a/__tests__/ProjectTable.selection.test.tsx
+++ b/__tests__/ProjectTable.selection.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import ProjectTable, {
+  ProjectInfo,
+} from '../src/renderer/components/project/ProjectTable';
+
+describe('ProjectTable selection', () => {
+  const projects: ProjectInfo[] = [
+    { name: 'One', version: '1.20', assets: 1, lastOpened: 0 },
+    { name: 'Two', version: '1.20', assets: 1, lastOpened: 0 },
+    { name: 'Three', version: '1.20', assets: 1, lastOpened: 0 },
+  ];
+
+  const noop = () => {};
+
+  it('selects a range with shift-click', () => {
+    const selected = new Set<string>();
+    const select = (n: string, c: boolean) => {
+      if (c) selected.add(n);
+      else selected.delete(n);
+    };
+
+    render(
+      <ProjectTable
+        projects={projects}
+        onSort={noop}
+        selected={selected}
+        onSelect={select}
+        onSelectAll={noop}
+        onOpen={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+        onRowClick={noop}
+      />
+    );
+
+    const boxes = screen.getAllByRole('checkbox', { name: /Select/ });
+    fireEvent.click(boxes[1]);
+    expect(selected.has('One')).toBe(true);
+    fireEvent.click(boxes[3], { shiftKey: true });
+    expect(selected.has('Two')).toBe(true);
+    expect(selected.has('Three')).toBe(true);
+  });
+
+  it('keeps selections when rows reorder', () => {
+    const selected = new Set<string>();
+    const select = (n: string, c: boolean) => {
+      if (c) selected.add(n);
+      else selected.delete(n);
+    };
+
+    const { rerender } = render(
+      <ProjectTable
+        projects={projects}
+        onSort={noop}
+        selected={selected}
+        onSelect={select}
+        onSelectAll={noop}
+        onOpen={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+        onRowClick={noop}
+      />
+    );
+
+    const boxes = screen.getAllByRole('checkbox', { name: /Select/ });
+    fireEvent.click(boxes[1]);
+    expect(selected.has('One')).toBe(true);
+
+    rerender(
+      <ProjectTable
+        projects={[...projects].reverse()}
+        onSort={noop}
+        selected={selected}
+        onSelect={select}
+        onSelectAll={noop}
+        onOpen={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+        onRowClick={noop}
+      />
+    );
+
+    const row = screen.getByText('One').closest('tr') as HTMLElement;
+    const box = within(row).getByRole('checkbox');
+    expect(box).toBeChecked();
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -125,6 +125,12 @@ row loads metadata from `project.json` via IPC and displays the pack description
 author, related URLs and creation timestamps. Use the **Edit** button to modify
 these fields and save back to `project.json`.
 
+## Row Selection
+
+Checkboxes in the project table select rows. Hold **Shift** while clicking to
+select a contiguous range beginning from the last clicked row. Selected rows are
+highlighted and selections persist when sorting or filtering the table.
+
 ## Bulk Export
 
 Select multiple rows using the checkboxes in the projects table and click

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -38,6 +38,7 @@ export default function ProjectTable({
   onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
 }) {
+  const lastIndex = React.useRef<number | null>(null);
   const allSelected =
     selected.size > 0 && projects.every((p) => selected.has(p.name));
 
@@ -52,7 +53,7 @@ export default function ProjectTable({
                 checked={allSelected}
                 onClick={(e) => e.stopPropagation()}
                 onChange={(e) => onSelectAll(e.target.checked)}
-                className="checkbox-sm"
+                className="checkbox checkbox-primary checkbox-sm"
               />
             </th>
             <th onClick={() => onSort('name')} className="cursor-pointer">
@@ -81,7 +82,9 @@ export default function ProjectTable({
                 if (e.key === 'Delete') onDelete(p.name);
               }}
               tabIndex={0}
-              className="cursor-pointer"
+              className={`cursor-pointer ${
+                selected.has(p.name) ? 'bg-base-300' : ''
+              }`}
             >
               <td>
                 <Checkbox
@@ -90,9 +93,23 @@ export default function ProjectTable({
                   onClick={(e) => e.stopPropagation()}
                   onChange={(e) => {
                     e.stopPropagation();
-                    onSelect(p.name, e.target.checked);
+                    const idx = projects.findIndex((x) => x.name === p.name);
+                    const checked = e.target.checked;
+                    if (
+                      (e.nativeEvent as MouseEvent).shiftKey &&
+                      lastIndex.current !== null
+                    ) {
+                      const start = Math.min(lastIndex.current, idx);
+                      const end = Math.max(lastIndex.current, idx);
+                      for (let i = start; i <= end; i++) {
+                        onSelect(projects[i].name, checked);
+                      }
+                    } else {
+                      onSelect(p.name, checked);
+                    }
+                    lastIndex.current = idx;
                   }}
-                  className="checkbox-sm"
+                  className="checkbox checkbox-primary checkbox-sm"
                 />
               </td>
               <td className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add shift-click multi-select to ProjectTable
- keep selection highlighted when sorting
- use daisyUI checkbox styles
- document new selection behaviour in the developer handbook
- test selection features
- check off completed TODO

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684ffb7da500833194b5386bbb5ad9f4