### PR TITLE
Improve settings layout with sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The Project Manager supports a few hotkeys:
 
 - **Enter** – open all selected projects.
 - **Delete** – remove all selected projects.
+  You can review these bindings from **Settings → Shortcuts**.
 
 ## Documentation
 

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -97,7 +97,7 @@ describe('SettingsView', () => {
     const input = await screen.findByLabelText('External texture editor');
     expect(input).toHaveValue('/usr/bin/gimp');
     fireEvent.change(input, { target: { value: '/opt/editor' } });
-    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[1]);
     expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
     expect(await screen.findAllByText('Editor path saved')).toHaveLength(2);
   });
@@ -111,7 +111,7 @@ describe('SettingsView', () => {
     const input = await screen.findByLabelText('Default export folder');
     expect(input).toHaveValue('/home');
     fireEvent.change(input, { target: { value: '/out' } });
-    const btn = screen.getAllByRole('button', { name: 'Save' })[1];
+    const btn = screen.getAllByRole('button', { name: 'Save' })[0];
     fireEvent.click(btn);
     expect(setDefaultExportDir).toHaveBeenCalledWith('/out');
     expect(await screen.findAllByText('Export directory saved')).toHaveLength(
@@ -146,5 +146,15 @@ describe('SettingsView', () => {
     fireEvent.click(toggle);
     expect(setConfetti).toHaveBeenCalledWith(false);
     expect(await screen.findAllByText('Preference saved')).toHaveLength(2);
+  });
+
+  it('shows keyboard shortcuts', () => {
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
+    expect(screen.getByText('Keyboard Shortcuts')).toBeInTheDocument();
+    expect(screen.getAllByTestId('kbd')).toHaveLength(2);
   });
 });

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,3 +35,4 @@ The Project Manager supports a few hotkeys:
 
 - **Enter** – open all selected projects.
 - **Delete** – remove all selected projects.
+  The list can be found inside **Settings → Shortcuts**.

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ExternalLink from '../components/common/ExternalLink';
 import { applyTheme, Theme } from '../utils/theme';
 import { useToast } from '../components/providers/ToastProvider';
+import { Kbd } from '../components/daisy/display';
 
 export default function SettingsView() {
   const [editor, setEditor] = useState('');
@@ -60,88 +61,146 @@ export default function SettingsView() {
     toast({ message: 'Preference saved', type: 'success' });
   };
   return (
-    <section className="p-4" data-testid="settings-view">
-      <div className="flex items-center mb-2 gap-2">
-        <h2 className="font-display text-xl flex-1">Settings</h2>
-        <ExternalLink
-          href="https://minecraft.wiki/w/Options"
-          aria-label="Help"
-          className="btn btn-circle btn-ghost btn-sm"
-        >
-          ?
-        </ExternalLink>
+    <section className="flex gap-4" data-testid="settings-view">
+      <div className="flex-1 p-4">
+        <div className="flex items-center mb-2 gap-2">
+          <h2 className="font-display text-xl flex-1">Settings</h2>
+          <ExternalLink
+            href="https://minecraft.wiki/w/Options"
+            aria-label="Help"
+            className="btn btn-circle btn-ghost btn-sm"
+          >
+            ?
+          </ExternalLink>
+        </div>
+
+        <div id="general" className="mb-8">
+          <h3 className="font-display text-lg mb-2">General</h3>
+          <div className="form-control max-w-md">
+            <label className="label" htmlFor="export-dir">
+              <span className="label-text">Default export folder</span>
+            </label>
+            <input
+              id="export-dir"
+              className="input input-bordered"
+              type="text"
+              value={exportDir}
+              onChange={(e) => setExportDir(e.target.value)}
+            />
+            <button
+              className="btn btn-primary btn-sm mt-2"
+              onClick={saveExportDir}
+            >
+              Save
+            </button>
+          </div>
+          <div className="form-control max-w-md mt-4">
+            <label className="cursor-pointer label" htmlFor="open-last-toggle">
+              <span className="label-text">
+                Open the most recently used project on startup
+              </span>
+              <input
+                id="open-last-toggle"
+                type="checkbox"
+                className="toggle"
+                checked={openLast}
+                onChange={toggleOpenLast}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div id="appearance" className="mb-8">
+          <h3 className="font-display text-lg mb-2">Appearance</h3>
+          <div className="form-control max-w-md">
+            <label className="label" htmlFor="theme-select">
+              <span className="label-text">Theme</span>
+            </label>
+            <select
+              id="theme-select"
+              className="select select-bordered"
+              value={theme}
+              onChange={(e) => updateTheme(e.target.value as Theme)}
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+          <div className="form-control max-w-md mt-4">
+            <label className="cursor-pointer label" htmlFor="confetti-toggle">
+              <span className="label-text">Confetti effects</span>
+              <input
+                id="confetti-toggle"
+                type="checkbox"
+                className="toggle"
+                checked={confetti}
+                onChange={toggleConfetti}
+              />
+            </label>
+          </div>
+        </div>
+
+        <div id="editor" className="mb-8">
+          <h3 className="font-display text-lg mb-2">External Editor</h3>
+          <div className="form-control max-w-md">
+            <label className="label" htmlFor="editor-path">
+              <span className="label-text">External texture editor</span>
+            </label>
+            <input
+              id="editor-path"
+              className="input input-bordered"
+              type="text"
+              value={editor}
+              onChange={(e) => setEditor(e.target.value)}
+            />
+            <button
+              className="btn btn-primary btn-sm mt-2"
+              onClick={saveEditor}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+
+        <div id="shortcuts" className="mb-8">
+          <h3 className="font-display text-lg mb-2">Keyboard Shortcuts</h3>
+          <p className="mb-2">The Project Manager supports:</p>
+          <ul className="list-disc list-inside">
+            <li>
+              <Kbd>Enter</Kbd> – open all selected projects.
+            </li>
+            <li>
+              <Kbd>Delete</Kbd> – remove all selected projects.
+            </li>
+          </ul>
+        </div>
       </div>
-      <div className="form-control max-w-md">
-        <label className="label" htmlFor="editor-path">
-          <span className="label-text">External texture editor</span>
-        </label>
-        <input
-          id="editor-path"
-          className="input input-bordered"
-          type="text"
-          value={editor}
-          onChange={(e) => setEditor(e.target.value)}
-        />
-        <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
-          Save
-        </button>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="label" htmlFor="export-dir">
-          <span className="label-text">Default export folder</span>
-        </label>
-        <input
-          id="export-dir"
-          className="input input-bordered"
-          type="text"
-          value={exportDir}
-          onChange={(e) => setExportDir(e.target.value)}
-        />
-        <button className="btn btn-primary btn-sm mt-2" onClick={saveExportDir}>
-          Save
-        </button>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="label" htmlFor="theme-select">
-          <span className="label-text">Theme</span>
-        </label>
-        <select
-          id="theme-select"
-          className="select select-bordered"
-          value={theme}
-          onChange={(e) => updateTheme(e.target.value as Theme)}
-        >
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-          <option value="system">System</option>
-        </select>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="cursor-pointer label" htmlFor="confetti-toggle">
-          <span className="label-text">Confetti effects</span>
-          <input
-            id="confetti-toggle"
-            type="checkbox"
-            className="toggle"
-            checked={confetti}
-            onChange={toggleConfetti}
-          />
-        </label>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="cursor-pointer label" htmlFor="open-last-toggle">
-          <span className="label-text">
-            Open the most recently used project on startup
-          </span>
-          <input
-            id="open-last-toggle"
-            type="checkbox"
-            className="toggle"
-            checked={openLast}
-            onChange={toggleOpenLast}
-          />
-        </label>
-      </div>
+
+      <aside className="w-64 p-4 bg-base-200 hidden md:block">
+        <ul className="menu">
+          <li>
+            <a href="#general" className="rounded-btn">
+              General
+            </a>
+          </li>
+          <li>
+            <a href="#appearance" className="rounded-btn">
+              Appearance
+            </a>
+          </li>
+          <li>
+            <a href="#editor" className="rounded-btn">
+              External Editor
+            </a>
+          </li>
+          <li>
+            <a href="#shortcuts" className="rounded-btn">
+              Shortcuts
+            </a>
+          </li>
+        </ul>
+      </aside>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- revamp Settings page with sidebar navigation
- show keyboard shortcuts using `<Kbd>`
- reference shortcuts section in documentation

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run dev:headless` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bb1a2f08331936826fad16ed293