### PR TITLE
Refactor settings view into subcomponents

### DIFF
--- a/__tests__/AppearanceSettings.test.tsx
+++ b/__tests__/AppearanceSettings.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AppearanceSettings from '../src/renderer/views/settings/AppearanceSettings';
+import ToastProvider from '../src/renderer/components/providers/ToastProvider';
+
+const getTheme = vi.fn();
+const setTheme = vi.fn();
+const getConfetti = vi.fn();
+const setConfetti = vi.fn();
+
+beforeEach(() => {
+  (window as unknown as { electronAPI: Record<string, unknown> }).electronAPI =
+    {
+      getTheme,
+      setTheme,
+      getConfetti,
+      setConfetti,
+    };
+  getTheme.mockResolvedValue('system');
+  setTheme.mockResolvedValue(undefined);
+  getConfetti.mockResolvedValue(true);
+  setConfetti.mockResolvedValue(undefined);
+});
+
+describe('AppearanceSettings', () => {
+  it('changes theme and toggles confetti', async () => {
+    render(
+      <ToastProvider>
+        <AppearanceSettings />
+      </ToastProvider>
+    );
+    const select = await screen.findByLabelText('Theme');
+    fireEvent.change(select, { target: { value: 'dark' } });
+    expect(setTheme).toHaveBeenCalledWith('dark');
+
+    const toggle = await screen.findByLabelText('Confetti effects');
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(setConfetti).toHaveBeenCalledWith(false);
+  });
+});

--- a/__tests__/GeneralSettings.test.tsx
+++ b/__tests__/GeneralSettings.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import GeneralSettings from '../src/renderer/views/settings/GeneralSettings';
+import ToastProvider from '../src/renderer/components/providers/ToastProvider';
+
+const getTextureEditor = vi.fn();
+const setTextureEditor = vi.fn();
+const getDefaultExportDir = vi.fn();
+const setDefaultExportDir = vi.fn();
+const getOpenLastProject = vi.fn();
+const setOpenLastProject = vi.fn();
+
+beforeEach(() => {
+  (window as unknown as { electronAPI: Record<string, unknown> }).electronAPI =
+    {
+      getTextureEditor,
+      setTextureEditor,
+      getDefaultExportDir,
+      setDefaultExportDir,
+      getOpenLastProject,
+      setOpenLastProject,
+    };
+  getTextureEditor.mockResolvedValue('/usr/bin/gimp');
+  setTextureEditor.mockResolvedValue(undefined);
+  getDefaultExportDir.mockResolvedValue('/home');
+  setDefaultExportDir.mockResolvedValue(undefined);
+  getOpenLastProject.mockResolvedValue(true);
+  setOpenLastProject.mockResolvedValue(undefined);
+});
+
+describe('GeneralSettings', () => {
+  it('loads and saves values', async () => {
+    render(
+      <ToastProvider>
+        <GeneralSettings />
+      </ToastProvider>
+    );
+    const editorInput = await screen.findByLabelText('External texture editor');
+    expect(editorInput).toHaveValue('/usr/bin/gimp');
+    fireEvent.change(editorInput, { target: { value: '/opt/editor' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+    expect(setTextureEditor).toHaveBeenCalledWith('/opt/editor');
+
+    const exportInput = await screen.findByLabelText('Default export folder');
+    expect(exportInput).toHaveValue('/home');
+    fireEvent.change(exportInput, { target: { value: '/out' } });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Save' })[1]);
+    expect(setDefaultExportDir).toHaveBeenCalledWith('/out');
+  });
+
+  it('toggles open last project', async () => {
+    render(
+      <ToastProvider>
+        <GeneralSettings />
+      </ToastProvider>
+    );
+    const toggle = await screen.findByLabelText(
+      'Open the most recently used project on startup'
+    );
+    expect(toggle).toBeChecked();
+    fireEvent.click(toggle);
+    expect(setOpenLastProject).toHaveBeenCalledWith(false);
+  });
+});

--- a/__tests__/ShortcutSettings.test.tsx
+++ b/__tests__/ShortcutSettings.test.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ShortcutSettings from '../src/renderer/views/settings/ShortcutSettings';
+
+describe('ShortcutSettings', () => {
+  it('renders shortcut list', () => {
+    render(<ShortcutSettings />);
+    expect(screen.getByText(/open all selected projects/i)).toBeInTheDocument();
+    expect(screen.getAllByTestId('kbd')[0]).toHaveTextContent('Enter');
+  });
+});

--- a/src/renderer/views/SettingsView.tsx
+++ b/src/renderer/views/SettingsView.tsx
@@ -1,69 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import ExternalLink from '../components/common/ExternalLink';
-import { applyTheme, Theme } from '../utils/theme';
-import { useToast } from '../components/providers/ToastProvider';
 import { Menu } from '../components/daisy/navigation';
-import { Kbd } from '../components/daisy/display';
+import GeneralSettings from './settings/GeneralSettings';
+import AppearanceSettings from './settings/AppearanceSettings';
+import ShortcutSettings from './settings/ShortcutSettings';
 
 export default function SettingsView() {
-  const [editor, setEditor] = useState('');
-  const [theme, setTheme] = useState<Theme>('system');
-  const [confetti, setConfetti] = useState(true);
-  const [openLast, setOpenLast] = useState(true);
-  const [exportDir, setExportDir] = useState('');
   const [tab, setTab] = useState<'general' | 'appearance' | 'shortcuts'>(
     'general'
   );
-  const toast = useToast();
-
-  useEffect(() => {
-    window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
-    window.electronAPI?.getTheme().then((t) => {
-      setTheme(t);
-    });
-    window.electronAPI?.getConfetti().then((c) => setConfetti(c));
-    window.electronAPI?.getDefaultExportDir().then((d) => setExportDir(d));
-    window.electronAPI?.getOpenLastProject().then((f) => setOpenLast(f));
-  }, []);
-
-  const saveEditor = () => {
-    window.electronAPI
-      ?.setTextureEditor(editor)
-      .then(() => toast({ message: 'Editor path saved', type: 'success' }))
-      .catch(() =>
-        toast({ message: 'Failed to save editor path', type: 'error' })
-      );
-  };
-
-  const updateTheme = async (t: Theme) => {
-    setTheme(t);
-    await window.electronAPI?.setTheme(t);
-    applyTheme(t);
-    toast({ message: 'Theme updated', type: 'success' });
-  };
-
-  const saveExportDir = () => {
-    window.electronAPI
-      ?.setDefaultExportDir(exportDir)
-      .then(() => toast({ message: 'Export directory saved', type: 'success' }))
-      .catch(() =>
-        toast({ message: 'Failed to save export directory', type: 'error' })
-      );
-  };
-
-  const toggleConfetti = async () => {
-    const next = !confetti;
-    setConfetti(next);
-    await window.electronAPI?.setConfetti(next);
-    toast({ message: 'Preference saved', type: 'success' });
-  };
-
-  const toggleOpenLast = async () => {
-    const next = !openLast;
-    setOpenLast(next);
-    await window.electronAPI?.setOpenLastProject(next);
-    toast({ message: 'Preference saved', type: 'success' });
-  };
   return (
     <section className="p-4 flex gap-4" data-testid="settings-view">
       <aside className="w-48">
@@ -108,106 +53,9 @@ export default function SettingsView() {
             ?
           </ExternalLink>
         </div>
-        {tab === 'general' && (
-          <div className="form-control max-w-md">
-            <label className="label" htmlFor="editor-path">
-              <span className="label-text">External texture editor</span>
-            </label>
-            <input
-              id="editor-path"
-              className="input input-bordered"
-              type="text"
-              value={editor}
-              onChange={(e) => setEditor(e.target.value)}
-            />
-            <button
-              className="btn btn-primary btn-sm mt-2"
-              onClick={saveEditor}
-            >
-              Save
-            </button>
-          </div>
-        )}
-        {tab === 'general' && (
-          <div className="form-control max-w-md mt-4">
-            <label className="label" htmlFor="export-dir">
-              <span className="label-text">Default export folder</span>
-            </label>
-            <input
-              id="export-dir"
-              className="input input-bordered"
-              type="text"
-              value={exportDir}
-              onChange={(e) => setExportDir(e.target.value)}
-            />
-            <button
-              className="btn btn-primary btn-sm mt-2"
-              onClick={saveExportDir}
-            >
-              Save
-            </button>
-          </div>
-        )}
-        {tab === 'appearance' && (
-          <div className="form-control max-w-md mt-4">
-            <label className="label" htmlFor="theme-select">
-              <span className="label-text">Theme</span>
-            </label>
-            <select
-              id="theme-select"
-              className="select select-bordered"
-              value={theme}
-              onChange={(e) => updateTheme(e.target.value as Theme)}
-            >
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-              <option value="system">System</option>
-            </select>
-          </div>
-        )}
-        {tab === 'appearance' && (
-          <div className="form-control max-w-md mt-4">
-            <label className="cursor-pointer label" htmlFor="confetti-toggle">
-              <span className="label-text">Confetti effects</span>
-              <input
-                id="confetti-toggle"
-                type="checkbox"
-                className="toggle"
-                checked={confetti}
-                onChange={toggleConfetti}
-              />
-            </label>
-          </div>
-        )}
-        {tab === 'general' && (
-          <div className="form-control max-w-md mt-4">
-            <label className="cursor-pointer label" htmlFor="open-last-toggle">
-              <span className="label-text">
-                Open the most recently used project on startup
-              </span>
-              <input
-                id="open-last-toggle"
-                type="checkbox"
-                className="toggle"
-                checked={openLast}
-                onChange={toggleOpenLast}
-              />
-            </label>
-          </div>
-        )}
-        {tab === 'shortcuts' && (
-          <div className="max-w-md">
-            <h3 className="font-semibold mb-2">Project Manager</h3>
-            <ul className="list-disc list-inside">
-              <li>
-                <Kbd>Enter</Kbd> – open all selected projects
-              </li>
-              <li>
-                <Kbd>Delete</Kbd> – remove all selected projects
-              </li>
-            </ul>
-          </div>
-        )}
+        {tab === 'general' && <GeneralSettings />}
+        {tab === 'appearance' && <AppearanceSettings />}
+        {tab === 'shortcuts' && <ShortcutSettings />}
       </div>
     </section>
   );

--- a/src/renderer/views/settings/AppearanceSettings.tsx
+++ b/src/renderer/views/settings/AppearanceSettings.tsx
@@ -1,0 +1,60 @@
+import React, { useEffect, useState } from 'react';
+import { applyTheme, Theme } from '../../utils/theme';
+import { useToast } from '../../components/providers/ToastProvider';
+
+export default function AppearanceSettings() {
+  const [theme, setTheme] = useState<Theme>('system');
+  const [confetti, setConfetti] = useState(true);
+  const toast = useToast();
+
+  useEffect(() => {
+    window.electronAPI?.getTheme().then(setTheme);
+    window.electronAPI?.getConfetti().then(setConfetti);
+  }, []);
+
+  const updateTheme = async (t: Theme) => {
+    setTheme(t);
+    await window.electronAPI?.setTheme(t);
+    applyTheme(t);
+    toast({ message: 'Theme updated', type: 'success' });
+  };
+
+  const toggleConfetti = async () => {
+    const next = !confetti;
+    setConfetti(next);
+    await window.electronAPI?.setConfetti(next);
+    toast({ message: 'Preference saved', type: 'success' });
+  };
+
+  return (
+    <>
+      <div className="form-control max-w-md mt-4">
+        <label className="label" htmlFor="theme-select">
+          <span className="label-text">Theme</span>
+        </label>
+        <select
+          id="theme-select"
+          className="select select-bordered"
+          value={theme}
+          onChange={(e) => updateTheme(e.target.value as Theme)}
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="cursor-pointer label" htmlFor="confetti-toggle">
+          <span className="label-text">Confetti effects</span>
+          <input
+            id="confetti-toggle"
+            type="checkbox"
+            className="toggle"
+            checked={confetti}
+            onChange={toggleConfetti}
+          />
+        </label>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/views/settings/GeneralSettings.tsx
+++ b/src/renderer/views/settings/GeneralSettings.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { useToast } from '../../components/providers/ToastProvider';
+
+export default function GeneralSettings() {
+  const [editor, setEditor] = useState('');
+  const [exportDir, setExportDir] = useState('');
+  const [openLast, setOpenLast] = useState(true);
+  const toast = useToast();
+
+  useEffect(() => {
+    window.electronAPI?.getTextureEditor().then((p) => setEditor(p));
+    window.electronAPI?.getDefaultExportDir().then((d) => setExportDir(d));
+    window.electronAPI?.getOpenLastProject().then((f) => setOpenLast(f));
+  }, []);
+
+  const saveEditor = () => {
+    window.electronAPI
+      ?.setTextureEditor(editor)
+      .then(() => toast({ message: 'Editor path saved', type: 'success' }))
+      .catch(() =>
+        toast({ message: 'Failed to save editor path', type: 'error' })
+      );
+  };
+
+  const saveExportDir = () => {
+    window.electronAPI
+      ?.setDefaultExportDir(exportDir)
+      .then(() => toast({ message: 'Export directory saved', type: 'success' }))
+      .catch(() =>
+        toast({ message: 'Failed to save export directory', type: 'error' })
+      );
+  };
+
+  const toggleOpenLast = async () => {
+    const next = !openLast;
+    setOpenLast(next);
+    await window.electronAPI?.setOpenLastProject(next);
+    toast({ message: 'Preference saved', type: 'success' });
+  };
+
+  return (
+    <>
+      <div className="form-control max-w-md">
+        <label className="label" htmlFor="editor-path">
+          <span className="label-text">External texture editor</span>
+        </label>
+        <input
+          id="editor-path"
+          className="input input-bordered"
+          type="text"
+          value={editor}
+          onChange={(e) => setEditor(e.target.value)}
+        />
+        <button className="btn btn-primary btn-sm mt-2" onClick={saveEditor}>
+          Save
+        </button>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="label" htmlFor="export-dir">
+          <span className="label-text">Default export folder</span>
+        </label>
+        <input
+          id="export-dir"
+          className="input input-bordered"
+          type="text"
+          value={exportDir}
+          onChange={(e) => setExportDir(e.target.value)}
+        />
+        <button className="btn btn-primary btn-sm mt-2" onClick={saveExportDir}>
+          Save
+        </button>
+      </div>
+      <div className="form-control max-w-md mt-4">
+        <label className="cursor-pointer label" htmlFor="open-last-toggle">
+          <span className="label-text">
+            Open the most recently used project on startup
+          </span>
+          <input
+            id="open-last-toggle"
+            type="checkbox"
+            className="toggle"
+            checked={openLast}
+            onChange={toggleOpenLast}
+          />
+        </label>
+      </div>
+    </>
+  );
+}

--- a/src/renderer/views/settings/ShortcutSettings.tsx
+++ b/src/renderer/views/settings/ShortcutSettings.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Kbd } from '../../components/daisy/display';
+
+export default function ShortcutSettings() {
+  return (
+    <div className="max-w-md">
+      <h3 className="font-semibold mb-2">Project Manager</h3>
+      <ul className="list-disc list-inside">
+        <li>
+          <Kbd>Enter</Kbd> – open all selected projects
+        </li>
+        <li>
+          <Kbd>Delete</Kbd> – remove all selected projects
+        </li>
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extract `GeneralSettings`, `AppearanceSettings` and `ShortcutSettings` components
- update `SettingsView` to use new components
- add unit tests for each new component

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523593de588331839a4705db7d3565