### PR TITLE
Add asset caching docs and JSDoc

### DIFF
--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -123,6 +123,14 @@ Two custom protocols simplify image previews:
 
 Both protocols are registered in `src/main/index.ts` when Electron starts.
 
+## Asset Cache
+
+Downloads from Mojang are stored under `<userData>/assets-cache`. Each
+version gets its own folder inside this directory. The client JAR is saved as
+`client.jar` and extracted to `client/` where `assets/minecraft/textures` lives.
+`ensureAssets` fetches and extracts the JAR the first time a version is
+requested; later calls simply reuse the existing folder.
+
 ## Project Metadata Sidebar
 
 The projects dashboard includes a sidebar next to the project table. Selecting a

--- a/src/main/assets.ts
+++ b/src/main/assets.ts
@@ -37,7 +37,9 @@ let activeProjectDir = '';
  * manifest URL is requested and the network is unavailable, a bundled copy is
  * used as a fallback.
  *
- * @throws if the request fails.
+ * @param url URL to request.
+ * @returns Parsed JSON typed as `T`.
+ * @throws If the request fails.
  */
 async function fetchJson<T>(url: string): Promise<T> {
   try {
@@ -60,6 +62,10 @@ async function fetchJson<T>(url: string): Promise<T> {
  *
  * The target directory is created if it does not exist. The body is saved as a
  * binary buffer so any file type can be retrieved.
+ *
+ * @param url URL to download.
+ * @param dest Absolute output path on disk.
+ * @returns Promise that resolves when the file is written.
  */
 async function downloadFile(url: string, dest: string): Promise<void> {
   const res = await fetch(url);
@@ -74,6 +80,10 @@ async function downloadFile(url: string, dest: string): Promise<void> {
  *
  * The operation streams the archive to disk to avoid buffering large files in
  * memory.
+ *
+ * @param src Path to the source zip archive.
+ * @param dest Directory that receives the extracted files.
+ * @returns Promise that resolves once extraction completes.
  */
 async function extractZip(src: string, dest: string): Promise<void> {
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- document how assets-cache is structured
- clarify asset fetching helpers with full JSDoc

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685235aaad688331900d0bcd0351423f