### PR TITLE
Refactor tests with shared utils

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -184,6 +184,9 @@ describe('App', () => {
       openHandler?.({}, '/tmp/proj');
     });
     await screen.findByText('Export Pack');
+    await act(async () => {
+      await Promise.resolve();
+    });
     exportProject.mockResolvedValueOnce({
       fileCount: 1,
       totalSize: 1,

--- a/__tests__/AssetBrowser.persist.test.tsx
+++ b/__tests__/AssetBrowser.persist.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
 
 const watchProject = vi.fn(async () => []);
@@ -21,40 +19,22 @@ const setAssetFilters = vi.fn();
 const getAssetZoom = vi.fn();
 const setAssetZoom = vi.fn();
 
-function SetPath({
-  path,
-  children,
-}: {
-  path: string;
-  children: React.ReactNode;
-}) {
-  const { setPath } = useProject();
-  const [ready, setReady] = React.useState(false);
-  React.useEffect(() => {
-    setPath(path);
-    setReady(true);
-  }, [path]);
-  return ready ? <>{children}</> : null;
-}
-
 beforeEach(() => {
   vi.clearAllMocks();
-  (window as unknown as { electronAPI: unknown }).electronAPI = {
-    watchProject,
-    unwatchProject,
-    onFileAdded,
-    onFileRemoved,
-    onFileRenamed,
-    onFileChanged,
-    getNoExport: vi.fn(async () => []),
-    setNoExport: vi.fn(),
-    getAssetSearch,
-    setAssetSearch,
-    getAssetFilters,
-    setAssetFilters,
-    getAssetZoom,
-    setAssetZoom,
-  } as never;
+  electronAPI.watchProject.mockImplementation(watchProject);
+  electronAPI.unwatchProject.mockImplementation(unwatchProject);
+  electronAPI.onFileAdded.mockImplementation(onFileAdded);
+  electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+  electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+  electronAPI.onFileChanged.mockImplementation(onFileChanged);
+  electronAPI.getNoExport.mockResolvedValue([]);
+  electronAPI.setNoExport.mockImplementation(() => undefined);
+  electronAPI.getAssetSearch.mockImplementation(getAssetSearch);
+  electronAPI.setAssetSearch.mockImplementation(setAssetSearch);
+  electronAPI.getAssetFilters.mockImplementation(getAssetFilters);
+  electronAPI.setAssetFilters.mockImplementation(setAssetFilters);
+  electronAPI.getAssetZoom.mockImplementation(getAssetZoom);
+  electronAPI.setAssetZoom.mockImplementation(setAssetZoom);
 });
 
 describe('AssetBrowser persistence', () => {

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, within, act } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import path from 'path';
 
 import AssetBrowser from '../src/renderer/components/AssetBrowser';
@@ -16,49 +14,24 @@ const onFileRemoved = vi.fn();
 const onFileRenamed = vi.fn();
 const onFileChanged = vi.fn();
 
-function SetPath({
-  path,
-  children,
-}: {
-  path: string;
-  children: React.ReactNode;
-}) {
-  const { setPath } = useProject();
-  const [ready, setReady] = React.useState(false);
-  React.useEffect(() => {
-    setPath(path);
-    setReady(true);
-  }, [path]);
-  return ready ? <>{children}</> : null;
-}
-
 describe('AssetBrowser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     watchProject.mockResolvedValue(['a.txt', 'b.png']);
-    (
-      window as unknown as {
-        electronAPI: {
-          watchProject: typeof watchProject;
-          unwatchProject: typeof unwatchProject;
-          onFileAdded: typeof onFileAdded;
-          onFileRemoved: typeof onFileRemoved;
-          onFileRenamed: typeof onFileRenamed;
-          onFileChanged: typeof onFileChanged;
-          getNoExport: () => Promise<string[]>;
-          setNoExport: () => void;
-        };
-      }
-    ).electronAPI = {
-      watchProject,
-      unwatchProject,
-      onFileAdded,
-      onFileRemoved,
-      onFileRenamed,
-      onFileChanged,
-      getNoExport: vi.fn(async () => []),
-      setNoExport: vi.fn(),
-    };
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
+    electronAPI.getNoExport.mockResolvedValue([]);
+    electronAPI.setNoExport.mockImplementation(() => undefined);
+    electronAPI.getAssetSearch.mockResolvedValue('');
+    electronAPI.getAssetFilters.mockResolvedValue([]);
+    electronAPI.getAssetZoom.mockResolvedValue(64);
+    electronAPI.setAssetSearch.mockImplementation(() => undefined);
+    electronAPI.setAssetFilters.mockImplementation(() => undefined);
+    electronAPI.setAssetZoom.mockImplementation(() => undefined);
   });
 
   it('renders files from directory', async () => {
@@ -96,37 +69,18 @@ describe('AssetBrowser', () => {
     const openFile = vi.fn();
     const renameFile = vi.fn();
     const deleteFile = vi.fn();
-    (
-      window as unknown as {
-        electronAPI: {
-          openInFolder: typeof openInFolder;
-          openFile: typeof openFile;
-          renameFile: typeof renameFile;
-          deleteFile: typeof deleteFile;
-          watchProject: typeof watchProject;
-          unwatchProject: typeof unwatchProject;
-          onFileAdded: typeof onFileAdded;
-          onFileRemoved: typeof onFileRemoved;
-          onFileRenamed: typeof onFileRenamed;
-          onFileChanged: typeof onFileChanged;
-          getNoExport: () => Promise<string[]>;
-          setNoExport: () => void;
-        };
-      }
-    ).electronAPI = {
-      openInFolder,
-      openFile,
-      renameFile,
-      deleteFile,
-      watchProject,
-      unwatchProject,
-      onFileAdded,
-      onFileRemoved,
-      onFileRenamed,
-      onFileChanged,
-      getNoExport: vi.fn(async () => []),
-      setNoExport: vi.fn(),
-    };
+    electronAPI.openInFolder.mockImplementation(openInFolder);
+    electronAPI.openFile.mockImplementation(openFile);
+    electronAPI.renameFile.mockImplementation(renameFile);
+    electronAPI.deleteFile.mockImplementation(deleteFile);
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
+    electronAPI.getNoExport.mockResolvedValue([]);
+    electronAPI.setNoExport.mockImplementation(() => undefined);
     render(
       <ProjectProvider>
         <SetPath path="/proj">
@@ -224,28 +178,15 @@ describe('AssetBrowser', () => {
 
   it('supports multi selection and delete key', async () => {
     const deleteFile = vi.fn();
-    interface API {
-      deleteFile: (p: string) => void;
-      watchProject: typeof watchProject;
-      unwatchProject: typeof unwatchProject;
-      onFileAdded: typeof onFileAdded;
-      onFileRemoved: typeof onFileRemoved;
-      onFileRenamed: typeof onFileRenamed;
-      onFileChanged: typeof onFileChanged;
-      getNoExport: () => Promise<string[]>;
-      setNoExport: () => void;
-    }
-    (window as unknown as { electronAPI: API }).electronAPI = {
-      deleteFile,
-      watchProject,
-      unwatchProject,
-      onFileAdded,
-      onFileRemoved,
-      onFileRenamed,
-      onFileChanged,
-      getNoExport: vi.fn(async () => []),
-      setNoExport: vi.fn(),
-    };
+    electronAPI.deleteFile.mockImplementation(deleteFile);
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
+    electronAPI.getNoExport.mockResolvedValue([]);
+    electronAPI.setNoExport.mockImplementation(() => undefined);
     render(
       <ProjectProvider>
         <SetPath path="/proj">
@@ -265,26 +206,14 @@ describe('AssetBrowser', () => {
   it('toggles noExport for selected files', async () => {
     const setNoExport = vi.fn();
     const getNoExport = vi.fn(async () => []);
-    interface API {
-      setNoExport: typeof setNoExport;
-      getNoExport: typeof getNoExport;
-      watchProject: typeof watchProject;
-      unwatchProject: typeof unwatchProject;
-      onFileAdded: typeof onFileAdded;
-      onFileRemoved: typeof onFileRemoved;
-      onFileRenamed: typeof onFileRenamed;
-      onFileChanged: typeof onFileChanged;
-    }
-    (window as unknown as { electronAPI: API }).electronAPI = {
-      setNoExport,
-      getNoExport,
-      watchProject,
-      unwatchProject,
-      onFileAdded,
-      onFileRemoved,
-      onFileRenamed,
-      onFileChanged,
-    };
+    electronAPI.setNoExport.mockImplementation(setNoExport);
+    electronAPI.getNoExport.mockImplementation(getNoExport);
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
     render(
       <ProjectProvider>
         <SetPath path="/proj">
@@ -308,26 +237,14 @@ describe('AssetBrowser', () => {
 
   it('shows noExport files dimmed', async () => {
     const getNoExport = vi.fn(async () => ['a.txt']);
-    interface API {
-      getNoExport: typeof getNoExport;
-      setNoExport: () => void;
-      watchProject: typeof watchProject;
-      unwatchProject: typeof unwatchProject;
-      onFileAdded: typeof onFileAdded;
-      onFileRemoved: typeof onFileRemoved;
-      onFileRenamed: typeof onFileRenamed;
-      onFileChanged: typeof onFileChanged;
-    }
-    (window as unknown as { electronAPI: API }).electronAPI = {
-      getNoExport,
-      setNoExport: vi.fn(),
-      watchProject,
-      unwatchProject,
-      onFileAdded,
-      onFileRemoved,
-      onFileRenamed,
-      onFileChanged,
-    };
+    electronAPI.getNoExport.mockImplementation(getNoExport);
+    electronAPI.setNoExport.mockImplementation(() => undefined);
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
     render(
       <ProjectProvider>
         <SetPath path="/proj">

--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, within, act } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 vi.mock('@monaco-editor/react', () => ({
   __esModule: true,
   default: ({
@@ -26,48 +24,18 @@ import ToastProvider from '../src/renderer/components/ToastProvider';
 import path from 'path';
 
 describe('AssetInfo', () => {
-  const readFile = vi.fn();
-  const saveRevision = vi.fn();
-  const openExternalEditor = vi.fn();
-  const onFileChanged = vi.fn();
+  const readFile = electronAPI.readFile as ReturnType<typeof vi.fn>;
+  const saveRevision = electronAPI.saveRevision as ReturnType<typeof vi.fn>;
+  const openExternalEditor = electronAPI.openExternalEditor as ReturnType<typeof vi.fn>;
+  const onFileChanged = electronAPI.onFileChanged as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (
-      window as unknown as {
-        electronAPI: {
-          readFile: typeof readFile;
-          saveRevision: typeof saveRevision;
-          openExternalEditor: typeof openExternalEditor;
-          onFileChanged: typeof onFileChanged;
-        };
-      }
-    ).electronAPI = {
-      readFile,
-      saveRevision,
-      openExternalEditor,
-      onFileChanged,
-    } as never;
-    readFile.mockResolvedValue('');
-    saveRevision.mockResolvedValue(undefined);
-    openExternalEditor.mockResolvedValue(undefined);
+    electronAPI.readFile.mockResolvedValue('');
+    electronAPI.saveRevision.mockResolvedValue(undefined);
+    electronAPI.openExternalEditor.mockResolvedValue(undefined);
+    electronAPI.onFileChanged.mockImplementation(() => undefined);
   });
-
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
 
   it('shows placeholder when no asset', () => {
     render(

--- a/__tests__/AssetSelector.filters.test.tsx
+++ b/__tests__/AssetSelector.filters.test.tsx
@@ -1,27 +1,15 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import AssetSelector from '../src/renderer/components/AssetSelector';
 
 describe('AssetSelector filters', () => {
-  const listTextures = vi.fn();
-  const getTextureUrl = vi.fn();
+  const listTextures = electronAPI.listTextures as ReturnType<typeof vi.fn>;
+  const getTextureUrl = electronAPI.getTextureUrl as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    interface ElectronAPI {
-      listTextures: (path: string) => Promise<string[]>;
-      addTexture: (path: string, tex: string) => Promise<void>;
-      getTextureUrl: (project: string, tex: string) => Promise<string>;
-    }
-    (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
-      listTextures,
-      addTexture: vi.fn(),
-      getTextureUrl,
-    };
     listTextures.mockResolvedValue([
       'block/stone.png',
       'item/apple.png',
@@ -30,22 +18,6 @@ describe('AssetSelector filters', () => {
     getTextureUrl.mockImplementation((_p, n) => `vanilla://${n}`);
     vi.clearAllMocks();
   });
-
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
 
   it('filters textures by category chip and supports keyboard toggle', async () => {
     render(

--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -1,53 +1,25 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 
 import AssetSelector from '../src/renderer/components/AssetSelector';
 
 describe('AssetSelector', () => {
-  const listTextures = vi.fn();
-  const addTexture = vi.fn();
-  const getTextureUrl = vi.fn();
+  const listTextures = electronAPI.listTextures as ReturnType<typeof vi.fn>;
+  const addTexture = electronAPI.addTexture as ReturnType<typeof vi.fn>;
+  const getTextureUrl = electronAPI.getTextureUrl as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    interface ElectronAPI {
-      listTextures: (path: string) => Promise<string[]>;
-      addTexture: (path: string, texture: string) => Promise<void>;
-      getTextureUrl: (project: string, tex: string) => Promise<string>;
-    }
-    (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
-      listTextures,
-      addTexture,
-      getTextureUrl,
-    };
-    listTextures.mockResolvedValue([
+    electronAPI.listTextures.mockResolvedValue([
       'block/grass.png',
       'item/axe.png',
       'other/custom.png',
     ]);
-    getTextureUrl.mockImplementation((_p, n) => `vanilla://${n}`);
+    electronAPI.getTextureUrl.mockImplementation((_p, n) => `vanilla://${n}`);
     vi.clearAllMocks();
   });
-
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
 
   it('lists textures and handles selection', async () => {
     const onSelect = vi.fn();

--- a/__tests__/AssetSelectorInfoPanel.test.tsx
+++ b/__tests__/AssetSelectorInfoPanel.test.tsx
@@ -1,28 +1,11 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import AssetSelectorInfoPanel from '../src/renderer/components/AssetSelectorInfoPanel';
 
 describe('AssetSelectorInfoPanel', () => {
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
   it('shows placeholder when no asset', () => {
     render(
       <ProjectProvider>
@@ -47,10 +30,7 @@ describe('AssetSelectorInfoPanel', () => {
 
   it('adds asset on button click', () => {
     const addTexture = vi.fn();
-    interface API {
-      addTexture: typeof addTexture;
-    }
-    (window as unknown as { electronAPI: API }).electronAPI = { addTexture };
+    electronAPI.addTexture.mockImplementation(addTexture);
     render(
       <ProjectProvider>
         <SetPath path="/p">

--- a/__tests__/ProjectInfoPanel.edit.test.tsx
+++ b/__tests__/ProjectInfoPanel.edit.test.tsx
@@ -18,10 +18,8 @@ vi.mock('@monaco-editor/react', () => ({
     />
   ),
 }));
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import ProjectInfoPanel from '../src/renderer/components/ProjectInfoPanel';
 
 const meta = {
@@ -33,42 +31,13 @@ const meta = {
   license: '',
 };
 
-function SetPath({
-  path,
-  children,
-}: {
-  path: string;
-  children: React.ReactNode;
-}) {
-  const { setPath } = useProject();
-  const [ready, setReady] = React.useState(false);
-  React.useEffect(() => {
-    setPath(path);
-    setReady(true);
-  }, [path]);
-  return ready ? <>{children}</> : null;
-}
-
 describe('ProjectInfoPanel metadata editing', () => {
-  const load = vi.fn();
-  const save = vi.fn();
+  const save = electronAPI.savePackMeta as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    (
-      window as unknown as {
-        electronAPI: {
-          loadPackMeta: typeof load;
-          savePackMeta: typeof save;
-          openInFolder: () => void;
-        };
-      }
-    ).electronAPI = {
-      loadPackMeta: load,
-      savePackMeta: save,
-      openInFolder: vi.fn(),
-    } as never;
-    load.mockResolvedValue(meta);
-    save.mockResolvedValue(undefined);
+    electronAPI.loadPackMeta.mockResolvedValue(meta);
+    electronAPI.savePackMeta.mockResolvedValue(undefined);
+    electronAPI.openInFolder.mockImplementation(() => undefined);
     vi.clearAllMocks();
   });
 

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -21,9 +21,9 @@ describe('ProjectInfoPanel', () => {
   const onBack = vi.fn();
 
   beforeEach(() => {
-    electronAPI.loadPackMeta.mockResolvedValue(meta);
-    electronAPI.openInFolder.mockImplementation(open);
     vi.clearAllMocks();
+    load.mockResolvedValue(meta);
+    open.mockResolvedValue(undefined);
   });
 
   it('loads metadata and triggers export', async () => {

--- a/__tests__/ProjectInfoPanel.test.tsx
+++ b/__tests__/ProjectInfoPanel.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 import ProjectInfoPanel from '../src/renderer/components/ProjectInfoPanel';
 
 const meta = {
@@ -17,39 +15,16 @@ const meta = {
 };
 
 describe('ProjectInfoPanel', () => {
-  const load = vi.fn();
-  const open = vi.fn();
+  const load = electronAPI.loadPackMeta as ReturnType<typeof vi.fn>;
+  const open = electronAPI.openInFolder as ReturnType<typeof vi.fn>;
   const onExport = vi.fn();
   const onBack = vi.fn();
 
   beforeEach(() => {
-    (
-      window as unknown as {
-        electronAPI: { loadPackMeta: typeof load; openInFolder: typeof open };
-      }
-    ).electronAPI = {
-      loadPackMeta: load,
-      openInFolder: open,
-    } as never;
-    load.mockResolvedValue(meta);
+    electronAPI.loadPackMeta.mockResolvedValue(meta);
+    electronAPI.openInFolder.mockImplementation(open);
     vi.clearAllMocks();
   });
-
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
 
   it('loads metadata and triggers export', async () => {
     render(

--- a/__tests__/TextureDiff.test.tsx
+++ b/__tests__/TextureDiff.test.tsx
@@ -2,37 +2,12 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import TextureDiff from '../src/renderer/components/TextureDiff';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
-
-function SetPath({
-  path,
-  children,
-}: {
-  path: string;
-  children: React.ReactNode;
-}) {
-  const { setPath } = useProject();
-  const [ready, setReady] = React.useState(false);
-  React.useEffect(() => {
-    setPath(path);
-    setReady(true);
-  }, [path]);
-  return ready ? <>{children}</> : null;
-}
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 
 describe('TextureDiff', () => {
   it('renders vanilla comparison', async () => {
-    const getTextureUrl = vi.fn().mockResolvedValue('vanilla://foo.png');
-    (
-      window as unknown as {
-        electronAPI: { getTextureUrl: typeof getTextureUrl };
-      }
-    ).electronAPI = {
-      getTextureUrl,
-    } as never;
+    electronAPI.getTextureUrl.mockResolvedValue('vanilla://foo.png');
 
     render(
       <ProjectProvider>
@@ -42,7 +17,10 @@ describe('TextureDiff', () => {
       </ProjectProvider>
     );
 
-    expect(getTextureUrl).toHaveBeenCalledWith('/proj', 'block/a.png');
+    expect(electronAPI.getTextureUrl).toHaveBeenCalledWith(
+      '/proj',
+      'block/a.png'
+    );
     expect(await screen.findByTestId('diff')).toBeInTheDocument();
     const imgs = screen.getAllByRole('img');
     expect(imgs[0]).toHaveAttribute('src', 'vanilla://foo.png');
@@ -50,15 +28,8 @@ describe('TextureDiff', () => {
   });
 
   it('calls onClose', async () => {
-    const getTextureUrl = vi.fn().mockResolvedValue('vanilla://foo.png');
     const onClose = vi.fn();
-    (
-      window as unknown as {
-        electronAPI: { getTextureUrl: typeof getTextureUrl };
-      }
-    ).electronAPI = {
-      getTextureUrl,
-    } as never;
+    electronAPI.getTextureUrl.mockResolvedValue('vanilla://foo.png');
 
     render(
       <ProjectProvider>

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -1,39 +1,18 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import TextureLab from '../src/renderer/components/TextureLab';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 
 describe('TextureLab', () => {
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
   it('renders modal with controls', () => {
     let changed:
       | ((e: unknown, args: { path: string; stamp: number }) => void)
       | undefined;
-    (
-      window as unknown as { electronAPI: { onFileChanged: typeof vi.fn } }
-    ).electronAPI = {
-      onFileChanged: vi.fn((cb) => {
-        changed = cb;
-      }),
-    } as never;
+    electronAPI.onFileChanged.mockImplementation((cb) => {
+      changed = cb;
+    });
 
     render(
       <ProjectProvider>

--- a/__tests__/revisions.test.tsx
+++ b/__tests__/revisions.test.tsx
@@ -20,10 +20,8 @@ vi.mock('@monaco-editor/react', () => ({
 import AssetInfo from '../src/renderer/components/AssetInfo';
 import RevisionsModal from '../src/renderer/components/RevisionsModal';
 import ToastProvider from '../src/renderer/components/ToastProvider';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 
 const saveRevision = vi.fn();
 const listRevisions = vi.fn();
@@ -33,44 +31,16 @@ const onFileChanged = vi.fn();
 
 beforeEach(() => {
   vi.clearAllMocks();
-  (
-    window as unknown as {
-      electronAPI: {
-        saveRevision: typeof saveRevision;
-        listRevisions: typeof listRevisions;
-        restoreRevision: typeof restoreRevision;
-        readFile: typeof readFile;
-        onFileChanged: typeof onFileChanged;
-      };
-    }
-  ).electronAPI = {
-    saveRevision,
-    listRevisions,
-    restoreRevision,
-    readFile,
-    onFileChanged,
-  } as never;
+  electronAPI.saveRevision.mockImplementation(saveRevision);
+  electronAPI.listRevisions.mockImplementation(listRevisions);
+  electronAPI.restoreRevision.mockImplementation(restoreRevision);
+  electronAPI.readFile.mockImplementation(readFile);
+  electronAPI.onFileChanged.mockImplementation(onFileChanged);
   listRevisions.mockResolvedValue(['1.png']);
   readFile.mockResolvedValue('');
   saveRevision.mockResolvedValue(undefined);
   restoreRevision.mockResolvedValue(undefined);
 });
-
-function SetPath({
-  path,
-  children,
-}: {
-  path: string;
-  children: React.ReactNode;
-}) {
-  const { setPath } = useProject();
-  const [ready, setReady] = React.useState(false);
-  React.useEffect(() => {
-    setPath(path);
-    setReady(true);
-  }, [path]);
-  return ready ? <>{children}</> : null;
-}
 
 describe('Revision history', () => {
   it('saves revision on save', async () => {

--- a/__tests__/test-utils.tsx
+++ b/__tests__/test-utils.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { vi } from 'vitest';
+import { useProject } from '../src/renderer/components/ProjectProvider';
+
+export function SetPath({
+  path,
+  children,
+}: {
+  path: string;
+  children: React.ReactNode;
+}) {
+  const { setPath } = useProject();
+  const [ready, setReady] = React.useState(false);
+  React.useEffect(() => {
+    setPath(path);
+    setReady(true);
+  }, [path]);
+  return ready ? <>{children}</> : null;
+}
+
+const handlers: Record<string, ReturnType<typeof vi.fn>> = {};
+
+export const electronAPI: Window['electronAPI'] = new Proxy(handlers, {
+  get(target, prop: string) {
+    if (!(prop in target)) {
+      // create a mock function on first access
+      target[prop as string] = vi.fn();
+    }
+    return target[prop as string];
+  },
+});
+
+// expose mocks on the global window object
+(window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI = electronAPI;

--- a/__tests__/useProjectFiles.test.tsx
+++ b/__tests__/useProjectFiles.test.tsx
@@ -3,10 +3,8 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useProjectFiles } from '../src/renderer/components/file/useProjectFiles';
 import ToastProvider from '../src/renderer/components/ToastProvider';
-import {
-  ProjectProvider,
-  useProject,
-} from '../src/renderer/components/ProjectProvider';
+import { ProjectProvider } from '../src/renderer/components/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
 
 const watchProject = vi.fn(async () => ['a.txt', 'b.png']);
 const unwatchProject = vi.fn();
@@ -35,34 +33,15 @@ declare global {
 describe('useProjectFiles', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
-      {
-        watchProject,
-        unwatchProject,
-        onFileAdded,
-        onFileRemoved,
-        onFileRenamed,
-        onFileChanged,
-        getNoExport,
-        setNoExport,
-      };
+    electronAPI.watchProject.mockImplementation(watchProject);
+    electronAPI.unwatchProject.mockImplementation(unwatchProject);
+    electronAPI.onFileAdded.mockImplementation(onFileAdded);
+    electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+    electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+    electronAPI.onFileChanged.mockImplementation(onFileChanged);
+    electronAPI.getNoExport.mockImplementation(getNoExport);
+    electronAPI.setNoExport.mockImplementation(setNoExport);
   });
-
-  function SetPath({
-    path,
-    children,
-  }: {
-    path: string;
-    children: React.ReactNode;
-  }) {
-    const { setPath } = useProject();
-    const [ready, setReady] = React.useState(false);
-    React.useEffect(() => {
-      setPath(path);
-      setReady(true);
-    }, [path]);
-    return ready ? <>{children}</> : null;
-  }
 
   it('watches project and handles events', async () => {
     let added: ((e: unknown, p: string) => void) | undefined;


### PR DESCRIPTION
## Summary
- add shared test-utils with SetPath and electron mocks
- use SetPath & electronAPI mocks across tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685155a860b883318d0fabdd5f68baa0