### PR TITLE
Add audio preview and lang asset support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -30,7 +30,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Custom namespace support (non-`minecraft` assets)
 - [x] Persist search query, category filters and zoom level between sessions
 - [ ] Arrow key navigation between thumbnails
-- [ ] Audio & language asset management with previews (`.ogg`, `.wav`, `.json`)
+- [x] Audio & language asset management with previews (`.ogg`, `.wav`, `.json`)
 - [ ] Asset atlas viewer for stitching HD texture previews
 - [ ] Asset dependency graph showing overrides
 

--- a/__tests__/AudioPreview.test.tsx
+++ b/__tests__/AudioPreview.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AudioPreview from '../src/renderer/components/assets/AudioPreview';
+
+describe('AudioPreview', () => {
+  it('renders modal with audio source', () => {
+    render(<AudioPreview asset="foo.ogg" onClose={() => {}} />);
+    const modal = screen.getByTestId('daisy-modal');
+    expect(modal).toBeInTheDocument();
+    const audio = screen.getByTestId('audio-player');
+    const src = audio.querySelector('source') as HTMLSourceElement;
+    expect(src.getAttribute('src')).toBe('asset://foo.ogg');
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -155,11 +155,14 @@ should be excluded from exports. The asset browser context menu includes a
 
 The vanilla asset browser lets you search textures from the selected Minecraft
 version. Results are grouped into collapsible **Blocks**, **Items**, **Entity**,
-**UI**, **Audio** and **Misc** sections using daisyUI's collapse component. Only assets
+**UI**, **Audio**, **Lang** and **Misc** sections using daisyUI's collapse component. Only assets
 that match the search query appear in each section. Thumbnails respect the zoom
 slider (24–128 px) and textures can be clicked or dragged into the asset browser
 to add them to the project.
 Text files such as `.txt` and `.json` display a document icon instead of a thumbnail.
+Language files under `lang/` are listed in their own **Lang** section.
+Audio files (`.ogg` and `.wav`) include a **Play Audio** button that opens a daisyUI modal
+with an HTML5 `<audio>` element for playback.
 
 Beside the asset information panel, a **Preview Pane** shows the currently
 selected texture under neutral lighting. The pane renders textures at a 1:1

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -12,7 +12,7 @@ interface Props {
   onSelectionChange?: (sel: string[]) => void;
 }
 
-const FILTERS = ['blocks', 'items', 'entity', 'ui', 'audio'] as const;
+const FILTERS = ['blocks', 'items', 'entity', 'ui', 'audio', 'lang'] as const;
 type Filter = (typeof FILTERS)[number];
 
 const normalizeForCategory = (file: string) => {
@@ -36,6 +36,7 @@ const getCategory = (name: string): Filter | 'misc' => {
   )
     return 'ui';
   if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
+  if (name.startsWith('lang/')) return 'lang';
   return 'misc';
 };
 
@@ -94,6 +95,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
       entity: [],
       ui: [],
       audio: [],
+      lang: [],
       misc: [],
     };
     for (const f of visible) {
@@ -163,33 +165,41 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
       </div>
       <div className="grid grid-cols-3 gap-4">
         <div className="col-span-2">
-          {(['blocks', 'items', 'entity', 'ui', 'audio', 'misc'] as const).map(
-            (key) => {
-              const list = categories[key];
-              if (list.length === 0) return null;
-              return (
-                <Accordion key={key} title={key} className="mb-2" defaultOpen>
-                  <div className="grid grid-cols-6 gap-2">
-                    {list.map((f) => (
-                      <AssetBrowserItem
-                        key={f}
-                        projectPath={projectPath}
-                        file={f}
-                        selected={selected}
-                        setSelected={setSelected}
-                        noExport={noExport}
-                        toggleNoExport={toggleNoExport}
-                        deleteFiles={deleteFiles}
-                        openRename={(file) => setRenameTarget(file)}
-                        zoom={zoom}
-                        stamp={versions[f]}
-                      />
-                    ))}
-                  </div>
-                </Accordion>
-              );
-            }
-          )}
+          {(
+            [
+              'blocks',
+              'items',
+              'entity',
+              'ui',
+              'audio',
+              'lang',
+              'misc',
+            ] as const
+          ).map((key) => {
+            const list = categories[key];
+            if (list.length === 0) return null;
+            return (
+              <Accordion key={key} title={key} className="mb-2" defaultOpen>
+                <div className="grid grid-cols-6 gap-2">
+                  {list.map((f) => (
+                    <AssetBrowserItem
+                      key={f}
+                      projectPath={projectPath}
+                      file={f}
+                      selected={selected}
+                      setSelected={setSelected}
+                      noExport={noExport}
+                      toggleNoExport={toggleNoExport}
+                      deleteFiles={deleteFiles}
+                      openRename={(file) => setRenameTarget(file)}
+                      zoom={zoom}
+                      stamp={versions[f]}
+                    />
+                  ))}
+                </div>
+              </Accordion>
+            );
+          })}
         </div>
         <div>
           <FileTree

--- a/src/renderer/components/assets/AssetInfo.tsx
+++ b/src/renderer/components/assets/AssetInfo.tsx
@@ -10,6 +10,7 @@ import RevisionsModal from '../modals/RevisionsModal';
 const PreviewPane = lazy(() => import('./PreviewPane'));
 const TextureLab = lazy(() => import('./TextureLab'));
 const TextureDiff = lazy(() => import('./TextureDiff'));
+const AudioPreview = lazy(() => import('./AudioPreview'));
 
 interface Props {
   asset: string | null;
@@ -24,6 +25,7 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [lab, setLab] = useState(false);
   const [diff, setDiff] = useState(false);
+  const [audio, setAudio] = useState(false);
   const [stamp, setStamp] = useState<number>();
   const [revs, setRevs] = useState(false);
 
@@ -45,6 +47,9 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
     ? ['.json', '.mcmeta'].includes(path.extname(asset).toLowerCase())
     : false;
   const isPng = asset ? path.extname(asset).toLowerCase() === '.png' : false;
+  const isAudio = asset
+    ? ['.ogg', '.wav'].includes(path.extname(asset).toLowerCase())
+    : false;
 
   useEffect(() => {
     if (asset && count === 1 && isText) {
@@ -94,7 +99,7 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
           </div>
         }
       >
-        <PreviewPane texture={asset} stamp={stamp} />
+        <PreviewPane texture={isPng ? asset : null} stamp={stamp} />
       </Suspense>
       <div className="flex-1 w-100">
         <h3 className="font-bold mb-1 break-all">{asset}</h3>
@@ -161,6 +166,22 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
             </Button>
           </div>
         )}
+        {isAudio && count === 1 && (
+          <div className="flex flex-col gap-2 mt-2">
+            <Button
+              className="btn-secondary btn-sm"
+              onClick={() => setAudio(true)}
+            >
+              Play Audio
+            </Button>
+            <Button
+              className="btn-secondary btn-sm"
+              onClick={() => setRevs(true)}
+            >
+              Revisions
+            </Button>
+          </div>
+        )}
         {lab && (
           <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
             <TextureLab
@@ -173,6 +194,11 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
         {diff && (
           <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
             <TextureDiff asset={asset} onClose={() => setDiff(false)} />
+          </Suspense>
+        )}
+        {audio && (
+          <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+            <AudioPreview asset={asset} onClose={() => setAudio(false)} />
           </Suspense>
         )}
         {revs && (

--- a/src/renderer/components/assets/AudioPreview.tsx
+++ b/src/renderer/components/assets/AudioPreview.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Modal, Button } from '../daisy/actions';
+
+export default function AudioPreview({
+  asset,
+  onClose,
+}: {
+  asset: string;
+  onClose: () => void;
+}) {
+  return (
+    <Modal open>
+      <h3 className="font-bold text-lg mb-2">Audio Preview</h3>
+      <audio controls data-testid="audio-player" className="w-full">
+        <source src={`asset://${asset}`} />
+        Your browser does not support the audio element.
+      </audio>
+      <div className="modal-action">
+        <Button onClick={onClose}>Close</Button>
+      </div>
+    </Modal>
+  );
+}


### PR DESCRIPTION
## Summary
- recognise language JSON and audio in AssetBrowser
- add AudioPreview modal component
- show audio preview button in AssetInfo
- document audio preview and language assets
- tick TODO for audio & language asset management
- add unit test for the audio preview modal

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6851717f22a88331aa510f9d5a29a361