### PR TITLE
Refactor project metadata handling

### DIFF
--- a/src/main/noExport.ts
+++ b/src/main/noExport.ts
@@ -1,25 +1,9 @@
-import fs from 'fs';
-import path from 'path';
 import type { IpcMain } from 'electron';
-import { ProjectMetadataSchema, type ProjectMetadata } from '../shared/project';
-
-async function readMeta(projectPath: string): Promise<ProjectMetadata> {
-  const p = path.join(projectPath, 'project.json');
-  const data = JSON.parse(await fs.promises.readFile(p, 'utf-8'));
-  return ProjectMetadataSchema.parse(data);
-}
-
-async function writeMeta(
-  projectPath: string,
-  meta: ProjectMetadata
-): Promise<void> {
-  const p = path.join(projectPath, 'project.json');
-  await fs.promises.writeFile(p, JSON.stringify(meta, null, 2));
-}
+import { readProjectMeta, writeProjectMeta } from './projectMeta';
 
 export async function getNoExport(projectPath: string): Promise<string[]> {
   try {
-    const meta = await readMeta(projectPath);
+    const meta = await readProjectMeta(projectPath);
     return meta.noExport ?? [];
   } catch {
     return [];
@@ -31,14 +15,14 @@ export async function setNoExport(
   files: string[],
   flag: boolean
 ): Promise<void> {
-  const meta = await readMeta(projectPath);
+  const meta = await readProjectMeta(projectPath);
   const set = new Set(meta.noExport ?? []);
   for (const f of files) {
     if (flag) set.add(f);
     else set.delete(f);
   }
   meta.noExport = Array.from(set);
-  await writeMeta(projectPath, meta);
+  await writeProjectMeta(projectPath, meta);
 }
 
 export function registerNoExportHandlers(ipc: IpcMain) {

--- a/src/main/projectMeta.ts
+++ b/src/main/projectMeta.ts
@@ -1,0 +1,21 @@
+import fs from 'fs';
+import path from 'path';
+import { ProjectMetadata, ProjectMetadataSchema } from '../shared/project';
+
+/** Read and parse the project.json metadata for a project. */
+export async function readProjectMeta(
+  projectPath: string
+): Promise<ProjectMetadata> {
+  const p = path.join(projectPath, 'project.json');
+  const data = JSON.parse(await fs.promises.readFile(p, 'utf-8'));
+  return ProjectMetadataSchema.parse(data);
+}
+
+/** Write the given metadata to project.json. */
+export async function writeProjectMeta(
+  projectPath: string,
+  meta: ProjectMetadata
+): Promise<void> {
+  const p = path.join(projectPath, 'project.json');
+  await fs.promises.writeFile(p, JSON.stringify(meta, null, 2));
+}


### PR DESCRIPTION
## Summary
- centralize project metadata read/write helpers in `projectMeta.ts`
- use helpers across main process modules

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851326d48bc83319e2903a772a2f9c3