### PR TITLE
Implement Monaco-based JSON editor

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Revision history (max 20)
 - [x] Preview against the vanilla texture using the `Diff` component
 - [x] Generic icon thumbnail for text files
-- [ ] More robust JSON editor
+- [x] More robust JSON editor
 - [ ] Optional 3D preview for entity models and item textures
 
 ### Project Info Panel

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -4,6 +4,23 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import path from 'path';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-testid="editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  loader: { config: vi.fn() },
+}));
 import PackMetaModal from '../src/renderer/components/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 
@@ -26,8 +43,8 @@ describe('PackMetaModal', () => {
         onCancel={onCancel}
       />
     );
-    fireEvent.change(screen.getByPlaceholderText('Description'), {
-      target: { value: 'new' },
+    fireEvent.change(screen.getByTestId('editor'), {
+      target: { value: '{"description":"new"}' },
     });
     fireEvent.click(screen.getByText('Save'));
     expect(onSave).toHaveBeenCalledWith(

--- a/__tests__/jsonEditor.test.tsx
+++ b/__tests__/jsonEditor.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import PackMetaModal from '../src/renderer/components/PackMetaModal';
+import ToastProvider from '../src/renderer/components/ToastProvider';
+import type { PackMeta } from '../src/main/projects';
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-testid="editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+  loader: { config: vi.fn() },
+}));
+
+describe('JsonEditor', () => {
+  it('rejects invalid JSON', () => {
+    const meta: PackMeta = {
+      description: '',
+      author: '',
+      urls: [],
+      created: 0,
+      license: '',
+    };
+    const onSave = vi.fn();
+    render(
+      <ToastProvider>
+        <PackMetaModal
+          project="Pack"
+          meta={meta}
+          onSave={onSave}
+          onCancel={() => {}}
+        />
+      </ToastProvider>
+    );
+    fireEvent.change(screen.getByTestId('editor'), { target: { value: '{' } });
+    fireEvent.click(screen.getByText('Save'));
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getAllByText('Invalid JSON')).toHaveLength(2);
+  });
+});

--- a/__tests__/windowBounds.test.ts
+++ b/__tests__/windowBounds.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect, vi } from 'vitest';
-import { setWindowBounds, setFullscreen } from '../src/main/windowBounds';
+import { setWindowBounds, setMaximized } from '../src/main/windowBounds';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
 
 describe('window bounds persistence', () => {
   it('persists across reloads', async () => {
     setWindowBounds({ x: 1, y: 2, width: 300, height: 400 });
-    setFullscreen(true);
+    setMaximized(true);
     vi.resetModules();
-    const { getWindowBounds, isFullscreen } = await import(
+    const { getWindowBounds, isMaximized } = await import(
       '../src/main/windowBounds'
     );
     expect(getWindowBounds()).toEqual({ x: 1, y: 2, width: 300, height: 400 });
-    expect(isFullscreen()).toBe(true);
+    expect(isMaximized()).toBe(true);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@monaco-editor/loader": "^1.5.0",
+        "@monaco-editor/react": "^4.7.0",
         "archiver": "^7.0.1",
         "chokidar": "^4.0.3",
         "electron-squirrel-startup": "^1.0.1",
@@ -16,6 +18,7 @@
         "fuse.js": "^7.1.0",
         "global-agent": "^3.0.0",
         "minecraft-data": "^3.89.0",
+        "monaco-editor": "^0.52.2",
         "react": "^19.1.0",
         "react-arborist": "^3.4.3",
         "react-canvas-confetti": "^2.0.7",
@@ -2381,6 +2384,29 @@
       },
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.5.0.tgz",
+      "integrity": "sha512-hKoGSM+7aAc7eRTRjpqAZucPmoNOC4UUbknb/VNoTkEIkCPhqV8LfbsgM1webRM7S/z21eHEx9Fkwx8Z/C/+Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -11586,6 +11612,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -14690,6 +14722,12 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
     "node_modules/statuses": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@monaco-editor/loader": "^1.5.0",
+    "@monaco-editor/react": "^4.7.0",
     "archiver": "^7.0.1",
     "chokidar": "^4.0.3",
     "electron-squirrel-startup": "^1.0.1",
@@ -26,6 +28,7 @@
     "fuse.js": "^7.1.0",
     "global-agent": "^3.0.0",
     "minecraft-data": "^3.89.0",
+    "monaco-editor": "^0.52.2",
     "react": "^19.1.0",
     "react-arborist": "^3.4.3",
     "react-canvas-confetti": "^2.0.7",

--- a/src/renderer/components/JsonEditor.tsx
+++ b/src/renderer/components/JsonEditor.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Editor, { loader } from '@monaco-editor/react';
+import 'monaco-editor/min/vs/editor/editor.main.css';
+
+loader.config({ paths: { vs: 'monaco-editor/min/vs' } });
+
+interface JsonEditorProps {
+  value: string;
+  onChange: (val: string) => void;
+  height?: string | number;
+}
+
+export default function JsonEditor({
+  value,
+  onChange,
+  height = '20rem',
+}: JsonEditorProps) {
+  return (
+    <Editor
+      language="json"
+      value={value}
+      onChange={(v) => onChange(v ?? '')}
+      height={height}
+      options={{ minimap: { enabled: false } }}
+    />
+  );
+}

--- a/src/renderer/components/PackMetaModal.tsx
+++ b/src/renderer/components/PackMetaModal.tsx
@@ -3,7 +3,9 @@ import path from 'path';
 import { app } from 'electron';
 import type { PackMeta } from '../../main/projects';
 import { Modal, Button } from './daisy/actions';
-import { InputField, Textarea } from './daisy/input';
+import JsonEditor from './JsonEditor';
+import { useToast } from './ToastProvider';
+import { PackMetaSchema } from '../../shared/project';
 
 export default function PackMetaModal({
   project,
@@ -16,46 +18,25 @@ export default function PackMetaModal({
   onSave: (m: PackMeta) => void;
   onCancel: () => void;
 }) {
-  const [desc, setDesc] = useState(meta.description);
-  const [author, setAuthor] = useState(meta.author);
-  const [urls, setUrls] = useState(meta.urls.join('\n'));
+  const [text, setText] = useState(JSON.stringify(meta, null, 2));
+  const toast = useToast();
   return (
     <Modal open>
       <form
         className="flex flex-col gap-2"
         onSubmit={(e) => {
           e.preventDefault();
-          onSave({
-            ...meta,
-            description: desc,
-            author,
-            urls: urls
-              .split(/\n+/)
-              .map((u: string) => u.trim())
-              .filter((u: string) => u),
-            updated: Date.now(),
-          });
+          try {
+            const data = JSON.parse(text);
+            const parsed = PackMetaSchema.parse(data);
+            onSave({ ...parsed, updated: Date.now() });
+          } catch {
+            toast({ message: 'Invalid JSON', type: 'error' });
+          }
         }}
       >
         <h3 className="font-bold text-lg">Edit Metadata</h3>
-        <Textarea
-          className="textarea-bordered"
-          value={desc}
-          onChange={(e) => setDesc(e.target.value)}
-          placeholder="Description"
-        />
-        <InputField
-          className="input-bordered"
-          value={author}
-          onChange={(e) => setAuthor(e.target.value)}
-          placeholder="Author"
-        />
-        <Textarea
-          className="textarea-bordered"
-          value={urls}
-          onChange={(e) => setUrls(e.target.value)}
-          placeholder="URLs (one per line)"
-        />
+        <JsonEditor value={text} onChange={setText} />
         <div className="modal-action">
           <Button
             type="button"


### PR DESCRIPTION
## Summary
- add `JsonEditor` component wrapping `monaco-editor` and configure loader to use local files
- swap text fields in `PackMetaModal` for `JsonEditor` and validate using `PackMetaSchema`
- mark JSON editor task done in `TODO.md`
- update tests and add `jsonEditor.test.tsx`
- patch window bounds test to use updated API
- add monaco packages

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68503cbf77888331be3d3ee585d6d028