### PR TITLE
Add Settings sidebar and shortcuts section

### DIFF
--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -125,6 +125,7 @@ describe('SettingsView', () => {
         <SettingsView />
       </ToastProvider>
     );
+    fireEvent.click(screen.getByRole('button', { name: 'Appearance' }));
     const select = await screen.findByLabelText('Theme');
     fireEvent.change(select, { target: { value: 'dark' } });
     await Promise.resolve();
@@ -141,10 +142,33 @@ describe('SettingsView', () => {
         <SettingsView />
       </ToastProvider>
     );
+    fireEvent.click(screen.getByRole('button', { name: 'Appearance' }));
     const toggle = await screen.findByLabelText('Confetti effects');
     expect(toggle).toBeChecked();
     fireEvent.click(toggle);
     expect(setConfetti).toHaveBeenCalledWith(false);
     expect(await screen.findAllByText('Preference saved')).toHaveLength(2);
+  });
+
+  it('renders navigation sidebar', () => {
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
+    expect(screen.getByTestId('settings-nav')).toBeInTheDocument();
+  });
+
+  it('shows keyboard shortcuts section', async () => {
+    render(
+      <ToastProvider>
+        <SettingsView />
+      </ToastProvider>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Keyboard Shortcuts' }));
+    expect(
+      await screen.findByText(/open all selected projects/i)
+    ).toBeInTheDocument();
+    expect(screen.getAllByTestId('kbd')[0]).toHaveTextContent('Enter');
   });
 });

--- a/src/renderer/components/skeleton/SettingsViewSkeleton.tsx
+++ b/src/renderer/components/skeleton/SettingsViewSkeleton.tsx
@@ -2,16 +2,24 @@ import React from 'react';
 
 export default function SettingsViewSkeleton() {
   return (
-    <section className="p-4" data-testid="settings-skeleton">
-      <div className="flex items-center mb-2 gap-2">
-        <div className="skeleton h-8 w-32 flex-1" />
-        <div className="skeleton h-8 w-8 rounded-full" />
-      </div>
-      <div className="flex flex-col gap-4 max-w-md">
-        <div className="skeleton h-10 w-full" />
-        <div className="skeleton h-10 w-full" />
-        <div className="skeleton h-10 w-full" />
-        <div className="skeleton h-6 w-24" />
+    <section className="p-4 flex gap-4" data-testid="settings-skeleton">
+      <aside className="w-48">
+        <div className="flex flex-col gap-2">
+          <div className="skeleton h-6 w-32" />
+          <div className="skeleton h-6 w-32" />
+          <div className="skeleton h-6 w-32" />
+        </div>
+      </aside>
+      <div className="flex-1">
+        <div className="flex items-center mb-2 gap-2">
+          <div className="skeleton h-8 w-32 flex-1" />
+          <div className="skeleton h-8 w-8 rounded-full" />
+        </div>
+        <div className="flex flex-col gap-4 max-w-md">
+          <div className="skeleton h-10 w-full" />
+          <div className="skeleton h-10 w-full" />
+          <div className="skeleton h-10 w-full" />
+        </div>
       </div>
     </section>
   );

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import ExternalLink from '../components/common/ExternalLink';
 import { applyTheme, Theme } from '../utils/theme';
 import { useToast } from '../components/providers/ToastProvider';
+import { Menu } from '../components/daisy/navigation';
+import { Kbd } from '../components/daisy/display';
 
 export default function SettingsView() {
   const [editor, setEditor] = useState('');
@@ -9,6 +11,9 @@ export default function SettingsView() {
   const [confetti, setConfetti] = useState(true);
   const [openLast, setOpenLast] = useState(true);
   const [exportDir, setExportDir] = useState('');
+  const [tab, setTab] = useState<'general' | 'appearance' | 'shortcuts'>(
+    'general'
+  );
   const toast = useToast();
 
   useEffect(() => {
@@ -60,87 +65,149 @@ export default function SettingsView() {
     toast({ message: 'Preference saved', type: 'success' });
   };
   return (
-    <section className="p-4" data-testid="settings-view">
-      <div className="flex items-center mb-2 gap-2">
-        <h2 className="font-display text-xl flex-1">Settings</h2>
-        <ExternalLink
-          href="https://minecraft.wiki/w/Options"
-          aria-label="Help"
-          className="btn btn-circle btn-ghost btn-sm"
-        >
-          ?
-        </ExternalLink>
-      </div>
-      <div className="form-control max-w-md">
-        <label className="label" htmlFor="editor-path">
-          <span className="label-text">External texture editor</span>
-        </label>
-        <input
-          id="editor-path"
-          className="input input-bordered"
-          type="text"
-          value={editor}
-          onChange={(e) => setEditor(e.target.value)}
-        />
-        <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
-          Save
-        </button>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="label" htmlFor="export-dir">
-          <span className="label-text">Default export folder</span>
-        </label>
-        <input
-          id="export-dir"
-          className="input input-bordered"
-          type="text"
-          value={exportDir}
-          onChange={(e) => setExportDir(e.target.value)}
-        />
-        <button className="btn btn-primary btn-sm mt-2" onClick={saveExportDir}>
-          Save
-        </button>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="label" htmlFor="theme-select">
-          <span className="label-text">Theme</span>
-        </label>
-        <select
-          id="theme-select"
-          className="select select-bordered"
-          value={theme}
-          onChange={(e) => updateTheme(e.target.value as Theme)}
-        >
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-          <option value="system">System</option>
-        </select>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="cursor-pointer label" htmlFor="confetti-toggle">
-          <span className="label-text">Confetti effects</span>
-          <input
-            id="confetti-toggle"
-            type="checkbox"
-            className="toggle"
-            checked={confetti}
-            onChange={toggleConfetti}
-          />
-        </label>
-      </div>
-      <div className="form-control max-w-md mt-4">
-        <label className="cursor-pointer label" htmlFor="open-last-toggle">
-          <span className="label-text">
-            Open the most recently used project on startup
-          </span>
-          <input
-            id="open-last-toggle"
-            type="checkbox"
-            className="toggle"
-            checked={openLast}
-            onChange={toggleOpenLast}
-          />
-        </label>
+    <section className="p-4 flex gap-4" data-testid="settings-view">
+      <aside className="w-48">
+        <Menu className="bg-base-200 rounded-box" data-testid="settings-nav">
+          <li>
+            <button
+              type="button"
+              className={tab === 'general' ? 'active' : ''}
+              onClick={() => setTab('general')}
+            >
+              General
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tab === 'appearance' ? 'active' : ''}
+              onClick={() => setTab('appearance')}
+            >
+              Appearance
+            </button>
+          </li>
+          <li>
+            <button
+              type="button"
+              className={tab === 'shortcuts' ? 'active' : ''}
+              onClick={() => setTab('shortcuts')}
+            >
+              Keyboard Shortcuts
+            </button>
+          </li>
+        </Menu>
+      </aside>
+      <div className="flex-1">
+        <div className="flex items-center mb-2 gap-2">
+          <h2 className="font-display text-xl flex-1">Settings</h2>
+          <ExternalLink
+            href="https://minecraft.wiki/w/Options"
+            aria-label="Help"
+            className="btn btn-circle btn-ghost btn-sm"
+          >
+            ?
+          </ExternalLink>
+        </div>
+        {tab === 'general' && (
+          <div className="form-control max-w-md">
+            <label className="label" htmlFor="editor-path">
+              <span className="label-text">External texture editor</span>
+            </label>
+            <input
+              id="editor-path"
+              className="input input-bordered"
+              type="text"
+              value={editor}
+              onChange={(e) => setEditor(e.target.value)}
+            />
+            <button
+              className="btn btn-primary btn-sm mt-2"
+              onClick={saveEditor}
+            >
+              Save
+            </button>
+          </div>
+        )}
+        {tab === 'general' && (
+          <div className="form-control max-w-md mt-4">
+            <label className="label" htmlFor="export-dir">
+              <span className="label-text">Default export folder</span>
+            </label>
+            <input
+              id="export-dir"
+              className="input input-bordered"
+              type="text"
+              value={exportDir}
+              onChange={(e) => setExportDir(e.target.value)}
+            />
+            <button
+              className="btn btn-primary btn-sm mt-2"
+              onClick={saveExportDir}
+            >
+              Save
+            </button>
+          </div>
+        )}
+        {tab === 'appearance' && (
+          <div className="form-control max-w-md mt-4">
+            <label className="label" htmlFor="theme-select">
+              <span className="label-text">Theme</span>
+            </label>
+            <select
+              id="theme-select"
+              className="select select-bordered"
+              value={theme}
+              onChange={(e) => updateTheme(e.target.value as Theme)}
+            >
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+              <option value="system">System</option>
+            </select>
+          </div>
+        )}
+        {tab === 'appearance' && (
+          <div className="form-control max-w-md mt-4">
+            <label className="cursor-pointer label" htmlFor="confetti-toggle">
+              <span className="label-text">Confetti effects</span>
+              <input
+                id="confetti-toggle"
+                type="checkbox"
+                className="toggle"
+                checked={confetti}
+                onChange={toggleConfetti}
+              />
+            </label>
+          </div>
+        )}
+        {tab === 'general' && (
+          <div className="form-control max-w-md mt-4">
+            <label className="cursor-pointer label" htmlFor="open-last-toggle">
+              <span className="label-text">
+                Open the most recently used project on startup
+              </span>
+              <input
+                id="open-last-toggle"
+                type="checkbox"
+                className="toggle"
+                checked={openLast}
+                onChange={toggleOpenLast}
+              />
+            </label>
+          </div>
+        )}
+        {tab === 'shortcuts' && (
+          <div className="max-w-md">
+            <h3 className="font-semibold mb-2">Project Manager</h3>
+            <ul className="list-disc list-inside">
+              <li>
+                <Kbd>Enter</Kbd> – open all selected projects
+              </li>
+              <li>
+                <Kbd>Delete</Kbd> – remove all selected projects
+              </li>
+            </ul>
+          </div>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add sidebar navigation for Settings view
- split settings into General, Appearance and Keyboard Shortcuts sections
- show project manager shortcuts with the Kbd component
- update skeleton for new layout
- update SettingsView tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68518bb1a2f08331936826fad16ed293