### PR TITLE
Implement texture comparison modal

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 ### Asset Info & Texture Inspector
 
 - [ ] Revision history (max 20)
-- [ ] Preview against the vanilla texture using the `Diff` component
+- [x] Preview against the vanilla texture using the `Diff` component
 - [x] Generic icon thumbnail for text files
 - [ ] More robust JSON editor
 - [ ] Optional 3D preview for entity models and item textures

--- a/__tests__/TextureDiff.test.tsx
+++ b/__tests__/TextureDiff.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TextureDiff from '../src/renderer/components/TextureDiff';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
+
+function SetPath({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactNode;
+}) {
+  const { setPath } = useProject();
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setPath(path);
+    setReady(true);
+  }, [path]);
+  return ready ? <>{children}</> : null;
+}
+
+describe('TextureDiff', () => {
+  it('renders vanilla comparison', async () => {
+    const getTextureUrl = vi.fn().mockResolvedValue('vanilla://foo.png');
+    (
+      window as unknown as {
+        electronAPI: { getTextureUrl: typeof getTextureUrl };
+      }
+    ).electronAPI = {
+      getTextureUrl,
+    } as never;
+
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <TextureDiff asset="block/a.png" onClose={() => undefined} />
+        </SetPath>
+      </ProjectProvider>
+    );
+
+    expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/a.png');
+    expect(await screen.findByTestId('diff')).toBeInTheDocument();
+    const imgs = screen.getAllByRole('img');
+    expect(imgs[0]).toHaveAttribute('src', 'vanilla://foo.png');
+    expect(imgs[1]).toHaveAttribute('src', 'asset://block/a.png');
+  });
+
+  it('calls onClose', async () => {
+    const getTextureUrl = vi.fn().mockResolvedValue('vanilla://foo.png');
+    const onClose = vi.fn();
+    (
+      window as unknown as {
+        electronAPI: { getTextureUrl: typeof getTextureUrl };
+      }
+    ).electronAPI = {
+      getTextureUrl,
+    } as never;
+
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <TextureDiff asset="block/a.png" onClose={onClose} />
+        </SetPath>
+      </ProjectProvider>
+    );
+
+    const btn = await screen.findByRole('button', { name: 'Close' });
+    fireEvent.click(btn);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -169,6 +169,13 @@ The **Pack Icon Editor** modal customises `pack.png` for a project. You can
 randomise the item and background, choose a border colour or upload a custom PNG.
 The image is processed with Sharp in the main process and saved at 128×128.
 
+## Asset Info
+
+The panel beside the asset browser displays details about the selected file. When
+viewing a PNG texture the panel offers a **Compare with Vanilla** button. It
+opens a modal that uses the daisyUI `Diff` component to show the project texture
+against the original game asset side by side.
+
 ## Windows Paths
 
 When writing tests or other code that constructs file system paths, prefer

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -8,6 +8,7 @@ import { useProject } from './ProjectProvider';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 const TextureLab = lazy(() => import('./TextureLab'));
+const TextureDiff = lazy(() => import('./TextureDiff'));
 
 interface Props {
   asset: string | null;
@@ -21,6 +22,7 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
   const [orig, setOrig] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [lab, setLab] = useState(false);
+  const [diff, setDiff] = useState(false);
 
   const full = asset ? path.join(projectPath, asset) : '';
 
@@ -120,11 +122,22 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
             >
               Edit Externally
             </Button>
+            <Button
+              className="btn-secondary btn-sm"
+              onClick={() => setDiff(true)}
+            >
+              Compare with Vanilla
+            </Button>
           </div>
         )}
         {lab && (
           <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
             <TextureLab file={full} onClose={() => setLab(false)} />
+          </Suspense>
+        )}
+        {diff && (
+          <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+            <TextureDiff asset={asset} onClose={() => setDiff(false)} />
           </Suspense>
         )}
       </div>

--- a/src/renderer/components/TextureDiff.tsx
+++ b/src/renderer/components/TextureDiff.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, Button } from './daisy/actions';
+import { Diff } from './daisy/display';
+import { useProject } from './ProjectProvider';
+
+export default function TextureDiff({
+  asset,
+  onClose,
+}: {
+  asset: string;
+  onClose: () => void;
+}) {
+  const { path: projectPath } = useProject();
+  const [vanilla, setVanilla] = useState<string | null>(null);
+
+  useEffect(() => {
+    setVanilla(null);
+    window.electronAPI
+      ?.getTextureUrl(projectPath, asset)
+      .then((url) => setVanilla(url));
+  }, [projectPath, asset]);
+
+  if (!vanilla) return null;
+
+  return (
+    <Modal open>
+      <h3 className="font-bold text-lg mb-2">Vanilla Comparison</h3>
+      <Diff
+        before={
+          <img
+            src={vanilla}
+            alt="vanilla"
+            style={{ imageRendering: 'pixelated' }}
+          />
+        }
+        after={
+          <img
+            src={`asset://${asset}`}
+            alt="project"
+            style={{ imageRendering: 'pixelated' }}
+          />
+        }
+      />
+      <div className="modal-action">
+        <Button onClick={onClose}>Close</Button>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- compare textures with vanilla version
- add TextureDiff component and tests
- document the new comparison feature in the handbook
- mark task complete in TODO list

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run lint` *(warnings present)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685003c5493c83319d1209244c531c2b