### PR TITLE
Switch pack metadata editor to form

### DIFF
--- a/__tests__/PackMetaModal.randomize.test.tsx
+++ b/__tests__/PackMetaModal.randomize.test.tsx
@@ -6,16 +6,6 @@ import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
-vi.mock('@monaco-editor/react', () => ({
-  __esModule: true,
-  default: ({
-    value,
-    onChange,
-  }: {
-    value: string;
-    onChange: (v: string) => void;
-  }) => <textarea value={value} onChange={(e) => onChange(e.target.value)} />,
-}));
 
 describe('PackMetaModal randomize regression', () => {
   it('sends absolute path to randomizeIcon', () => {

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -4,22 +4,6 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import path from 'path';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
-vi.mock('@monaco-editor/react', () => ({
-  __esModule: true,
-  default: ({
-    value,
-    onChange,
-  }: {
-    value: string;
-    onChange: (v: string) => void;
-  }) => (
-    <textarea
-      data-testid="editor"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    />
-  ),
-}));
 import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 
@@ -43,10 +27,8 @@ describe('PackMetaModal', () => {
         onCancel={onCancel}
       />
     );
-    fireEvent.change(screen.getByTestId('editor'), {
-      target: {
-        value: JSON.stringify({ ...meta, description: 'new' }, null, 2),
-      },
+    fireEvent.change(screen.getByTestId('description-input'), {
+      target: { value: 'new' },
     });
     fireEvent.click(screen.getByText('Save'));
     expect(onSave).toHaveBeenCalledWith(

--- a/__tests__/ProjectInfoPanel.edit.test.tsx
+++ b/__tests__/ProjectInfoPanel.edit.test.tsx
@@ -2,22 +2,6 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-vi.mock('@monaco-editor/react', () => ({
-  __esModule: true,
-  default: ({
-    value,
-    onChange,
-  }: {
-    value: string;
-    onChange: (v: string) => void;
-  }) => (
-    <textarea
-      data-testid="editor"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    />
-  ),
-}));
 import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
 import { SetPath, electronAPI } from './test-utils';
 import ProjectInfoPanel from '../src/renderer/components/project/ProjectInfoPanel';
@@ -41,7 +25,7 @@ describe('ProjectInfoPanel metadata editing', () => {
     vi.clearAllMocks();
   });
 
-  it('opens modal and saves edited metadata', async () => {
+  it('saves edited metadata using inline form', async () => {
     render(
       <ProjectProvider>
         <SetPath path="/p/Pack">
@@ -54,19 +38,13 @@ describe('ProjectInfoPanel metadata editing', () => {
       </ProjectProvider>
     );
 
-    await screen.findByText('desc');
-    fireEvent.click(screen.getByText('desc'));
-    await screen.findByTestId('daisy-modal');
-    fireEvent.change(screen.getByTestId('editor'), {
-      target: {
-        value: JSON.stringify({ ...meta, description: 'new desc' }, null, 2),
-      },
-    });
+    const input = await screen.findByTestId('description-input');
+    fireEvent.change(input, { target: { value: 'new desc' } });
     fireEvent.click(screen.getByText('Save'));
     expect(save).toHaveBeenCalledWith(
       'Pack',
       expect.objectContaining({ description: 'new desc' })
     );
-    await screen.findByText('new desc');
+    expect((input as HTMLTextAreaElement).value).toBe('new desc');
   });
 });

--- a/__tests__/jsonEditor.test.tsx
+++ b/__tests__/jsonEditor.test.tsx
@@ -3,29 +3,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
-vi.mock('@monaco-editor/react', () => ({
-  __esModule: true,
-  default: ({
-    value,
-    onChange,
-  }: {
-    value: string;
-    onChange: (v: string) => void;
-  }) => (
-    <textarea
-      data-testid="editor"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    />
-  ),
-}));
 
 import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 import ToastProvider from '../src/renderer/components/providers/ToastProvider';
 
 describe('JsonEditor integration', () => {
-  it('rejects invalid JSON', () => {
+  it('saves metadata through the form', () => {
     const meta: PackMeta = {
       version: '1.21.1',
       description: '',
@@ -45,9 +29,12 @@ describe('JsonEditor integration', () => {
         />
       </ToastProvider>
     );
-    fireEvent.change(screen.getByTestId('editor'), { target: { value: '{' } });
+    fireEvent.change(screen.getByTestId('description-input'), {
+      target: { value: 'new' },
+    });
     fireEvent.click(screen.getByText('Save'));
-    expect(onSave).not.toHaveBeenCalled();
-    expect(screen.getAllByText('Invalid metadata').length).toBeGreaterThan(0);
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'new' })
+    );
   });
 });

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -132,7 +132,7 @@ these fields and save back to `project.json`. The sidebar also includes a
 **Rename** button that opens a modal to change the project's folder name and
 updates `project.json` accordingly.
 
-Pack metadata, including the pack version, can also be edited from the Editor's **Project Info Panel** by clicking the description. The selected version is stored in `project.json` and appended to export filenames.
+Pack metadata, including the pack version, can also be edited from the Editor's **Project Info Panel** using the form at the bottom of the panel. The selected version is stored in `project.json` and appended to export filenames.
 
 ## Row Selection
 

--- a/src/renderer/components/project/ProjectInfoPanel.tsx
+++ b/src/renderer/components/project/ProjectInfoPanel.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import path from 'path';
 import type { PackMeta } from '../../../main/projects';
 import { Button } from '../daisy/actions';
-import PackMetaModal from '../modals/PackMetaModal';
+import { PackMetaForm } from '../modals/PackMetaModal';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - webpack replaces import with URL string
 import defaultIcon from '../../../../resources/default_pack.png';
@@ -22,7 +22,6 @@ export default function ProjectInfoPanel({
 }: Props) {
   const { path: projectPath } = useProject();
   const [meta, setMeta] = useState<PackMeta | null>(null);
-  const [edit, setEdit] = useState(false);
   const name = path.basename(projectPath);
 
   useEffect(() => {
@@ -50,12 +49,6 @@ export default function ProjectInfoPanel({
           />
           <h2 className="card-title text-lg font-display">{name}</h2>
           <p className="text-xs break-all">{projectPath}</p>
-          <p
-            className="text-sm text-center break-all flex-1 cursor-pointer hover:underline"
-            onClick={() => meta && setEdit(true)}
-          >
-            {meta?.description}
-          </p>
           <div className="card-actions justify-end w-full mt-auto">
             <Button
               className="btn-neutral btn-sm"
@@ -69,18 +62,18 @@ export default function ProjectInfoPanel({
           </div>
         </div>
       </div>
-      {edit && meta && (
-        <PackMetaModal
-          project={name}
-          meta={meta}
-          onCancel={() => setEdit(false)}
-          onSave={(m) => {
-            window.electronAPI?.savePackMeta(name, m).then(() => {
-              setMeta(m);
-              setEdit(false);
-            });
-          }}
-        />
+      {meta && (
+        <div className="mt-4">
+          <PackMetaForm
+            project={name}
+            meta={meta}
+            onSave={(m) => {
+              window.electronAPI?.savePackMeta(name, m).then(() => {
+                setMeta(m);
+              });
+            }}
+          />
+        </div>
       )}
     </>
   );


### PR DESCRIPTION
## Summary
- make `PackMetaModal` expose `PackMetaForm` and switch to form inputs
- embed `PackMetaForm` directly in `ProjectInfoPanel`
- adjust tests for new form behaviour
- update documentation about editing metadata

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685232c10ab08331985e8cb5dbfa0b12