### PR TITLE
Add project rename feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -18,7 +18,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 - [x] Better selection behavior in the project manager
 - [ ] Better bulk action detection when using hotkeys
-- [ ] Ability to edit a project's name
+- [x] Ability to edit a project's name
 
 ---
 

--- a/__tests__/renameProject.test.ts
+++ b/__tests__/renameProject.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+import {
+  createProject,
+  renameProject,
+  registerProjectHandlers,
+} from '../src/main/projects';
+import * as icon from '../src/main/icon';
+
+const baseDir = path.join(os.tmpdir(), `rename-${uuid()}`);
+
+let handler:
+  | ((e: unknown, name: string, newName: string) => void | Promise<void>)
+  | undefined;
+const ipcMock = {
+  handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+    if (channel === 'rename-project') handler = fn as typeof handler;
+  },
+} as unknown as import('electron').IpcMain;
+
+beforeAll(() => {
+  fs.mkdirSync(baseDir, { recursive: true });
+  vi.spyOn(icon, 'generatePackIcon').mockResolvedValue();
+});
+
+afterAll(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
+describe('renameProject', () => {
+  it('renames folder and updates metadata', async () => {
+    await createProject(baseDir, 'Old', '1.20');
+    await renameProject(baseDir, 'Old', 'New');
+    expect(fs.existsSync(path.join(baseDir, 'New'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'Old'))).toBe(false);
+    const data = JSON.parse(
+      fs.readFileSync(path.join(baseDir, 'New', 'project.json'), 'utf-8')
+    );
+    expect(data.name).toBe('New');
+  });
+
+  it('registers IPC handler', async () => {
+    registerProjectHandlers(ipcMock, baseDir, vi.fn());
+    expect(handler).toBeTypeOf('function');
+    await handler?.({}, 'New', 'Newer');
+    expect(fs.existsSync(path.join(baseDir, 'Newer'))).toBe(true);
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -125,7 +125,9 @@ Both protocols are registered in `src/main/index.ts` when Electron starts.
 The projects dashboard includes a sidebar next to the project table. Selecting a
 row loads metadata from `project.json` via IPC and displays the pack description,
 author, related URLs and creation timestamps. Use the **Edit** button to modify
-these fields and save back to `project.json`.
+these fields and save back to `project.json`. The sidebar also includes a
+**Rename** button that opens a modal to change the project's folder name and
+updates `project.json` accordingly.
 
 ## Row Selection
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -30,6 +30,8 @@ const api = {
   importProject: () => invoke('import-project'),
   duplicateProject: (name: string, newName: string) =>
     invoke('duplicate-project', name, newName),
+  renameProject: (name: string, newName: string) =>
+    invoke('rename-project', name, newName),
   deleteProject: (name: string) => invoke('delete-project', name),
   openProject: (name: string) => invoke('open-project', name),
   onOpenProject: (listener: (e: unknown, path: string) => void) =>

--- a/src/renderer/components/ProjectSidebar.tsx
+++ b/src/renderer/components/ProjectSidebar.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ExternalLink from './ExternalLink';
 import PackMetaModal from './PackMetaModal';
+import RenameModal from './RenameModal';
 import type { PackMeta } from '../../main/projects';
 import { ProjectSidebarSkeleton } from './skeleton';
 
@@ -11,6 +12,7 @@ export default function ProjectSidebar({
 }) {
   const [meta, setMeta] = useState<PackMeta | null>(null);
   const [edit, setEdit] = useState(false);
+  const [rename, setRename] = useState(false);
 
   useEffect(() => {
     if (project) {
@@ -51,6 +53,12 @@ export default function ProjectSidebar({
               >
                 Edit
               </button>
+              <button
+                className="btn btn-neutral btn-sm mt-2"
+                onClick={() => setRename(true)}
+              >
+                Rename
+              </button>
             </div>
           ) : (
             <ProjectSidebarSkeleton />
@@ -69,6 +77,19 @@ export default function ProjectSidebar({
             window.electronAPI?.savePackMeta(project, m).then(() => {
               setMeta(m);
               setEdit(false);
+            });
+          }}
+        />
+      )}
+      {rename && project && (
+        <RenameModal
+          current={project}
+          title="Rename Project"
+          confirmText="Rename"
+          onCancel={() => setRename(false)}
+          onRename={(n) => {
+            window.electronAPI?.renameProject(project, n).then(() => {
+              setRename(false);
             });
           }}
         />

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -19,6 +19,7 @@ declare global {
       createProject: IpcInvoke<'create-project'>;
       importProject: IpcInvoke<'import-project'>;
       duplicateProject: IpcInvoke<'duplicate-project'>;
+      renameProject: IpcInvoke<'rename-project'>;
       deleteProject: IpcInvoke<'delete-project'>;
       openProject: IpcInvoke<'open-project'>;
       loadPackMeta: IpcInvoke<'load-pack-meta'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -10,6 +10,7 @@ export interface IpcRequestMap {
   'create-project': [string, string];
   'import-project': [];
   'duplicate-project': [string, string];
+  'rename-project': [string, string];
   'delete-project': [string];
   'open-project': [string];
   'load-pack-meta': [string];
@@ -54,6 +55,7 @@ export interface IpcResponseMap {
   'create-project': void;
   'import-project': void;
   'duplicate-project': void;
+  'rename-project': void;
   'delete-project': void;
   'open-project': void;
   'load-pack-meta': PackMeta;


### PR DESCRIPTION
## Summary
- add rename-project IPC method
- expose renameProject in preload and global types
- implement rename modal in ProjectSidebar
- add renameProject unit tests
- document rename capability in handbook
- mark task done in TODO

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850018b5e6c83318eecea7515951b9a