### PR TITLE
Add toPosixPath helper

### DIFF
--- a/__tests__/toPosixPath.test.ts
+++ b/__tests__/toPosixPath.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { toPosixPath } from '../src/shared/toPosixPath';
+
+describe('toPosixPath', () => {
+  it('converts Windows style paths', () => {
+    expect(toPosixPath('foo\\bar\\baz')).toBe('foo/bar/baz');
+  });
+
+  it('leaves POSIX paths unchanged', () => {
+    expect(toPosixPath('foo/bar/baz')).toBe('foo/bar/baz');
+  });
+});

--- a/src/main/assets.ts
+++ b/src/main/assets.ts
@@ -12,6 +12,7 @@ import {
   displayForFormat,
   PackFormatInfo,
 } from '../shared/packFormat';
+import { toPosixPath } from '../shared/toPosixPath';
 
 /** URL pointing to Mojang's version manifest which lists all official releases. */
 const VERSION_MANIFEST =
@@ -150,7 +151,7 @@ export async function listTextures(projectPath: string): Promise<string[]> {
         await walk(p);
       } else if (entry.name.endsWith('.png')) {
         const rel = path.relative(texRoot, p);
-        out.push(rel.split(path.sep).join('/'));
+        out.push(toPosixPath(rel));
       }
     }
   };

--- a/src/renderer/components/assets/TextureLab.tsx
+++ b/src/renderer/components/assets/TextureLab.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import path from 'path';
+import { toPosixPath } from '../../../shared/toPosixPath';
 import { Loading } from '../daisy/feedback';
 import type { TextureEditOptions } from '../../../shared/texture';
 import { Modal, Button } from '../daisy/actions';
@@ -29,14 +30,14 @@ export default function TextureLab({
   }, [stamp]);
 
   useEffect(() => {
-    const relPath = path.relative(projectPath, file).split(path.sep).join('/');
+    const relPath = toPosixPath(path.relative(projectPath, file));
     const listener = (_e: unknown, args: { path: string; stamp: number }) => {
       if (args.path === relPath) setVersion(args.stamp);
     };
     window.electronAPI?.onFileChanged(listener);
   }, [file, projectPath]);
 
-  const rel = path.relative(projectPath, file).split(path.sep).join('/');
+  const rel = toPosixPath(path.relative(projectPath, file));
   const filter = `hue-rotate(${hue}deg) saturate(${sat}) brightness(${bright})${
     gray ? ' grayscale(1)' : ''
   }`;

--- a/src/renderer/components/assets/TextureThumb.tsx
+++ b/src/renderer/components/assets/TextureThumb.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import path from 'path';
+import { toPosixPath } from '../../../shared/toPosixPath';
 import TextIcon from '../common/TextIcon';
 
 interface Props {
@@ -28,7 +29,7 @@ export default function TextureThumb({
   const ext = texture ? path.extname(texture).toLowerCase() : '';
   const url =
     texture && ext === '.png'
-      ? `${protocol}://${texture.split(path.sep).join('/')}${stamp ? `?t=${stamp}` : ''}`
+      ? `${protocol}://${toPosixPath(texture)}${stamp ? `?t=${stamp}` : ''}`
       : null;
   const isText = ext === '.txt' || ext === '.json';
 

--- a/src/shared/toPosixPath.ts
+++ b/src/shared/toPosixPath.ts
@@ -1,0 +1,3 @@
+export function toPosixPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}


### PR DESCRIPTION
## Summary
- add `toPosixPath` helper
- use `toPosixPath` when reading textures
- update texture components to use helper
- test `toPosixPath`

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685235b65b28833189171d681ce2ea75