### PR TITLE
Implement undo/redo provider with hotkeys

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 
 ## Global UX
 
-- [ ] Undo/Redo queue (last 20 actions)
+- [x] Undo/Redo queue (last 20 actions)
 - [x] Persist window size and position across launches
 - [x] Open the most recently used project on startup; add a setting to disable this
 

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -6,6 +6,7 @@ import {
   useProject,
 } from '../src/renderer/components/ProjectProvider';
 import path from 'path';
+import UndoRedoProvider from '../src/renderer/components/UndoRedoProvider';
 
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
 
@@ -64,9 +65,11 @@ describe('AssetBrowser', () => {
   it('renders files from directory', async () => {
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     expect(watchProject).toHaveBeenCalledWith('/proj');
@@ -81,9 +84,11 @@ describe('AssetBrowser', () => {
   it('is scrollable', async () => {
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     await screen.findAllByText('a.txt');
@@ -129,9 +134,11 @@ describe('AssetBrowser', () => {
     };
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     const item = (await screen.findAllByText('a.txt'))[0];
@@ -192,9 +199,11 @@ describe('AssetBrowser', () => {
 
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     await screen.findAllByText('a.txt');
@@ -248,9 +257,11 @@ describe('AssetBrowser', () => {
     };
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     const a = (await screen.findAllByText('a.txt'))[0];
@@ -287,9 +298,11 @@ describe('AssetBrowser', () => {
     };
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
-          <AssetBrowser />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/proj">
+            <AssetBrowser />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     const a = (await screen.findAllByText('a.txt'))[0];
@@ -330,10 +343,12 @@ describe('AssetBrowser', () => {
     };
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
+        <UndoRedoProvider>
+          <SetPath path="/proj">
           <AssetBrowser />
         </SetPath>
-      </ProjectProvider>
+      </UndoRedoProvider>
+</ProjectProvider>
     );
     const el = (await screen.findAllByText('a.txt'))[0];
     const container = el.closest('div[tabindex="0"]') as HTMLElement;
@@ -345,10 +360,12 @@ describe('AssetBrowser', () => {
   it('filters by search and adjusts zoom', async () => {
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
+        <UndoRedoProvider>
+          <SetPath path="/proj">
           <AssetBrowser />
         </SetPath>
-      </ProjectProvider>
+      </UndoRedoProvider>
+</ProjectProvider>
     );
     await screen.findAllByText('a.txt');
     const search = screen.getByPlaceholderText('Search files');
@@ -369,10 +386,12 @@ describe('AssetBrowser', () => {
     ]);
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
+        <UndoRedoProvider>
+          <SetPath path="/proj">
           <AssetBrowser />
         </SetPath>
-      </ProjectProvider>
+      </UndoRedoProvider>
+</ProjectProvider>
     );
     await screen.findAllByText('stone.png');
     const itemsChip = screen.getByText('Items');
@@ -385,10 +404,12 @@ describe('AssetBrowser', () => {
   it('renders grid and tree together', async () => {
     render(
       <ProjectProvider>
-        <SetPath path="/proj">
+        <UndoRedoProvider>
+          <SetPath path="/proj">
           <AssetBrowser />
         </SetPath>
-      </ProjectProvider>
+      </UndoRedoProvider>
+</ProjectProvider>
     );
     await screen.findAllByText('a.txt');
     expect(screen.getByTestId('file-tree')).toBeInTheDocument();

--- a/__tests__/AssetSelectorInfoPanel.test.tsx
+++ b/__tests__/AssetSelectorInfoPanel.test.tsx
@@ -5,6 +5,7 @@ import {
   ProjectProvider,
   useProject,
 } from '../src/renderer/components/ProjectProvider';
+import UndoRedoProvider from '../src/renderer/components/UndoRedoProvider';
 import AssetSelectorInfoPanel from '../src/renderer/components/AssetSelectorInfoPanel';
 
 describe('AssetSelectorInfoPanel', () => {
@@ -26,9 +27,11 @@ describe('AssetSelectorInfoPanel', () => {
   it('shows placeholder when no asset', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/p">
-          <AssetSelectorInfoPanel asset={null} />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/p">
+            <AssetSelectorInfoPanel asset={null} />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     expect(screen.getByText('No asset selected')).toBeInTheDocument();
@@ -37,9 +40,11 @@ describe('AssetSelectorInfoPanel', () => {
   it('displays asset name', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/p">
-          <AssetSelectorInfoPanel asset="block/a.png" />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/p">
+            <AssetSelectorInfoPanel asset="block/a.png" />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     expect(screen.getByText('block/a.png')).toBeInTheDocument();
@@ -53,9 +58,11 @@ describe('AssetSelectorInfoPanel', () => {
     (window as unknown as { electronAPI: API }).electronAPI = { addTexture };
     render(
       <ProjectProvider>
-        <SetPath path="/p">
-          <AssetSelectorInfoPanel asset="block/a.png" />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/p">
+            <AssetSelectorInfoPanel asset="block/a.png" />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     screen.getByText('Add').click();

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -13,6 +13,7 @@ vi.mock('electron', () => ({
 }));
 
 import EditorView from '../src/renderer/views/EditorView';
+import UndoRedoProvider from '../src/renderer/components/UndoRedoProvider';
 
 vi.mock('react-canvas-confetti', () => ({
   __esModule: true,
@@ -25,7 +26,13 @@ vi.mock('../src/renderer/components/AssetBrowser', () => ({
   default: () => <div>browser</div>,
 }));
 vi.mock('../src/renderer/components/ProjectInfoPanel', () => ({
-  default: ({ onExport, onBack }: { onExport: () => void; onBack: () => void }) => {
+  default: ({
+    onExport,
+    onBack,
+  }: {
+    onExport: () => void;
+    onBack: () => void;
+  }) => {
     const { path } = useProject();
     return (
       <div>
@@ -91,9 +98,11 @@ describe('EditorView', () => {
   it('shows project path and exports pack', async () => {
     render(
       <ProjectProvider>
-        <SetPath path="/tmp/proj">
-          <EditorView onBack={() => undefined} />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/tmp/proj">
+            <EditorView onBack={() => undefined} />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     expect(screen.getByText('/tmp/proj')).toBeInTheDocument();
@@ -110,9 +119,11 @@ describe('EditorView', () => {
     const back = vi.fn();
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
-          <EditorView onBack={back} />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/tmp">
+            <EditorView onBack={back} />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     fireEvent.click(screen.getByText('Back to Projects'));
@@ -122,9 +133,11 @@ describe('EditorView', () => {
   it('opens help link externally', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
-          <EditorView onBack={() => undefined} />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/tmp">
+            <EditorView onBack={() => undefined} />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     const link = screen.getByRole('link', { name: 'Help' });
@@ -139,9 +152,11 @@ describe('EditorView', () => {
   it('opens asset selector modal', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
-          <EditorView onBack={() => undefined} />
-        </SetPath>
+        <UndoRedoProvider>
+          <SetPath path="/tmp">
+            <EditorView onBack={() => undefined} />
+          </SetPath>
+        </UndoRedoProvider>
       </ProjectProvider>
     );
     fireEvent.click(screen.getByRole('button', { name: 'Add From Vanilla' }));

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -109,7 +109,7 @@ describe('SettingsView', () => {
       </ToastProvider>
     );
     const input = await screen.findByLabelText('Default export folder');
-    expect(input).toHaveValue('/home');
+    await screen.findByDisplayValue('/home');
     fireEvent.change(input, { target: { value: '/out' } });
     const btn = screen.getAllByRole('button', { name: 'Save' })[1];
     fireEvent.click(btn);

--- a/__tests__/UndoRedoProvider.test.tsx
+++ b/__tests__/UndoRedoProvider.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import UndoRedoProvider, {
+  useUndoRedo,
+} from '../src/renderer/components/UndoRedoProvider';
+import ToastProvider from '../src/renderer/components/ToastProvider';
+
+function TestComp() {
+  const { addTexture, renameFile, deleteFile, undo, redo } = useUndoRedo();
+  return (
+    <div>
+      <button onClick={() => addTexture('/proj', 'a.png')}>add</button>
+      <button onClick={() => renameFile('old.txt', 'new.txt')}>rename</button>
+      <button onClick={() => deleteFile('del.txt')}>delete</button>
+      <button onClick={undo}>undo</button>
+      <button onClick={redo}>redo</button>
+    </div>
+  );
+}
+
+describe('UndoRedoProvider', () => {
+  const addTexture = vi.fn();
+  const renameFile = vi.fn();
+  const deleteFile = vi.fn();
+  const readFile = vi.fn(async () => 'data');
+  const writeFile = vi.fn();
+
+  beforeEach(() => {
+    interface API {
+      addTexture: typeof addTexture;
+      renameFile: typeof renameFile;
+      deleteFile: typeof deleteFile;
+      readFile: typeof readFile;
+      writeFile: typeof writeFile;
+    }
+    (window as unknown as { electronAPI: API }).electronAPI = {
+      addTexture,
+      renameFile,
+      deleteFile,
+      readFile,
+      writeFile,
+    };
+    vi.clearAllMocks();
+  });
+
+  it('records add/undo/redo actions', async () => {
+    render(
+      <ToastProvider>
+        <UndoRedoProvider>
+          <TestComp />
+        </UndoRedoProvider>
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('add'));
+    expect(addTexture).toHaveBeenCalledWith('/proj', 'a.png');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('undo'));
+      await Promise.resolve();
+    });
+    expect(deleteFile).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      fireEvent.click(screen.getByText('redo'));
+      await Promise.resolve();
+    });
+    expect(addTexture).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles rename undo/redo', async () => {
+    render(
+      <ToastProvider>
+        <UndoRedoProvider>
+          <TestComp />
+        </UndoRedoProvider>
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('rename'));
+    expect(renameFile).toHaveBeenCalledWith('old.txt', 'new.txt');
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByText('undo'));
+      await Promise.resolve();
+    });
+    expect(renameFile).toHaveBeenCalledTimes(2);
+  });
+
+  it('binds hotkeys', async () => {
+    render(
+      <ToastProvider>
+        <UndoRedoProvider>
+          <TestComp />
+        </UndoRedoProvider>
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByText('rename'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+      await Promise.resolve();
+    });
+    expect(renameFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -188,6 +188,14 @@ Revisions are stored in a hidden `.history` folder within each project and up to
 20 entries are kept per asset. Selecting a revision will restore that version
 and store the current file as a new revision.
 
+## Undo & Redo
+
+Editor actions such as adding, renaming and deleting files are tracked by the
+`UndoRedoProvider`. The provider keeps the last 20 actions in memory. Users can
+undo with **Ctrl/Cmd+Z** and redo with **Ctrl/Cmd+Shift+Z**. The Editor view
+also exposes small daisyUI buttons for these actions. When no further undo or
+redo is available a toast message is shown.
+
 ## Windows Paths
 
 When writing tests or other code that constructs file system paths, prefer

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -14,6 +14,7 @@ const SettingsView = lazy(() => import('../views/SettingsView'));
 const AboutView = lazy(() => import('../views/AboutView'));
 
 import { ProjectProvider, useProject } from './ProjectProvider';
+import UndoRedoProvider from './UndoRedoProvider';
 
 function AppContent() {
   const { path: projectPath, setPath: setProjectPath } = useProject();
@@ -86,7 +87,9 @@ function AppContent() {
 export default function App() {
   return (
     <ProjectProvider>
-      <AppContent />
+      <UndoRedoProvider>
+        <AppContent />
+      </UndoRedoProvider>
     </ProjectProvider>
   );
 }

--- a/src/renderer/components/AssetBrowser.tsx
+++ b/src/renderer/components/AssetBrowser.tsx
@@ -5,6 +5,7 @@ import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from './file/useProjectFiles';
 import FileTree from './FileTree';
 import { useProject } from './ProjectProvider';
+import { useUndoRedo } from './UndoRedoProvider';
 import { FilterBadge, InputField, Range } from './daisy/input';
 import { Accordion } from './daisy/display';
 
@@ -110,8 +111,10 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
     );
   };
 
+  const { deleteFile, renameFile } = useUndoRedo();
+
   const deleteFiles = (files: string[]) => {
-    files.forEach((f) => window.electronAPI?.deleteFile(f));
+    files.forEach((f) => deleteFile(f));
     setSelected(new Set());
   };
 
@@ -211,7 +214,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
           onRename={(n) => {
             const full = path.join(projectPath, renameTarget);
             const target = path.join(path.dirname(full), n);
-            window.electronAPI?.renameFile(full, target);
+            renameFile(full, target);
             setRenameTarget(null);
           }}
         />

--- a/src/renderer/components/AssetSelectorInfoPanel.tsx
+++ b/src/renderer/components/AssetSelectorInfoPanel.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import TextureThumb from './TextureThumb';
 import { Button } from './daisy/actions';
 import { useProject } from './ProjectProvider';
+import { useUndoRedo } from './UndoRedoProvider';
 
 interface Props {
   asset: string | null;
@@ -9,6 +10,7 @@ interface Props {
 
 export default function AssetSelectorInfoPanel({ asset }: Props) {
   const { path: projectPath } = useProject();
+  const { addTexture } = useUndoRedo();
   if (!asset) return <div className="p-2">No asset selected</div>;
   return (
     <div className="p-2" data-testid="selector-info">
@@ -16,7 +18,7 @@ export default function AssetSelectorInfoPanel({ asset }: Props) {
       <p className="break-all text-sm">{asset}</p>
       <Button
         className="btn-primary btn-sm mt-2"
-        onClick={() => window.electronAPI?.addTexture(projectPath, asset)}
+        onClick={() => addTexture(projectPath, asset)}
       >
         Add
       </Button>

--- a/src/renderer/components/UndoRedoProvider.tsx
+++ b/src/renderer/components/UndoRedoProvider.tsx
@@ -1,0 +1,142 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import path from 'path';
+import { useToast } from './ToastProvider';
+
+export type EditorAction =
+  | { type: 'add'; project: string; texture: string; dest: string }
+  | { type: 'rename'; oldPath: string; newPath: string }
+  | { type: 'delete'; path: string; data: string };
+
+interface Context {
+  addTexture: (project: string, texture: string) => Promise<void>;
+  renameFile: (oldPath: string, newPath: string) => Promise<void>;
+  deleteFile: (file: string) => Promise<void>;
+  undo: () => Promise<void>;
+  redo: () => Promise<void>;
+}
+
+const noop = async () => {
+  /* noop */
+};
+const defaultValue: Context = {
+  addTexture: noop,
+  renameFile: noop,
+  deleteFile: noop,
+  undo: noop,
+  redo: noop,
+};
+const UndoRedoContext = createContext<Context>(defaultValue);
+export const useUndoRedo = () => useContext(UndoRedoContext);
+
+export default function UndoRedoProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const toast = useToast();
+  const [undoStack, setUndoStack] = useState<EditorAction[]>([]);
+  const [redoStack, setRedoStack] = useState<EditorAction[]>([]);
+
+  const record = (action: EditorAction) => {
+    setUndoStack((prev) => {
+      const next = [...prev, action];
+      return next.slice(-20);
+    });
+    setRedoStack([]);
+  };
+
+  const addTexture = async (project: string, texture: string) => {
+    await window.electronAPI?.addTexture(project, texture);
+    const dest = path.join(project, 'assets', 'minecraft', 'textures', texture);
+    record({ type: 'add', project, texture, dest });
+  };
+
+  const renameFile = async (oldPath: string, newPath: string) => {
+    await window.electronAPI?.renameFile(oldPath, newPath);
+    record({ type: 'rename', oldPath, newPath });
+  };
+
+  const deleteFile = async (file: string) => {
+    let data = '';
+    try {
+      data = await window.electronAPI?.readFile(file);
+    } catch {
+      /* ignore */
+    }
+    await window.electronAPI?.deleteFile(file);
+    record({ type: 'delete', path: file, data });
+  };
+
+  const perform = async (action: EditorAction, forward: boolean) => {
+    switch (action.type) {
+      case 'add':
+        if (forward) {
+          await window.electronAPI?.addTexture(action.project, action.texture);
+        } else {
+          await window.electronAPI?.deleteFile(action.dest);
+        }
+        break;
+      case 'rename':
+        if (forward) {
+          await window.electronAPI?.renameFile(action.oldPath, action.newPath);
+        } else {
+          await window.electronAPI?.renameFile(action.newPath, action.oldPath);
+        }
+        break;
+      case 'delete':
+        if (forward) {
+          await window.electronAPI?.deleteFile(action.path);
+        } else {
+          await window.electronAPI?.writeFile(action.path, action.data);
+        }
+        break;
+      default:
+        break;
+    }
+  };
+
+  const undo = async () => {
+    if (undoStack.length === 0) {
+      toast({ message: 'Nothing to undo', type: 'info' });
+      return;
+    }
+    const last = undoStack[undoStack.length - 1];
+    await perform(last, false);
+    setUndoStack((u) => u.slice(0, -1));
+    setRedoStack((r) => [...r, last]);
+  };
+
+  const redo = async () => {
+    if (redoStack.length === 0) {
+      toast({ message: 'Nothing to redo', type: 'info' });
+      return;
+    }
+    const last = redoStack[redoStack.length - 1];
+    await perform(last, true);
+    setRedoStack((r) => r.slice(0, -1));
+    setUndoStack((u) => [...u, last]);
+  };
+
+  useEffect(() => {
+    const handle = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'z') {
+        e.preventDefault();
+        if (e.shiftKey) {
+          redo();
+        } else {
+          undo();
+        }
+      }
+    };
+    window.addEventListener('keydown', handle);
+    return () => window.removeEventListener('keydown', handle);
+  }, [undoStack, redoStack]);
+
+  return (
+    <UndoRedoContext.Provider
+      value={{ addTexture, renameFile, deleteFile, undo, redo }}
+    >
+      {children}
+    </UndoRedoContext.Provider>
+  );
+}

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -11,6 +11,7 @@ import ExportWizardModal, {
 } from '../components/ExportWizardModal';
 import ExternalLink from '../components/ExternalLink';
 import { Modal, Button } from '../components/daisy/actions';
+import { useUndoRedo } from '../components/UndoRedoProvider';
 import type { ExportSummary } from '../../main/exporter';
 /* eslint-disable import/no-unresolved */
 import {
@@ -30,6 +31,7 @@ import { useProject } from '../components/ProjectProvider';
 
 export default function EditorView({ onBack, onSettings }: EditorViewProps) {
   const { path: projectPath } = useProject();
+  const { undo, redo } = useUndoRedo();
   const [selected, setSelected] = useState<string[]>([]);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
@@ -79,6 +81,12 @@ export default function EditorView({ onBack, onSettings }: EditorViewProps) {
       data-testid="editor-view"
     >
       <div className="flex items-center justify-end mb-2 gap-2">
+        <Button className="btn-sm" onClick={undo} aria-label="Undo">
+          Undo
+        </Button>
+        <Button className="btn-sm" onClick={redo} aria-label="Redo">
+          Redo
+        </Button>
         <Button
           className="btn-primary btn-sm"
           onClick={() => setSelectorOpen(true)}


### PR DESCRIPTION
## Summary
- add `UndoRedoProvider` to track editor actions
- hook add/rename/delete functions into the provider
- expose undo/redo hotkeys and buttons in EditorView
- update tests for new provider and hotkeys
- document undo/redo system in developer handbook
- mark TODO for undo/redo queue

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68511215efe48331a2b375faac7ab9d7