### PR TITLE
Skip .history directories

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -51,6 +51,21 @@ describe('AssetBrowser', () => {
     expect(img.style.imageRendering).toBe('pixelated');
   });
 
+  it('filters out .history files', async () => {
+    watchProject.mockResolvedValue(['.history/a.txt', 'visible.txt']);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
+    expect((await screen.findAllByText('visible.txt')).length).toBeGreaterThan(
+      0
+    );
+    expect(screen.queryByText('a.txt')).toBeNull();
+  });
+
   it('is scrollable', async () => {
     render(
       <ProjectProvider>

--- a/__tests__/exporter.test.ts
+++ b/__tests__/exporter.test.ts
@@ -102,4 +102,14 @@ describe('exportPack', () => {
     const names = dir.files.map((f) => f.path);
     expect(names).not.toContain('folder/');
   });
+
+  it('never includes .history content', async () => {
+    const hist = path.join(projectDir, '.history');
+    fs.mkdirSync(hist, { recursive: true });
+    fs.writeFileSync(path.join(hist, 'old.txt'), 'x');
+    await exportPack(projectDir, outZip);
+    const dir = await unzipper.Open.file(outZip);
+    const names = dir.files.map((f) => f.path);
+    expect(names.some((n) => n.includes('.history'))).toBe(false);
+  });
 });

--- a/__tests__/useProjectFiles.test.tsx
+++ b/__tests__/useProjectFiles.test.tsx
@@ -94,6 +94,26 @@ describe('useProjectFiles', () => {
     expect(unwatchProject).toHaveBeenCalledWith('/proj');
   });
 
+  it('ignores files in .history directories', async () => {
+    watchProject.mockResolvedValue(['.history/a.txt', 'keep.txt']);
+    let added: ((e: unknown, p: string) => void) | undefined;
+    onFileAdded.mockImplementation((cb) => {
+      added = cb;
+    });
+    const { result } = renderHook(() => useProjectFiles(), {
+      wrapper: ({ children }) => (
+        <ProjectProvider>
+          <SetPath path="/proj">{children}</SetPath>
+        </ProjectProvider>
+      ),
+    });
+    await waitFor(() => expect(result.current.files).toEqual(['keep.txt']));
+    act(() => {
+      added?.({}, '.history/b.txt');
+    });
+    expect(result.current.files).toEqual(['keep.txt']);
+  });
+
   it('toggles noExport state', async () => {
     const { result } = renderHook(() => useProjectFiles(), {
       wrapper: ({ children }) => (

--- a/src/main/exporter.ts
+++ b/src/main/exporter.ts
@@ -32,6 +32,7 @@ function addDirectory(
     if (ignore.has(rel)) continue;
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      if (entry.name === '.history') continue;
       addDirectory(archive, full, ignore, rel);
     } else {
       archive.file(full, { name: rel });


### PR DESCRIPTION
## Summary
- filter `.history` entries in `useProjectFiles`
- ignore `.history` during export
- ensure `.history` never shows up in exported zips or in the browser

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68517131d62c8331ac1b91a85261d249