### PR TITLE
Add monaco JSON editor for metadata

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Revision history (max 20)
 - [x] Preview against the vanilla texture using the `Diff` component
 - [x] Generic icon thumbnail for text files
-- [ ] More robust JSON editor
+- [x] More robust JSON editor
 - [ ] Optional 3D preview for entity models and item textures
 
 ### Project Info Panel

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -26,8 +26,10 @@ describe('PackMetaModal', () => {
         onCancel={onCancel}
       />
     );
-    fireEvent.change(screen.getByPlaceholderText('Description'), {
-      target: { value: 'new' },
+    const box = screen.getByRole('textbox');
+    const updated = { ...meta, description: 'new' };
+    fireEvent.change(box, {
+      target: { value: JSON.stringify(updated, null, 2) },
     });
     fireEvent.click(screen.getByText('Save'));
     expect(onSave).toHaveBeenCalledWith(

--- a/__tests__/jsonEditor.test.tsx
+++ b/__tests__/jsonEditor.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PackMetaModal from '../src/renderer/components/PackMetaModal';
+import ToastProvider from '../src/renderer/components/ToastProvider';
+import type { PackMeta } from '../src/main/projects';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+
+describe('PackMetaModal JSON validation', () => {
+  it('rejects invalid json', () => {
+    const meta: PackMeta = {
+      description: '',
+      author: '',
+      urls: [],
+      created: 0,
+      license: '',
+    };
+    const onSave = vi.fn();
+    render(
+      <ToastProvider>
+        <PackMetaModal
+          project="Pack"
+          meta={meta}
+          onSave={onSave}
+          onCancel={vi.fn()}
+        />
+      </ToastProvider>
+    );
+    const box = screen.getByRole('textbox');
+    fireEvent.change(box, { target: { value: '{' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getAllByText('Invalid metadata')).toHaveLength(2);
+  });
+});

--- a/__tests__/windowBounds.test.ts
+++ b/__tests__/windowBounds.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
-import { setWindowBounds, setFullscreen } from '../src/main/windowBounds';
+import { setWindowBounds, setMaximized } from '../src/main/windowBounds';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
 
 describe('window bounds persistence', () => {
   it('persists across reloads', async () => {
     setWindowBounds({ x: 1, y: 2, width: 300, height: 400 });
-    setFullscreen(true);
+    setMaximized(true);
     vi.resetModules();
-    const { getWindowBounds, isFullscreen } = await import(
+    const { getWindowBounds, isMaximized } = await import(
       '../src/main/windowBounds'
     );
     expect(getWindowBounds()).toEqual({ x: 1, y: 2, width: 300, height: 400 });
-    expect(isFullscreen()).toBe(true);
+    expect(isMaximized()).toBe(true);
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -125,8 +125,9 @@ Both protocols are registered in `src/main/index.ts` when Electron starts.
 
 The projects dashboard includes a sidebar next to the project table. Selecting a
 row loads metadata from `project.json` via IPC and displays the pack description,
-author, related URLs and creation timestamps. Use the **Edit** button to modify
-these fields and save back to `project.json`. The sidebar also includes a
+author, related URLs and creation timestamps. Use the **Edit** button to open a
+JSON editor powered by Monaco. Edits are validated against `PackMetaSchema` when
+saving and any errors appear as a toast. The sidebar also includes a
 **Rename** button that opens a modal to change the project's folder name and
 updates `project.json` accordingly.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@monaco-editor/react": "^4.7.0",
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
         "electron-squirrel-startup": "^1.0.1",
@@ -16,6 +17,7 @@
         "fuse.js": "^7.1.0",
         "global-agent": "^3.0.0",
         "minecraft-data": "^3.89.0",
+        "monaco-editor": "^0.52.2",
         "react": "^19.1.0",
         "react-arborist": "^3.4.3",
         "react-canvas-confetti": "^2.0.7",
@@ -2381,6 +2383,29 @@
       },
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11586,6 +11611,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14690,6 +14721,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@monaco-editor/react": "^4.7.0",
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
     "electron-squirrel-startup": "^1.0.1",
@@ -26,6 +27,7 @@
     "fuse.js": "^7.1.0",
     "global-agent": "^3.0.0",
     "minecraft-data": "^3.89.0",
+    "monaco-editor": "^0.52.2",
     "react": "^19.1.0",
     "react-arborist": "^3.4.3",
     "react-canvas-confetti": "^2.0.7",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
@@ -13,3 +14,18 @@ if (!window.matchMedia) {
     removeEventListener: vi.fn(),
   })) as unknown as typeof window.matchMedia;
 }
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) =>
+    React.createElement('textarea', {
+      value,
+      onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) =>
+        onChange(e.target.value),
+    }),
+}));

--- a/src/renderer/components/JsonEditor.tsx
+++ b/src/renderer/components/JsonEditor.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Editor, { OnChange } from '@monaco-editor/react';
+
+interface JsonEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  height?: string;
+}
+
+export default function JsonEditor({
+  value,
+  onChange,
+  height = '200px',
+}: JsonEditorProps) {
+  const handleChange: OnChange = (val) => {
+    onChange(val ?? '');
+  };
+  return (
+    <Editor
+      height={height}
+      defaultLanguage="json"
+      value={value}
+      onChange={handleChange}
+      theme="vs-dark"
+      options={{ minimap: { enabled: false }, automaticLayout: true }}
+    />
+  );
+}

--- a/src/renderer/components/PackMetaModal.tsx
+++ b/src/renderer/components/PackMetaModal.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 import path from 'path';
 import { app } from 'electron';
 import type { PackMeta } from '../../main/projects';
+import { PackMetaSchema } from '../../shared/project';
 import { Modal, Button } from './daisy/actions';
-import { InputField, Textarea } from './daisy/input';
+import JsonEditor from './JsonEditor';
+import { useToast } from './ToastProvider';
 
 export default function PackMetaModal({
   project,
@@ -16,46 +18,25 @@ export default function PackMetaModal({
   onSave: (m: PackMeta) => void;
   onCancel: () => void;
 }) {
-  const [desc, setDesc] = useState(meta.description);
-  const [author, setAuthor] = useState(meta.author);
-  const [urls, setUrls] = useState(meta.urls.join('\n'));
+  const [text, setText] = useState(JSON.stringify(meta, null, 2));
+  const toast = useToast();
   return (
     <Modal open>
       <form
         className="flex flex-col gap-2"
         onSubmit={(e) => {
           e.preventDefault();
-          onSave({
-            ...meta,
-            description: desc,
-            author,
-            urls: urls
-              .split(/\n+/)
-              .map((u: string) => u.trim())
-              .filter((u: string) => u),
-            updated: Date.now(),
-          });
+          try {
+            const obj = JSON.parse(text);
+            const parsed = PackMetaSchema.parse(obj);
+            onSave({ ...parsed, updated: Date.now() });
+          } catch {
+            toast({ message: 'Invalid metadata', type: 'error' });
+          }
         }}
       >
         <h3 className="font-bold text-lg">Edit Metadata</h3>
-        <Textarea
-          className="textarea-bordered"
-          value={desc}
-          onChange={(e) => setDesc(e.target.value)}
-          placeholder="Description"
-        />
-        <InputField
-          className="input-bordered"
-          value={author}
-          onChange={(e) => setAuthor(e.target.value)}
-          placeholder="Author"
-        />
-        <Textarea
-          className="textarea-bordered"
-          value={urls}
-          onChange={(e) => setUrls(e.target.value)}
-          placeholder="URLs (one per line)"
-        />
+        <JsonEditor value={text} onChange={setText} height="16rem" />
         <div className="modal-action">
           <Button
             type="button"


### PR DESCRIPTION
## Summary
- install monaco editor packages
- add `JsonEditor` component using `@monaco-editor/react`
- use the new editor in `PackMetaModal` with zod validation and toast errors
- add unit test for invalid JSON
- update existing tests and docs
- mark task in TODO

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685035df110c83319df1dac52624fd33