### PR TITLE
Implement automatic texture revisions

### DIFF
--- a/__tests__/externalEditorIPC.test.ts
+++ b/__tests__/externalEditorIPC.test.ts
@@ -11,6 +11,10 @@ vi.mock('child_process', () => {
   return { spawn: spawnMock, default: { spawn: spawnMock } };
 });
 
+vi.mock('../src/main/revision', () => ({
+  saveRevisionForFile: vi.fn(async () => {}),
+}));
+
 vi.mock('../src/main/layout', () => ({
   getTextureEditor: () => '/usr/bin/gimp',
 }));
@@ -30,6 +34,8 @@ describe('open-external-editor IPC', () => {
   it('spawns configured editor with file path', async () => {
     expect(handler).toBeTypeOf('function');
     await handler?.({}, '/tmp/a.png');
+    const { saveRevisionForFile } = await import('../src/main/revision');
+    expect(saveRevisionForFile).toHaveBeenCalledWith('/tmp/a.png');
     expect(spawnMock).toHaveBeenCalledWith('/usr/bin/gimp', ['/tmp/a.png'], {
       detached: true,
       stdio: 'ignore',

--- a/__tests__/revisionAuto.test.ts
+++ b/__tests__/revisionAuto.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import sharp from 'sharp';
+import { editTexture } from '../src/main/textureLab';
+import { listRevisions } from '../src/main/revision';
+vi.mock('../src/main/layout', () => ({ getTextureEditor: () => '/bin/true' }));
+vi.mock('child_process', () => {
+  const spawn = vi.fn(() => ({ unref: vi.fn() }));
+  return { spawn, default: { spawn } };
+});
+
+function makeProject() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'revtest-'));
+  fs.writeFileSync(path.join(dir, 'project.json'), '{}');
+  return dir;
+}
+
+describe('automatic revision history', () => {
+  it('saves revision when texture lab edits', async () => {
+    const proj = makeProject();
+    const file = path.join(proj, 'a.png');
+    await sharp({
+      create: { width: 2, height: 2, channels: 4, background: '#f00' },
+    })
+      .png()
+      .toFile(file);
+    await editTexture(file, { grayscale: true });
+    const revs = await listRevisions(proj, 'a.png');
+    expect(revs.length).toBe(1);
+    fs.rmSync(proj, { recursive: true, force: true });
+  });
+
+  it('saves revision before external edit', async () => {
+    const proj = makeProject();
+    const file = path.join(proj, 'b.png');
+    fs.writeFileSync(file, 'data');
+    const { openWithEditor } = await import('../src/main/externalEditor');
+    await openWithEditor(file);
+    fs.writeFileSync(file, 'new');
+    await new Promise((r) => setTimeout(r, 10));
+    const revs = await listRevisions(proj, 'b.png');
+    expect(revs.length).toBe(1);
+    fs.rmSync(proj, { recursive: true, force: true });
+  });
+});

--- a/__tests__/textureLabIPC.test.ts
+++ b/__tests__/textureLabIPC.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import sharp from 'sharp';
 import { registerTextureLabHandlers } from '../src/main/textureLab';
+
+vi.mock('../src/main/revision', () => ({
+  saveRevisionForFile: vi.fn(async () => {}),
+}));
 
 let handler:
   | ((e: unknown, file: string, opts: unknown) => Promise<void>)
@@ -27,6 +31,8 @@ describe('edit-texture IPC', () => {
     );
     expect(handler).toBeTypeOf('function');
     await handler?.({}, tmp, { grayscale: true });
+    const { saveRevisionForFile } = await import('../src/main/revision');
+    expect(saveRevisionForFile).toHaveBeenCalledWith(tmp);
     const meta = await sharp(tmp).metadata();
     expect(meta.format).toBe('png');
     fs.unlinkSync(tmp);

--- a/src/main/externalEditor.ts
+++ b/src/main/externalEditor.ts
@@ -1,10 +1,12 @@
 import { spawn } from 'child_process';
 import type { IpcMain } from 'electron';
 import { getTextureEditor } from './layout';
+import { saveRevisionForFile } from './revision';
 
-export function openWithEditor(file: string): void {
+export async function openWithEditor(file: string): Promise<void> {
   const editor = getTextureEditor();
   if (!editor) return;
+  await saveRevisionForFile(file);
   spawn(editor, [file], {
     detached: true,
     stdio: 'ignore',

--- a/src/main/ipcFiles.ts
+++ b/src/main/ipcFiles.ts
@@ -3,7 +3,12 @@ import { shell } from 'electron';
 import { emitRenamed } from './ipc/fileWatcher';
 import fs from 'fs';
 import path from 'path';
-import { saveRevision, listRevisions, restoreRevision } from './revision';
+import {
+  saveRevision,
+  listRevisions,
+  restoreRevision,
+  saveRevisionForFile,
+} from './revision';
 
 /** Register IPC handlers for file interactions. */
 export function registerFileHandlers(ipc: IpcMain) {
@@ -20,6 +25,7 @@ export function registerFileHandlers(ipc: IpcMain) {
   });
 
   ipc.handle('write-file', async (_e, file: string, data: string) => {
+    await saveRevisionForFile(file);
     await fs.promises.writeFile(file, data, 'utf-8');
   });
 

--- a/src/main/revision.ts
+++ b/src/main/revision.ts
@@ -51,3 +51,23 @@ export async function restoreRevision(
   await saveRevision(project, rel);
   await fs.promises.copyFile(src, dest);
 }
+
+/** Find the project root for the given file by locating project.json */
+export function findProjectRoot(file: string): string | null {
+  let dir = path.resolve(path.dirname(file));
+  while (true) {
+    if (fs.existsSync(path.join(dir, 'project.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+/** Save a revision for the specified absolute file path */
+export async function saveRevisionForFile(file: string): Promise<void> {
+  const project = findProjectRoot(file);
+  if (!project) return;
+  const rel = path.relative(project, file).split(path.sep).join('/');
+  await saveRevision(project, rel);
+}

--- a/src/main/textureLab.ts
+++ b/src/main/textureLab.ts
@@ -1,11 +1,13 @@
 import sharp from 'sharp';
 import type { IpcMain } from 'electron';
 import type { TextureEditOptions } from '../shared/texture';
+import { saveRevisionForFile } from './revision';
 
 export async function editTexture(
   file: string,
   opts: TextureEditOptions
 ): Promise<void> {
+  await saveRevisionForFile(file);
   let img = sharp(file);
   if (opts.rotate) img = img.rotate(opts.rotate);
 


### PR DESCRIPTION
## Summary
- track prior versions automatically with `saveRevisionForFile`
- call into history when editing textures
- preserve revisions before launching external editors
- ensure write-file IPC captures history
- add revision history tests

## Testing
- `npm test`
- `npm run lint`
- `npm run format`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68516efb769c833198484584037fca71