### PR TITLE
Remember export directory

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -54,7 +54,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Target resolution radio (16×/32×/64×)
 - [ ] Validation checklist (missing textures, duplicates)
 - [ ] Version field for projects; it should also appear in exported file names
-- [ ] Remember the last export target folder using electron store on successful exports
+- [x] Remember the last export target folder using electron store on successful exports
 
 ---
 

--- a/__tests__/exportDirPersistence.test.tsx
+++ b/__tests__/exportDirPersistence.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+
+// eslint-disable-next-line no-var
+var showOpenDialogMock: ReturnType<typeof vi.fn>;
+// eslint-disable-next-line no-var
+var showSaveDialogMock: ReturnType<typeof vi.fn>;
+
+vi.mock('electron', () => {
+  showOpenDialogMock = vi.fn();
+  showSaveDialogMock = vi.fn();
+  return {
+    dialog: {
+      showOpenDialog: showOpenDialogMock,
+      showSaveDialog: showSaveDialogMock,
+    },
+    app: { getPath: () => '/tmp' },
+  };
+});
+
+const tmpDir = path.join(os.tmpdir(), `exp-${uuid()}`);
+const baseDir = path.join(tmpDir, 'projects');
+const proj = path.join(baseDir, 'A');
+const outDir = path.join(tmpDir, 'out');
+
+beforeAll(() => {
+  fs.mkdirSync(proj, { recursive: true });
+  fs.writeFileSync(path.join(proj, 'a.txt'), '1');
+  fs.mkdirSync(outDir, { recursive: true });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('export directory persistence', () => {
+  it('stores folder after bulk export', async () => {
+    const { exportProjects } = await import('../src/main/exporter');
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: [outDir],
+    });
+    await exportProjects(baseDir, ['A']);
+    vi.resetModules();
+    const { getDefaultExportDir } = await import('../src/main/layout');
+    expect(getDefaultExportDir()).toBe(outDir);
+  });
+
+  it('stores folder after single export', async () => {
+    let handler: ((e: unknown, p: string) => unknown) | undefined;
+    const ipcMock = {
+      handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+        if (channel === 'export-project') handler = fn as typeof handler;
+      },
+    } as unknown as import('electron').IpcMain;
+    const { registerExportHandlers } = await import('../src/main/exporter');
+    registerExportHandlers(ipcMock, baseDir);
+    showSaveDialogMock.mockResolvedValue({
+      canceled: false,
+      filePath: path.join(outDir, 'A.zip'),
+    });
+    expect(handler).toBeTypeOf('function');
+    await handler?.({}, proj);
+    vi.resetModules();
+    const { getDefaultExportDir } = await import('../src/main/layout');
+    expect(getDefaultExportDir()).toBe(outDir);
+  });
+});

--- a/__tests__/exportProjects.test.ts
+++ b/__tests__/exportProjects.test.ts
@@ -23,6 +23,7 @@ vi.mock('electron', () => {
 
 vi.mock('../src/main/layout', () => ({
   getDefaultExportDir: () => outDir,
+  setDefaultExportDir: vi.fn(),
 }));
 
 import { exportProjects } from '../src/main/exporter';

--- a/__tests__/windowBounds.test.ts
+++ b/__tests__/windowBounds.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
-import { setWindowBounds, setFullscreen } from '../src/main/windowBounds';
+import { setWindowBounds, setMaximized } from '../src/main/windowBounds';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
 
 describe('window bounds persistence', () => {
   it('persists across reloads', async () => {
     setWindowBounds({ x: 1, y: 2, width: 300, height: 400 });
-    setFullscreen(true);
+    setMaximized(true);
     vi.resetModules();
-    const { getWindowBounds, isFullscreen } = await import(
+    const { getWindowBounds, isMaximized } = await import(
       '../src/main/windowBounds'
     );
     expect(getWindowBounds()).toEqual({ x: 1, y: 2, width: 300, height: 400 });
-    expect(isFullscreen()).toBe(true);
+    expect(isMaximized()).toBe(true);
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -37,6 +37,7 @@ npm run format
 
 5. Window size, position and fullscreen state persist across launches thanks to `electron-store`.
 6. The Asset Browser remembers the last search text, category filters and zoom level using `electron-store`.
+7. Export dialogs default to the most recently used folder, which is stored via `electron-store` after each successful export.
 
 ## Project Structure
 

--- a/src/main/exporter.ts
+++ b/src/main/exporter.ts
@@ -7,7 +7,7 @@ import archiver from 'archiver';
 import { packFormatForVersion } from '../shared/packFormat';
 import type { IpcMain } from 'electron';
 import { dialog } from 'electron';
-import { getDefaultExportDir } from './layout';
+import { getDefaultExportDir, setDefaultExportDir } from './layout';
 import { ProjectMetadataSchema } from '../shared/project';
 
 export interface ExportSummary {
@@ -122,6 +122,7 @@ export async function exportProjects(
       throw new Error(`Failed to export ${name}`);
     });
   }
+  setDefaultExportDir(dir);
 }
 
 export function registerExportHandlers(ipc: IpcMain, baseDir: string) {
@@ -137,7 +138,9 @@ export function registerExportHandlers(ipc: IpcMain, baseDir: string) {
         filters: [{ name: 'Zip Files', extensions: ['zip'] }],
       });
       if (canceled || !filePath) return;
-      return exportPack(projectPath, filePath);
+      const summary = await exportPack(projectPath, filePath);
+      setDefaultExportDir(path.dirname(filePath));
+      return summary;
     }
   );
   ipc.handle('export-projects', (_e, names: string[]) =>


### PR DESCRIPTION
## Summary
- store chosen export folder after successful exports
- open export dialog in the previously used folder
- document export folder persistence in the handbook
- check off TODO about remembering export target
- test persistence logic
- fix outdated windowBounds test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685035f5f9ac8331806f2611f8ea4747