### PR TITLE
Implement multi-project hotkeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ original filename is still shown alongside the formatted name and in tooltips.
 Specify the path to your preferred image editor under **Settings**. PNG textures
 can then be opened directly from the asset info panel using the **Edit
 Externally** button.
+
+### Keyboard Shortcuts
+
+The Project Manager supports a few hotkeys:
+
+- **Enter** – open all selected projects.
+- **Delete** – remove all selected projects.

--- a/TODO.md
+++ b/TODO.md
@@ -17,7 +17,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 ## Project Manager
 
 - [x] Better selection behavior in the project manager
-- [ ] Better bulk action detection when using hotkeys
+- [x] Better bulk action detection when using hotkeys
 - [ ] Ability to edit a project's name
 
 ---

--- a/__tests__/ProjectManagerView.hotkeys.test.tsx
+++ b/__tests__/ProjectManagerView.hotkeys.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectManagerView from '../src/renderer/views/ProjectManagerView';
+import type { ProjectInfo } from '../src/renderer/components/project/ProjectTable';
+
+describe('ProjectManagerView hotkeys', () => {
+  const listProjects = vi.fn();
+  const listPackFormats = vi.fn();
+  const openProject = vi.fn();
+  const deleteProject = vi.fn();
+  const getProjectSort = vi.fn();
+  const setProjectSort = vi.fn();
+
+  beforeEach(() => {
+    interface API {
+      listProjects: () => Promise<ProjectInfo[]>;
+      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      openProject: (name: string) => void;
+      deleteProject: (name: string) => Promise<void>;
+      createProject: (name: string, version: string) => Promise<void>;
+      importProject: () => Promise<void>;
+      duplicateProject: (name: string, newName: string) => Promise<void>;
+      getProjectSort: () => Promise<{ key: keyof ProjectInfo; asc: boolean }>;
+      setProjectSort: (key: keyof ProjectInfo, asc: boolean) => Promise<void>;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      listProjects,
+      listPackFormats,
+      openProject,
+      deleteProject,
+      createProject: vi.fn(),
+      importProject: vi.fn(),
+      duplicateProject: vi.fn(),
+      getProjectSort,
+      setProjectSort,
+    };
+    listProjects.mockResolvedValue([
+      { name: 'Alpha', version: '1.20', assets: 2, lastOpened: 0 },
+      { name: 'Beta', version: '1.20', assets: 3, lastOpened: 1 },
+    ]);
+    listPackFormats.mockResolvedValue([]);
+    deleteProject.mockResolvedValue(Promise.resolve());
+    getProjectSort.mockResolvedValue({ key: 'name', asc: true });
+    setProjectSort.mockResolvedValue(Promise.resolve());
+    openProject.mockReset();
+    deleteProject.mockReset();
+  });
+
+  it('opens all selected projects with Enter', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('checkbox');
+    const boxes = screen.getAllByRole('checkbox', { name: /Select/ });
+    fireEvent.click(boxes[1]);
+    fireEvent.click(boxes[2], { ctrlKey: true });
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(openProject).toHaveBeenCalledWith('Alpha');
+    expect(openProject).toHaveBeenCalledWith('Beta');
+  });
+
+  it('deletes all selected projects with Delete', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('checkbox');
+    const boxes = screen.getAllByRole('checkbox', { name: /Select/ });
+    fireEvent.click(boxes[1]);
+    fireEvent.click(boxes[2], { ctrlKey: true });
+    fireEvent.keyDown(window, { key: 'Delete' });
+    expect(deleteProject).toHaveBeenCalledWith('Alpha');
+    expect(deleteProject).toHaveBeenCalledWith('Beta');
+  });
+});

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -78,8 +78,8 @@ export default function ProjectTable({
               onClick={() => onRowClick(p.name)}
               onDoubleClick={() => onOpen(p.name)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter') onOpen(p.name);
-                if (e.key === 'Delete') onDelete(p.name);
+                if (e.key === 'Enter' && selected.size <= 1) onOpen(p.name);
+                if (e.key === 'Delete' && selected.size <= 1) onDelete(p.name);
               }}
               tabIndex={0}
               className={`cursor-pointer ${

--- a/src/renderer/hooks/useProjectHotkeys.ts
+++ b/src/renderer/hooks/useProjectHotkeys.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useToast } from '../components/ToastProvider';
+
+export default function useProjectHotkeys(
+  selected: Set<string>,
+  onOpen: (name: string) => void,
+  onDelete: (names: string[]) => void
+) {
+  const toast = useToast();
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if (selected.size === 0) return;
+      if (e.key === 'Delete') {
+        e.preventDefault();
+        onDelete(Array.from(selected));
+        toast({
+          message:
+            selected.size > 1
+              ? `Deleted ${selected.size} projects`
+              : 'Project deleted',
+          type: 'info',
+        });
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        Array.from(selected).forEach(onOpen);
+        if (selected.size > 1) {
+          toast({
+            message: `Opened ${selected.size} projects`,
+            type: 'success',
+          });
+        }
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [selected, onOpen, onDelete, toast]);
+}

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -11,6 +11,7 @@ import SearchToolbar from '../components/project/SearchToolbar';
 import ExportWizardModal, {
   BulkProgress,
 } from '../components/ExportWizardModal';
+import useProjectHotkeys from '../hooks/useProjectHotkeys';
 
 // Lists all available projects and lets the user open them.
 
@@ -87,6 +88,12 @@ const ProjectManagerView: React.FC = () => {
       .finally(() => setProgress(null));
   };
 
+  const handleDeleteSelected = (names: string[]) => {
+    names.forEach((n) => window.electronAPI?.deleteProject(n));
+    setSelected(new Set());
+    refresh();
+  };
+
   const chipVersions = useMemo(
     () => Array.from(new Set(projects.map((p) => p.version))),
     [projects]
@@ -123,6 +130,8 @@ const ProjectManagerView: React.FC = () => {
     else ns.delete(name);
     setSelected(ns);
   };
+
+  useProjectHotkeys(selected, handleOpen, handleDeleteSelected);
 
   return (
     <section className="flex gap-4 max-w-5xl mx-auto">


### PR DESCRIPTION
## Summary
- add `useProjectHotkeys` hook
- apply hotkeys in ProjectManagerView for opening and deleting multiple projects
- adjust ProjectTable to respect multi-selection
- document keyboard shortcuts in README
- mark TODO item as complete
- add tests for bulk hotkeys

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68500aa4c6388331a1d83c460a32226f