### PR TITLE
Add arrow key navigation for asset browser

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -29,7 +29,7 @@ UI components **must** ship with Vitest + RTL tests; overall coverage ≥ 90�
 - [ ] Dirty badge for changed assets
 - [ ] Custom namespace support (non-`minecraft` assets)
 - [x] Persist search query, category filters and zoom level between sessions
-- [ ] Arrow key navigation between thumbnails
+- [x] Arrow key navigation between thumbnails
 - [ ] Audio & language asset management with previews (`.ogg`, `.wav`, `.json`)
 - [ ] Asset atlas viewer for stitching HD texture previews
 - [ ] Asset dependency graph showing overrides

--- a/__tests__/AssetBrowser.navigation.test.tsx
+++ b/__tests__/AssetBrowser.navigation.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
+import { SetPath, electronAPI } from './test-utils';
+import AssetBrowser from '../src/renderer/components/assets/AssetBrowser';
+
+const watchProject = vi.fn(async () => [
+  'a.png',
+  'b.png',
+  'c.png',
+  'd.png',
+  'e.png',
+  'f.png',
+  'g.png',
+  'h.png',
+]);
+const unwatchProject = vi.fn();
+const onFileAdded = vi.fn();
+const onFileRemoved = vi.fn();
+const onFileRenamed = vi.fn();
+const onFileChanged = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  electronAPI.watchProject.mockImplementation(watchProject);
+  electronAPI.unwatchProject.mockImplementation(unwatchProject);
+  electronAPI.onFileAdded.mockImplementation(onFileAdded);
+  electronAPI.onFileRemoved.mockImplementation(onFileRemoved);
+  electronAPI.onFileRenamed.mockImplementation(onFileRenamed);
+  electronAPI.onFileChanged.mockImplementation(onFileChanged);
+  electronAPI.getNoExport.mockResolvedValue([]);
+  electronAPI.setNoExport.mockImplementation(() => undefined);
+  electronAPI.getAssetSearch.mockResolvedValue('');
+  electronAPI.getAssetFilters.mockResolvedValue([]);
+  electronAPI.getAssetZoom.mockResolvedValue(64);
+  electronAPI.setAssetSearch.mockImplementation(() => undefined);
+  electronAPI.setAssetFilters.mockImplementation(() => undefined);
+  electronAPI.setAssetZoom.mockImplementation(() => undefined);
+});
+
+describe('AssetBrowser thumbnail navigation', () => {
+  it('moves selection with arrow keys', async () => {
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetBrowser />
+        </SetPath>
+      </ProjectProvider>
+    );
+    await screen.findAllByText('a.png');
+    const wrapper = screen.getByTestId('asset-browser');
+    wrapper.focus();
+
+    fireEvent.keyDown(wrapper, { key: 'ArrowRight' });
+    const bItem = screen
+      .getAllByText('b.png')[0]
+      .closest('div[tabindex="0"]') as HTMLElement;
+    expect(bItem).toHaveClass('ring');
+    expect(bItem).toHaveFocus();
+
+    fireEvent.keyDown(wrapper, { key: 'ArrowLeft' });
+    const aItem = screen
+      .getAllByText('a.png')[0]
+      .closest('div[tabindex="0"]') as HTMLElement;
+    expect(aItem).toHaveClass('ring');
+    expect(aItem).toHaveFocus();
+
+    fireEvent.keyDown(wrapper, { key: 'ArrowDown' });
+    const gItem = screen
+      .getAllByText('g.png')[0]
+      .closest('div[tabindex="0"]') as HTMLElement;
+    expect(gItem).toHaveClass('ring');
+    expect(gItem).toHaveFocus();
+
+    fireEvent.keyDown(wrapper, { key: 'ArrowUp' });
+    const againA = screen
+      .getAllByText('a.png')[0]
+      .closest('div[tabindex="0"]') as HTMLElement;
+    expect(againA).toHaveClass('ring');
+    expect(againA).toHaveFocus();
+  });
+});

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -160,6 +160,7 @@ that match the search query appear in each section. Thumbnails respect the zoom
 slider (24–128 px) and textures can be clicked or dragged into the asset browser
 to add them to the project.
 Text files such as `.txt` and `.json` display a document icon instead of a thumbnail.
+You can also use the arrow keys to move selection between thumbnails.
 
 Beside the asset information panel, a **Preview Pane** shows the currently
 selected texture under neutral lighting. The pane renders textures at a 1:1

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -7,6 +7,7 @@ import FileTree from './FileTree';
 import { useProject } from '../providers/ProjectProvider';
 import { FilterBadge, InputField, Range } from '../daisy/input';
 import { Accordion } from '../daisy/display';
+import useThumbnailNavigation from '../../hooks/useThumbnailNavigation';
 
 interface Props {
   onSelectionChange?: (sel: string[]) => void;
@@ -104,6 +105,8 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
     return out;
   }, [visible]);
 
+  const nav = useThumbnailNavigation(visible, selected, setSelected, 6);
+
   const toggleFilter = (f: Filter) => {
     setFilters((prev) =>
       prev.includes(f) ? prev.filter((p) => p !== f) : [...prev, f]
@@ -128,7 +131,9 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();
           handleDeleteSelected();
+          return;
         }
+        nav.onKeyDown(e);
       }}
       tabIndex={0}
     >
@@ -183,6 +188,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
                         openRename={(file) => setRenameTarget(file)}
                         zoom={zoom}
                         stamp={versions[f]}
+                        ref={nav.register(f)}
                       />
                     ))}
                   </div>

--- a/src/renderer/components/assets/AssetBrowserItem.tsx
+++ b/src/renderer/components/assets/AssetBrowserItem.tsx
@@ -17,136 +17,144 @@ interface Props {
   stamp?: number;
 }
 
-const AssetBrowserItem: React.FC<Props> = ({
-  projectPath,
-  file,
-  selected,
-  setSelected,
-  noExport,
-  toggleNoExport,
-  deleteFiles,
-  openRename,
-  zoom,
-  stamp,
-}) => {
-  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
-  const firstItem = useRef<HTMLButtonElement>(null);
+const AssetBrowserItem = React.forwardRef<HTMLDivElement, Props>(
+  (
+    {
+      projectPath,
+      file,
+      selected,
+      setSelected,
+      noExport,
+      toggleNoExport,
+      deleteFiles,
+      openRename,
+      zoom,
+      stamp,
+    },
+    ref
+  ) => {
+    const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(
+      null
+    );
+    const firstItem = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (menuPos && firstItem.current) {
-      firstItem.current.focus();
-    }
-  }, [menuPos]);
+    useEffect(() => {
+      if (menuPos && firstItem.current) {
+        firstItem.current.focus();
+      }
+    }, [menuPos]);
 
-  const full = path.join(projectPath, file);
-  const name = path.basename(file);
-  const formatted = file.endsWith('.png') ? formatTextureName(name) : name;
-  const texPath = file.endsWith('.png') ? file : null;
-  const altText = texPath ? formatted : name;
+    const full = path.join(projectPath, file);
+    const name = path.basename(file);
+    const formatted = file.endsWith('.png') ? formatTextureName(name) : name;
+    const texPath = file.endsWith('.png') ? file : null;
+    const altText = texPath ? formatted : name;
 
-  const isSelected = selected.has(file);
+    const isSelected = selected.has(file);
 
-  const toggleSelect = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    const ns = new Set(selected);
-    if (e.ctrlKey || e.metaKey || e.shiftKey) {
-      if (ns.has(file)) ns.delete(file);
-      else ns.add(file);
-    } else {
-      ns.clear();
-      ns.add(file);
-    }
-    setSelected(ns);
-  };
+    const toggleSelect = (e: React.MouseEvent) => {
+      e.stopPropagation();
+      const ns = new Set(selected);
+      if (e.ctrlKey || e.metaKey || e.shiftKey) {
+        if (ns.has(file)) ns.delete(file);
+        else ns.add(file);
+      } else {
+        ns.clear();
+        ns.add(file);
+      }
+      setSelected(ns);
+    };
 
-  const showMenu = (x: number, y: number) => {
-    setMenuPos({ x, y });
-  };
+    const showMenu = (x: number, y: number) => {
+      setMenuPos({ x, y });
+    };
 
-  const handleContext = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (!selected.has(file)) {
-      setSelected(new Set([file]));
-    }
-    showMenu(e.clientX, e.clientY);
-  };
-
-  const handleKey = (e: React.KeyboardEvent) => {
-    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+    const handleContext = (e: React.MouseEvent) => {
       e.preventDefault();
-      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
-      showMenu(rect.right, rect.bottom);
-    }
-  };
+      if (!selected.has(file)) {
+        setSelected(new Set([file]));
+      }
+      showMenu(e.clientX, e.clientY);
+    };
 
-  const closeMenu = () => setMenuPos(null);
+    const handleKey = (e: React.KeyboardEvent) => {
+      if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+        e.preventDefault();
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        showMenu(rect.right, rect.bottom);
+      }
+    };
 
-  return (
-    <div
-      className={`card card-compact cursor-pointer hover:ring ring-accent relative text-center tooltip ${
-        isSelected ? 'ring' : ''
-      } ${noExport.has(file) ? 'border border-gray-400' : ''}`}
-      data-tip={`${formatted} \n${name}`}
-      tabIndex={0}
-      onClick={toggleSelect}
-      onDoubleClick={() => window.electronAPI?.openFile(full)}
-      onContextMenu={handleContext}
-      onKeyDown={handleKey}
-      onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
-          closeMenu();
-        }
-      }}
-    >
-      <figure className={noExport.has(file) ? 'opacity-50' : ''}>
-        <TextureThumb
-          texture={texPath}
-          alt={altText}
-          size={zoom}
-          simplified
-          stamp={stamp}
-        />
-      </figure>
-      <div className="card-body p-1">
-        <div className="text-xs leading-tight">
-          <div className="truncate" style={{ width: zoom }}>
-            {formatted}
-          </div>
-          <div className="opacity-50 truncate" style={{ width: zoom }}>
-            {name}
+    const closeMenu = () => setMenuPos(null);
+
+    return (
+      <div
+        ref={ref}
+        className={`card card-compact cursor-pointer hover:ring ring-accent relative text-center tooltip ${
+          isSelected ? 'ring' : ''
+        } ${noExport.has(file) ? 'border border-gray-400' : ''}`}
+        data-tip={`${formatted} \n${name}`}
+        tabIndex={0}
+        onClick={toggleSelect}
+        onDoubleClick={() => window.electronAPI?.openFile(full)}
+        onContextMenu={handleContext}
+        onKeyDown={handleKey}
+        onBlur={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            closeMenu();
+          }
+        }}
+      >
+        <figure className={noExport.has(file) ? 'opacity-50' : ''}>
+          <TextureThumb
+            texture={texPath}
+            alt={altText}
+            size={zoom}
+            simplified
+            stamp={stamp}
+          />
+        </figure>
+        <div className="card-body p-1">
+          <div className="text-xs leading-tight">
+            <div className="truncate" style={{ width: zoom }}>
+              {formatted}
+            </div>
+            <div className="opacity-50 truncate" style={{ width: zoom }}>
+              {name}
+            </div>
           </div>
         </div>
+        <AssetContextMenu
+          filePath={full}
+          selectionCount={selected.size}
+          noExportChecked={(() => {
+            const list = selected.has(file) ? Array.from(selected) : [file];
+            return list.every((x) => noExport.has(x));
+          })()}
+          style={{
+            left: menuPos?.x,
+            top: menuPos?.y,
+            display: menuPos ? 'block' : 'none',
+          }}
+          firstItemRef={firstItem}
+          onReveal={() => window.electronAPI?.openInFolder(full)}
+          onOpen={() => window.electronAPI?.openFile(full)}
+          onRename={() => openRename(file)}
+          onDelete={() =>
+            deleteFiles(
+              selected.size > 1
+                ? Array.from(selected).map((s) => path.join(projectPath, s))
+                : [full]
+            )
+          }
+          onToggleNoExport={(flag) => {
+            const list = selected.has(file) ? Array.from(selected) : [file];
+            toggleNoExport(list, flag);
+          }}
+        />
       </div>
-      <AssetContextMenu
-        filePath={full}
-        selectionCount={selected.size}
-        noExportChecked={(() => {
-          const list = selected.has(file) ? Array.from(selected) : [file];
-          return list.every((x) => noExport.has(x));
-        })()}
-        style={{
-          left: menuPos?.x,
-          top: menuPos?.y,
-          display: menuPos ? 'block' : 'none',
-        }}
-        firstItemRef={firstItem}
-        onReveal={() => window.electronAPI?.openInFolder(full)}
-        onOpen={() => window.electronAPI?.openFile(full)}
-        onRename={() => openRename(file)}
-        onDelete={() =>
-          deleteFiles(
-            selected.size > 1
-              ? Array.from(selected).map((s) => path.join(projectPath, s))
-              : [full]
-          )
-        }
-        onToggleNoExport={(flag) => {
-          const list = selected.has(file) ? Array.from(selected) : [file];
-          toggleNoExport(list, flag);
-        }}
-      />
-    </div>
-  );
-};
+    );
+  }
+);
 
 export default AssetBrowserItem;

--- a/src/renderer/hooks/useThumbnailNavigation.ts
+++ b/src/renderer/hooks/useThumbnailNavigation.ts
@@ -1,0 +1,60 @@
+import { useCallback, useRef } from 'react';
+
+export default function useThumbnailNavigation(
+  files: string[],
+  selected: Set<string>,
+  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>,
+  cols = 6
+) {
+  const refs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const register = useCallback(
+    (file: string) => (el: HTMLDivElement | null) => {
+      if (el) refs.current[file] = el;
+      else delete refs.current[file];
+    },
+    []
+  );
+
+  const focusFile = (file: string) => {
+    const el = refs.current[file];
+    if (el) {
+      el.focus();
+      if (typeof el.scrollIntoView === 'function') {
+        el.scrollIntoView({ block: 'nearest' });
+      }
+    }
+  };
+
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!['ArrowRight', 'ArrowLeft', 'ArrowDown', 'ArrowUp'].includes(e.key))
+        return;
+      if (files.length === 0) return;
+      e.preventDefault();
+      const list = files;
+      let idx = selected.size === 1 ? list.indexOf(Array.from(selected)[0]) : 0;
+      if (idx < 0) idx = 0;
+      switch (e.key) {
+        case 'ArrowRight':
+          idx = Math.min(list.length - 1, idx + 1);
+          break;
+        case 'ArrowLeft':
+          idx = Math.max(0, idx - 1);
+          break;
+        case 'ArrowDown':
+          idx = Math.min(list.length - 1, idx + cols);
+          break;
+        case 'ArrowUp':
+          idx = Math.max(0, idx - cols);
+          break;
+      }
+      const target = list[idx];
+      setSelected(new Set([target]));
+      focusFile(target);
+    },
+    [files, selected, setSelected, cols]
+  );
+
+  return { register, onKeyDown };
+}


### PR DESCRIPTION
## Summary
- add `useThumbnailNavigation` hook for grid navigation
- enable arrow key navigation in `AssetBrowser`
- forward ref in `AssetBrowserItem`
- test thumbnail navigation
- document keyboard control
- mark TODO as done

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685171666f308331951ca890998cacf2