### PR TITLE
Add file change watcher

### DIFF
--- a/__tests__/AssetBrowser.persist.test.tsx
+++ b/__tests__/AssetBrowser.persist.test.tsx
@@ -12,6 +12,7 @@ const unwatchProject = vi.fn();
 const onFileAdded = vi.fn();
 const onFileRemoved = vi.fn();
 const onFileRenamed = vi.fn();
+const onFileChanged = vi.fn();
 
 const getAssetSearch = vi.fn();
 const setAssetSearch = vi.fn();
@@ -44,6 +45,7 @@ beforeEach(() => {
     onFileAdded,
     onFileRemoved,
     onFileRenamed,
+    onFileChanged,
     getNoExport: vi.fn(async () => []),
     setNoExport: vi.fn(),
     getAssetSearch,

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -14,6 +14,7 @@ const unwatchProject = vi.fn();
 const onFileAdded = vi.fn();
 const onFileRemoved = vi.fn();
 const onFileRenamed = vi.fn();
+const onFileChanged = vi.fn();
 
 function SetPath({
   path,
@@ -43,6 +44,7 @@ describe('AssetBrowser', () => {
           onFileAdded: typeof onFileAdded;
           onFileRemoved: typeof onFileRemoved;
           onFileRenamed: typeof onFileRenamed;
+          onFileChanged: typeof onFileChanged;
           getNoExport: () => Promise<string[]>;
           setNoExport: () => void;
         };
@@ -53,6 +55,7 @@ describe('AssetBrowser', () => {
       onFileAdded,
       onFileRemoved,
       onFileRenamed,
+      onFileChanged,
       getNoExport: vi.fn(async () => []),
       setNoExport: vi.fn(),
     };
@@ -105,6 +108,7 @@ describe('AssetBrowser', () => {
           onFileAdded: typeof onFileAdded;
           onFileRemoved: typeof onFileRemoved;
           onFileRenamed: typeof onFileRenamed;
+          onFileChanged: typeof onFileChanged;
           getNoExport: () => Promise<string[]>;
           setNoExport: () => void;
         };
@@ -119,6 +123,7 @@ describe('AssetBrowser', () => {
       onFileAdded,
       onFileRemoved,
       onFileRenamed,
+      onFileChanged,
       getNoExport: vi.fn(async () => []),
       setNoExport: vi.fn(),
     };
@@ -169,6 +174,9 @@ describe('AssetBrowser', () => {
     let renamed:
       | ((e: unknown, args: { oldPath: string; newPath: string }) => void)
       | undefined;
+    let changed:
+      | ((e: unknown, args: { path: string; stamp: number }) => void)
+      | undefined;
     onFileAdded.mockImplementation((cb) => {
       added = cb;
     });
@@ -177,6 +185,9 @@ describe('AssetBrowser', () => {
     });
     onFileRenamed.mockImplementation((cb) => {
       renamed = cb;
+    });
+    onFileChanged.mockImplementation((cb) => {
+      changed = cb;
     });
 
     render(
@@ -199,6 +210,12 @@ describe('AssetBrowser', () => {
     await screen.findAllByText('d.png');
     expect(screen.queryByText('b.png')).toBeNull();
     expect(screen.getAllByText('d.png')[0]).toBeInTheDocument();
+
+    const img = screen.getByAltText('D') as HTMLImageElement;
+    const before = img.src;
+    changed?.({}, { path: 'd.png', stamp: 42 });
+    expect(img.src).not.toBe(before);
+    expect(img.src).toContain('t=42');
   });
 
   it('supports multi selection and delete key', async () => {
@@ -210,6 +227,7 @@ describe('AssetBrowser', () => {
       onFileAdded: typeof onFileAdded;
       onFileRemoved: typeof onFileRemoved;
       onFileRenamed: typeof onFileRenamed;
+      onFileChanged: typeof onFileChanged;
       getNoExport: () => Promise<string[]>;
       setNoExport: () => void;
     }
@@ -220,6 +238,7 @@ describe('AssetBrowser', () => {
       onFileAdded,
       onFileRemoved,
       onFileRenamed,
+      onFileChanged,
       getNoExport: vi.fn(async () => []),
       setNoExport: vi.fn(),
     };
@@ -250,6 +269,7 @@ describe('AssetBrowser', () => {
       onFileAdded: typeof onFileAdded;
       onFileRemoved: typeof onFileRemoved;
       onFileRenamed: typeof onFileRenamed;
+      onFileChanged: typeof onFileChanged;
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       setNoExport,
@@ -259,6 +279,7 @@ describe('AssetBrowser', () => {
       onFileAdded,
       onFileRemoved,
       onFileRenamed,
+      onFileChanged,
     };
     render(
       <ProjectProvider>
@@ -291,6 +312,7 @@ describe('AssetBrowser', () => {
       onFileAdded: typeof onFileAdded;
       onFileRemoved: typeof onFileRemoved;
       onFileRenamed: typeof onFileRenamed;
+      onFileChanged: typeof onFileChanged;
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       getNoExport,
@@ -300,6 +322,7 @@ describe('AssetBrowser', () => {
       onFileAdded,
       onFileRemoved,
       onFileRenamed,
+      onFileChanged,
     };
     render(
       <ProjectProvider>

--- a/__tests__/FileTree.test.tsx
+++ b/__tests__/FileTree.test.tsx
@@ -27,6 +27,7 @@ function Wrapper(props: Partial<Parameters<typeof FileTree>[0]>) {
       toggleNoExport={vi.fn()}
       deleteFiles={vi.fn()}
       openRename={vi.fn()}
+      versions={{}}
       {...props}
     />
   ) : null;

--- a/__tests__/fileWatcher.test.ts
+++ b/__tests__/fileWatcher.test.ts
@@ -74,6 +74,11 @@ describe('fileWatcher IPC', () => {
     watcher.emit('unlink', path.join(tmpDir, 'b.txt'));
     expect(sendMock).toHaveBeenCalledWith('file-removed', 'b.txt');
 
+    watcher.emit('change', path.join(tmpDir, 'c.txt'));
+    const call = sendMock.mock.calls.find((c) => c[0] === 'file-changed');
+    expect(call?.[1]).toMatchObject({ path: 'c.txt' });
+    expect(typeof call?.[1].stamp).toBe('number');
+
     emitRenamed(path.join(tmpDir, 'a.txt'), path.join(tmpDir, 'd.txt'));
     expect(sendMock).toHaveBeenCalledWith('file-renamed', {
       oldPath: 'a.txt',

--- a/src/main/assets.ts
+++ b/src/main/assets.ts
@@ -235,6 +235,9 @@ export function registerAssetProtocol(protocol: Protocol) {
     if (/(\\|\/)$/.test(file)) {
       file = file.substring(0, file.length - 1);
     }
+    if (file.includes("?t=")) {
+      file = file.substring(0, file.indexOf("?t="));
+    }
     callback(file);
   });
 }

--- a/src/main/ipc/fileWatcher.ts
+++ b/src/main/ipc/fileWatcher.ts
@@ -44,6 +44,12 @@ export function registerFileWatcherHandlers(
           path.relative(projectPath, file).split(path.sep).join('/')
         );
       });
+      watcher.on('change', (file) => {
+        win?.webContents.send('file-changed', {
+          path: path.relative(projectPath, file).split(path.sep).join('/'),
+          stamp: Date.now(),
+        });
+      });
       watchers.set(projectPath, watcher);
     }
     return listFiles(projectPath);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -97,6 +97,9 @@ const api = {
   onFileRenamed: (
     listener: (e: unknown, args: { oldPath: string; newPath: string }) => void
   ) => on('file-renamed', listener),
+  onFileChanged: (
+    listener: (e: unknown, args: { path: string; stamp: number }) => void
+  ) => on('file-changed', listener),
   loadPackMeta: (name: string) => invoke('load-pack-meta', name),
   savePackMeta: (name: string, meta: import('../main/projects').PackMeta) =>
     invoke('save-pack-meta', name, meta),

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -41,7 +41,7 @@ const getCategory = (name: string): Filter | 'misc' => {
 
 const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
   const { path: projectPath } = useProject();
-  const { files, noExport, toggleNoExport } = useProjectFiles();
+  const { files, noExport, toggleNoExport, versions } = useProjectFiles();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -182,6 +182,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
                         deleteFiles={deleteFiles}
                         openRename={(file) => setRenameTarget(file)}
                         zoom={zoom}
+                        stamp={versions[f]}
                       />
                     ))}
                   </div>
@@ -199,6 +200,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
             toggleNoExport={toggleNoExport}
             deleteFiles={deleteFiles}
             openRename={(file) => setRenameTarget(file)}
+            versions={versions}
           />
         </div>
       </div>

--- a/src/renderer/components/AssetBrowserItem.tsx
+++ b/src/renderer/components/AssetBrowserItem.tsx
@@ -14,6 +14,7 @@ interface Props {
   deleteFiles: (files: string[]) => void;
   openRename: (file: string) => void;
   zoom: number;
+  stamp?: number;
 }
 
 const AssetBrowserItem: React.FC<Props> = ({
@@ -26,6 +27,7 @@ const AssetBrowserItem: React.FC<Props> = ({
   deleteFiles,
   openRename,
   zoom,
+  stamp,
 }) => {
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const firstItem = useRef<HTMLButtonElement>(null);
@@ -97,7 +99,13 @@ const AssetBrowserItem: React.FC<Props> = ({
       }}
     >
       <figure className={noExport.has(file) ? 'opacity-50' : ''}>
-        <TextureThumb texture={texPath} alt={altText} size={zoom} simplified />
+        <TextureThumb
+          texture={texPath}
+          alt={altText}
+          size={zoom}
+          simplified
+          stamp={stamp}
+        />
       </figure>
       <div className="card-body p-1">
         <div className="text-xs leading-tight">

--- a/src/renderer/components/FileTree.tsx
+++ b/src/renderer/components/FileTree.tsx
@@ -14,6 +14,7 @@ interface Props {
   toggleNoExport: (files: string[], flag: boolean) => void;
   deleteFiles: (files: string[]) => void;
   openRename: (file: string) => void;
+  versions: Record<string, number>;
 }
 
 export default function FileTree({
@@ -24,6 +25,7 @@ export default function FileTree({
   toggleNoExport,
   deleteFiles,
   openRename,
+  versions,
 }: Props) {
   const { path: projectPath } = useProject();
   const data = React.useMemo<TreeItem[]>(() => buildTree(files), [files]);
@@ -88,6 +90,7 @@ export default function FileTree({
                 alt={path.basename(f)}
                 size={24}
                 simplified
+                stamp={versions[f]}
               />
             )}
             <span className="text-sm break-all">{path.basename(f)}</span>
@@ -178,6 +181,7 @@ export default function FileTree({
                 alt={path.basename(node.data.name)}
                 size={24}
                 simplified
+                stamp={versions[node.id]}
               />
             )}
             <span className="text-sm break-all">

--- a/src/renderer/components/TextureThumb.tsx
+++ b/src/renderer/components/TextureThumb.tsx
@@ -13,6 +13,8 @@ interface Props {
   protocol?: 'asset' | 'vanilla';
   /** Use simplified markup without border wrapper */
   simplified?: boolean;
+  /** Optional cache-busting stamp */
+  stamp?: number;
 }
 
 export default function TextureThumb({
@@ -21,11 +23,12 @@ export default function TextureThumb({
   size = 64,
   protocol = 'asset',
   simplified = false,
+  stamp,
 }: Props) {
   const ext = texture ? path.extname(texture).toLowerCase() : '';
   const url =
     texture && ext === '.png'
-      ? `${protocol}://${texture.split(path.sep).join('/')}`
+      ? `${protocol}://${texture.split(path.sep).join('/')}${stamp ? `?t=${stamp}` : ''}`
       : null;
   const isText = ext === '.txt' || ext === '.json';
 

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -6,6 +6,7 @@ export function useProjectFiles() {
   const { path: projectPath } = useProject();
   const [files, setFiles] = useState<string[]>([]);
   const [noExport, setNoExport] = useState<Set<string>>(new Set());
+  const [versions, setVersions] = useState<Record<string, number>>({});
   const toast = useToast();
 
   useEffect(() => {
@@ -23,9 +24,12 @@ export function useProjectFiles() {
       setFiles((f) => f.filter((x) => x !== p));
     const rename = (_e: unknown, args: { oldPath: string; newPath: string }) =>
       setFiles((f) => f.map((x) => (x === args.oldPath ? args.newPath : x)));
+    const change = (_e: unknown, args: { path: string; stamp: number }) =>
+      setVersions((v) => ({ ...v, [args.path]: args.stamp }));
     window.electronAPI?.onFileAdded(add);
     window.electronAPI?.onFileRemoved(remove);
     window.electronAPI?.onFileRenamed(rename);
+    window.electronAPI?.onFileChanged(change);
     return () => {
       alive = false;
       window.electronAPI?.unwatchProject(projectPath);
@@ -60,5 +64,5 @@ export function useProjectFiles() {
     });
   };
 
-  return { files, noExport, toggleNoExport };
+  return { files, noExport, toggleNoExport, versions };
 }

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -70,6 +70,7 @@ declare global {
       onFileAdded: IpcListener<'file-added'>;
       onFileRemoved: IpcListener<'file-removed'>;
       onFileRenamed: IpcListener<'file-renamed'>;
+      onFileChanged: IpcListener<'file-changed'>;
     };
   }
 }

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -119,4 +119,5 @@ export interface IpcEventMap {
   'file-added': string;
   'file-removed': string;
   'file-renamed': { oldPath: string; newPath: string };
+  'file-changed': { path: string; stamp: number };
 }


### PR DESCRIPTION
## Summary
- trigger `file-changed` IPC events on texture edits
- expose `onFileChanged` handler in preload and global typings
- track modification stamps in `useProjectFiles`
- bust image cache via `TextureThumb` stamp
- keep AssetBrowser and FileTree in sync with file changes
- test file change events

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run typecheck` *(fails: missing modules)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6850eed951708331969807843bc90405