### PR TITLE
Implement asset revision history

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ An Electron-based tool for creating Minecraft resource packs. The interface is d
 - **Random pack icon** – new packs start with a pastel background and random item image; you can regenerate from pack settings.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.
 - **External Editing** – configure your favourite image editor in **Settings** and launch it from the asset info panel.
+- **Revision History** – every save keeps the previous version inside a hidden `.history` folder. Up to 20 revisions can be restored from the Asset Info panel.
 
 ### Texture Naming
 

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 ### Asset Info & Texture Inspector
 
-- [ ] Revision history (max 20)
+- [x] Revision history (max 20)
 - [x] Preview against the vanilla texture using the `Diff` component
 - [x] Generic icon thumbnail for text files
 - [x] More robust JSON editor

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
 import {
   ProjectProvider,
   useProject,
@@ -213,7 +213,9 @@ describe('AssetBrowser', () => {
 
     const img = screen.getByAltText('D') as HTMLImageElement;
     const before = img.src;
-    changed?.({}, { path: 'd.png', stamp: 42 });
+    await act(async () => {
+      changed?.({}, { path: 'd.png', stamp: 42 });
+    });
     expect(img.src).not.toBe(before);
     expect(img.src).toContain('t=42');
   });

--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -11,7 +11,7 @@ import path from 'path';
 
 describe('AssetInfo', () => {
   const readFile = vi.fn();
-  const writeFile = vi.fn();
+  const saveRevision = vi.fn();
   const openExternalEditor = vi.fn();
 
   beforeEach(() => {
@@ -20,17 +20,17 @@ describe('AssetInfo', () => {
       window as unknown as {
         electronAPI: {
           readFile: typeof readFile;
-          writeFile: typeof writeFile;
+          saveRevision: typeof saveRevision;
           openExternalEditor: typeof openExternalEditor;
         };
       }
     ).electronAPI = {
       readFile,
-      writeFile,
+      saveRevision,
       openExternalEditor,
     } as never;
     readFile.mockResolvedValue('');
-    writeFile.mockResolvedValue(undefined);
+    saveRevision.mockResolvedValue(undefined);
     openExternalEditor.mockResolvedValue(undefined);
   });
 
@@ -122,7 +122,7 @@ describe('AssetInfo', () => {
     expect(box).toHaveValue('hello');
     fireEvent.change(box, { target: { value: 'new' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    expect(writeFile).toHaveBeenCalledWith(path.join('/p', 'a.txt'), 'new');
+    expect(saveRevision).toHaveBeenCalledWith('/p', 'a.txt', 'new');
   });
 
   it('blocks invalid json', async () => {
@@ -137,7 +137,7 @@ describe('AssetInfo', () => {
     const box = await screen.findByRole('textbox');
     fireEvent.change(box, { target: { value: '{' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-    expect(writeFile).not.toHaveBeenCalled();
+    expect(saveRevision).not.toHaveBeenCalled();
     expect(screen.getByText('Invalid JSON')).toBeInTheDocument();
   });
 });

--- a/__tests__/revisions.test.tsx
+++ b/__tests__/revisions.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssetInfo from '../src/renderer/components/AssetInfo';
+import RevisionsModal from '../src/renderer/components/RevisionsModal';
+import ToastProvider from '../src/renderer/components/ToastProvider';
+import {
+  ProjectProvider,
+  useProject,
+} from '../src/renderer/components/ProjectProvider';
+
+const saveRevision = vi.fn();
+const listRevisions = vi.fn();
+const restoreRevision = vi.fn();
+const readFile = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (
+    window as unknown as {
+      electronAPI: {
+        saveRevision: typeof saveRevision;
+        listRevisions: typeof listRevisions;
+        restoreRevision: typeof restoreRevision;
+        readFile: typeof readFile;
+      };
+    }
+  ).electronAPI = {
+    saveRevision,
+    listRevisions,
+    restoreRevision,
+    readFile,
+  } as never;
+  listRevisions.mockResolvedValue(['1.png']);
+  readFile.mockResolvedValue('');
+  saveRevision.mockResolvedValue(undefined);
+  restoreRevision.mockResolvedValue(undefined);
+});
+
+function SetPath({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactNode;
+}) {
+  const { setPath } = useProject();
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setPath(path);
+    setReady(true);
+  }, [path]);
+  return ready ? <>{children}</> : null;
+}
+
+describe('Revision history', () => {
+  it('saves revision on save', async () => {
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <ToastProvider>
+            <AssetInfo asset="a.txt" />
+          </ToastProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    const box = await screen.findByRole('textbox');
+    fireEvent.change(box, { target: { value: 'hi' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(saveRevision).toHaveBeenCalledWith('/p', 'a.txt', 'hi');
+  });
+
+  it('restores a revision', async () => {
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <ToastProvider>
+            <RevisionsModal asset="a.txt" onClose={() => {}} />
+          </ToastProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    const btn = await screen.findByText('Restore');
+    fireEvent.click(btn);
+    expect(restoreRevision).toHaveBeenCalledWith('/p', 'a.txt', '1.png');
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -183,6 +183,11 @@ viewing a PNG texture the panel offers a **Compare with Vanilla** button. It
 opens a modal that uses the daisyUI `Diff` component to show the project texture
 against the original game asset side by side.
 
+The **Revisions** button opens a modal listing previous versions of the file.
+Revisions are stored in a hidden `.history` folder within each project and up to
+20 entries are kept per asset. Selecting a revision will restore that version
+and store the current file as a new revision.
+
 ## Windows Paths
 
 When writing tests or other code that constructs file system paths, prefer

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -18,6 +18,7 @@ This guide explains how to use **minecraft-resource-packer** to create and manag
 - **Random pack icon** – new packs start with a pastel background and random item image; you can regenerate from pack settings.
 - **Export** – generate a zipped resource pack containing the selected files along with a valid `pack.mcmeta`. The output is ready to drop into Minecraft.
 - **External Editing** – configure your favourite image editor in **Settings** and launch it from the asset info panel.
+- **Revision History** – previous versions are kept in a hidden `.history` folder. Open the Revisions modal from Asset Info to restore any of the last 20 saves.
 
 ## Texture Naming
 

--- a/src/main/ipcFiles.ts
+++ b/src/main/ipcFiles.ts
@@ -2,6 +2,8 @@ import type { IpcMain } from 'electron';
 import { shell } from 'electron';
 import { emitRenamed } from './ipc/fileWatcher';
 import fs from 'fs';
+import path from 'path';
+import { saveRevision, listRevisions, restoreRevision } from './revision';
 
 /** Register IPC handlers for file interactions. */
 export function registerFileHandlers(ipc: IpcMain) {
@@ -20,6 +22,25 @@ export function registerFileHandlers(ipc: IpcMain) {
   ipc.handle('write-file', async (_e, file: string, data: string) => {
     await fs.promises.writeFile(file, data, 'utf-8');
   });
+
+  ipc.handle(
+    'save-revision',
+    async (_e, project: string, rel: string, data: string) => {
+      await saveRevision(project, rel);
+      await fs.promises.writeFile(path.join(project, rel), data, 'utf-8');
+    }
+  );
+
+  ipc.handle('list-revisions', (_e, project: string, rel: string) =>
+    listRevisions(project, rel)
+  );
+
+  ipc.handle(
+    'restore-revision',
+    async (_e, project: string, rel: string, rev: string) => {
+      await restoreRevision(project, rel, rev);
+    }
+  );
 
   ipc.handle('rename-file', async (_e, oldPath: string, newPath: string) => {
     await fs.promises.rename(oldPath, newPath);

--- a/src/main/revision.ts
+++ b/src/main/revision.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+
+/** Save the current version of a file into the project's .history folder */
+export async function saveRevision(
+  project: string,
+  rel: string
+): Promise<void> {
+  const abs = path.join(project, rel);
+  if (!fs.existsSync(abs)) return;
+  const histDir = path.join(project, '.history', rel);
+  await fs.promises.mkdir(histDir, { recursive: true });
+  const stamp = Date.now();
+  const ext = path.extname(rel);
+  const dest = path.join(histDir, `${stamp}${ext}`);
+  await fs.promises.copyFile(abs, dest);
+  const list = await fs.promises.readdir(histDir);
+  if (list.length > 20) {
+    const sorted = list.sort();
+    const remove = sorted.slice(0, list.length - 20);
+    await Promise.all(
+      remove.map((f) => fs.promises.unlink(path.join(histDir, f)))
+    );
+  }
+}
+
+/** List revisions for the given file relative path */
+export async function listRevisions(
+  project: string,
+  rel: string
+): Promise<string[]> {
+  const histDir = path.join(project, '.history', rel);
+  try {
+    const list = await fs.promises.readdir(histDir);
+    return list.sort().reverse();
+  } catch {
+    return [];
+  }
+}
+
+/** Restore the specified revision */
+export async function restoreRevision(
+  project: string,
+  rel: string,
+  revision: string
+): Promise<void> {
+  const histDir = path.join(project, '.history', rel);
+  const src = path.join(histDir, revision);
+  const dest = path.join(project, rel);
+  if (!fs.existsSync(src)) throw new Error('Revision not found');
+  await saveRevision(project, rel);
+  await fs.promises.copyFile(src, dest);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,6 +53,12 @@ const api = {
   openExternalEditor: (file: string) => invoke('open-external-editor', file),
   readFile: (file: string) => invoke('read-file', file),
   writeFile: (file: string, data: string) => invoke('write-file', file, data),
+  saveRevision: (project: string, rel: string, data: string) =>
+    invoke('save-revision', project, rel, data),
+  listRevisions: (project: string, rel: string) =>
+    invoke('list-revisions', project, rel),
+  restoreRevision: (project: string, rel: string, rev: string) =>
+    invoke('restore-revision', project, rel, rev),
   renameFile: (oldPath: string, newPath: string) =>
     invoke('rename-file', oldPath, newPath),
   deleteFile: (file: string) => invoke('delete-file', file),

--- a/src/renderer/components/AssetInfo.tsx
+++ b/src/renderer/components/AssetInfo.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from './daisy/feedback';
 import { Textarea } from './daisy/input';
 import { Button } from './daisy/actions';
 import { useProject } from './ProjectProvider';
+import RevisionsModal from './RevisionsModal';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 const TextureLab = lazy(() => import('./TextureLab'));
@@ -23,6 +24,7 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [lab, setLab] = useState(false);
   const [diff, setDiff] = useState(false);
+  const [revs, setRevs] = useState(false);
 
   const full = asset ? path.join(projectPath, asset) : '';
 
@@ -58,10 +60,13 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
       }
     }
     setError(null);
-    window.electronAPI?.writeFile(full, text).then(() => {
-      setOrig(text);
-      toast({ message: 'File saved', type: 'success' });
-    });
+    window.electronAPI
+      ?.saveRevision(projectPath, asset, text)
+      .then(() => {
+        setOrig(text);
+        toast({ message: 'File saved', type: 'success' });
+      })
+      .catch(() => toast({ message: 'Save failed', type: 'error' }));
   };
 
   const handleReset = () => setText(orig);
@@ -98,6 +103,12 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
               <Button className="btn-secondary btn-sm" onClick={handleReset}>
                 Reset
               </Button>
+              <Button
+                className="btn-secondary btn-sm"
+                onClick={() => setRevs(true)}
+              >
+                Revisions
+              </Button>
             </div>
           </>
         )}
@@ -128,6 +139,12 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
             >
               Compare with Vanilla
             </Button>
+            <Button
+              className="btn-secondary btn-sm"
+              onClick={() => setRevs(true)}
+            >
+              Revisions
+            </Button>
           </div>
         )}
         {lab && (
@@ -139,6 +156,9 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
           <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
             <TextureDiff asset={asset} onClose={() => setDiff(false)} />
           </Suspense>
+        )}
+        {revs && (
+          <RevisionsModal asset={asset} onClose={() => setRevs(false)} />
         )}
       </div>
     </div>

--- a/src/renderer/components/RevisionsModal.tsx
+++ b/src/renderer/components/RevisionsModal.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import path from 'path';
+import { Modal, Button } from './daisy/actions';
+import { useProject } from './ProjectProvider';
+import { useToast } from './ToastProvider';
+
+export default function RevisionsModal({
+  asset,
+  onClose,
+}: {
+  asset: string;
+  onClose: () => void;
+}) {
+  const { path: projectPath } = useProject();
+  const toast = useToast();
+  const [list, setList] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (!projectPath) return;
+    window.electronAPI
+      ?.listRevisions(projectPath, asset)
+      .then((l) => {
+        if (l) setList(l);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, [projectPath, asset]);
+
+  const restore = (rev: string) => {
+    if (!projectPath) return;
+    window.electronAPI
+      ?.restoreRevision(projectPath, asset, rev)
+      .then(() => toast({ message: 'Revision restored', type: 'success' }))
+      .catch(() => toast({ message: 'Failed to restore', type: 'error' }));
+  };
+
+  const basename = (rev: string) => path.parse(rev).name;
+
+  return (
+    <Modal open className="max-w-sm">
+      <h3 className="font-bold text-lg mb-2">Revisions</h3>
+      <ul className="menu bg-base-200 rounded-box mb-2 max-h-60 overflow-y-auto">
+        {list.map((rev) => (
+          <li key={rev} className="menu-item">
+            <button
+              type="button"
+              className="flex justify-between w-full"
+              onClick={() => restore(rev)}
+            >
+              <span>{new Date(Number(basename(rev))).toLocaleString()}</span>
+              <span className="text-primary">Restore</span>
+            </button>
+          </li>
+        ))}
+        {list.length === 0 && <li className="p-2">No revisions</li>}
+      </ul>
+      <div className="modal-action">
+        <Button onClick={onClose}>Close</Button>
+      </div>
+    </Modal>
+  );
+}

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -36,6 +36,9 @@ declare global {
       openFile: IpcInvoke<'open-file'>;
       readFile: IpcInvoke<'read-file'>;
       writeFile: IpcInvoke<'write-file'>;
+      saveRevision: IpcInvoke<'save-revision'>;
+      listRevisions: IpcInvoke<'list-revisions'>;
+      restoreRevision: IpcInvoke<'restore-revision'>;
       renameFile: IpcInvoke<'rename-file'>;
       deleteFile: IpcInvoke<'delete-file'>;
       editTexture: IpcInvoke<'edit-texture'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -28,6 +28,9 @@ export interface IpcRequestMap {
   'open-external-editor': [string];
   'read-file': [string];
   'write-file': [string, string];
+  'save-revision': [string, string, string];
+  'list-revisions': [string, string];
+  'restore-revision': [string, string, string];
   'rename-file': [string, string];
   'delete-file': [string];
   'edit-texture': [string, TextureEditOptions];
@@ -83,6 +86,9 @@ export interface IpcResponseMap {
   'open-external-editor': void;
   'read-file': string;
   'write-file': void;
+  'save-revision': void;
+  'list-revisions': string[];
+  'restore-revision': void;
   'rename-file': void;
   'delete-file': void;
   'edit-texture': void;


### PR DESCRIPTION
## Summary
- keep last 20 revisions of each asset in `.history`
- allow restoring revisions from a new modal
- add IPC handlers and preload bindings
- expose revision buttons in AssetInfo
- document feature and mark TODO complete
- test saving and restoring revisions

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run dev:headless` *(fails: `xvfb-run: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850fe7e49848331ab53d01583c1e261