### PR TITLE
Fix metadata modal test

### DIFF
--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -7,10 +7,6 @@ import {
 } from '../src/renderer/components/ProjectProvider';
 
 import AssetSelector from '../src/renderer/components/AssetSelector';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
 
 describe('AssetSelector', () => {
   const listTextures = vi.fn();

--- a/__tests__/ProjectInfoPanel.edit.test.tsx
+++ b/__tests__/ProjectInfoPanel.edit.test.tsx
@@ -1,6 +1,23 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <textarea
+      data-testid="editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
 import {
   ProjectProvider,
   useProject,
@@ -70,8 +87,10 @@ describe('ProjectInfoPanel metadata editing', () => {
     await screen.findByText('desc');
     fireEvent.click(screen.getByText('desc'));
     await screen.findByTestId('daisy-modal');
-    fireEvent.change(screen.getByPlaceholderText('Description'), {
-      target: { value: 'new desc' },
+    fireEvent.change(screen.getByTestId('editor'), {
+      target: {
+        value: JSON.stringify({ ...meta, description: 'new desc' }, null, 2),
+      },
     });
     fireEvent.click(screen.getByText('Save'));
     expect(save).toHaveBeenCalledWith(

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts,.tsx src __tests__ *.ts",
+    "lint": "eslint --no-warn-ignored --ext .ts,.tsx src __tests__ *.ts",
     "test": "vitest run --coverage",
     "dev": "electron-forge start",
     "dev:headless": "xvfb-run -a electron-forge start -- --no-sandbox",

--- a/src/renderer/components/PackMetaModal.tsx
+++ b/src/renderer/components/PackMetaModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import path from 'path';
 import { app } from 'electron';
-import Editor from '@monaco-editor/react';
+import MonacoEditor from '@monaco-editor/react';
 import { PackMetaSchema } from '../../shared/project';
 import type { PackMeta } from '../../main/projects';
 import { Modal, Button } from './daisy/actions';
@@ -36,13 +36,13 @@ export default function PackMetaModal({
         }}
       >
         <h3 className="font-bold text-lg">Edit Metadata</h3>
-        <Editor
+        <MonacoEditor
           height="20rem"
           defaultLanguage="json"
           value={text}
           onChange={(v) => setText(v ?? '')}
-          options={{ minimap: { enabled: false }}}
-          theme='vs-dark'
+          options={{ minimap: { enabled: false } }}
+          theme="vs-dark"
         />
         <div className="modal-action">
           <Button


### PR DESCRIPTION
## Summary
- mock monaco editor in `ProjectInfoPanel` tests
- update test for new JSON editor
- clean up duplicate imports
- rename Monaco editor import
- silence ESLint ignore warnings

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6850e358929c8331a9173f35372f682b