### PR TITLE
Add AssetBrowserProvider context

### DIFF
--- a/src/renderer/components/assets/AssetBrowserItem.tsx
+++ b/src/renderer/components/assets/AssetBrowserItem.tsx
@@ -3,16 +3,11 @@ import path from 'path';
 import { formatTextureName } from '../../utils/textureNames';
 import AssetContextMenu from '../file/AssetContextMenu';
 import TextureThumb from './TextureThumb';
+import { useAssetBrowser } from '../providers/AssetBrowserProvider';
 
 interface Props {
   projectPath: string;
   file: string;
-  selected: Set<string>;
-  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
-  noExport: Set<string>;
-  toggleNoExport: (files: string[], flag: boolean) => void;
-  deleteFiles: (files: string[]) => void;
-  openRename: (file: string) => void;
   zoom: number;
   stamp?: number;
 }
@@ -20,15 +15,17 @@ interface Props {
 const AssetBrowserItem: React.FC<Props> = ({
   projectPath,
   file,
-  selected,
-  setSelected,
-  noExport,
-  toggleNoExport,
-  deleteFiles,
-  openRename,
   zoom,
   stamp,
 }) => {
+  const {
+    selected,
+    setSelected,
+    noExport,
+    toggleNoExport,
+    deleteFiles,
+    openRename,
+  } = useAssetBrowser();
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const firstItem = useRef<HTMLButtonElement>(null);
 

--- a/src/renderer/components/assets/FileTree.tsx
+++ b/src/renderer/components/assets/FileTree.tsx
@@ -5,28 +5,22 @@ import { buildTree, TreeItem } from '../../utils/tree';
 import TextureThumb from './TextureThumb';
 import AssetContextMenu from '../file/AssetContextMenu';
 import { useProject } from '../providers/ProjectProvider';
+import { useAssetBrowser } from '../providers/AssetBrowserProvider';
 
 interface Props {
   files: string[];
-  selected: Set<string>;
-  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
-  noExport: Set<string>;
-  toggleNoExport: (files: string[], flag: boolean) => void;
-  deleteFiles: (files: string[]) => void;
-  openRename: (file: string) => void;
   versions: Record<string, number>;
 }
 
-export default function FileTree({
-  files,
-  selected,
-  setSelected,
-  noExport,
-  toggleNoExport,
-  deleteFiles,
-  openRename,
-  versions,
-}: Props) {
+export default function FileTree({ files, versions }: Props) {
+  const {
+    selected,
+    setSelected,
+    noExport,
+    toggleNoExport,
+    deleteFiles,
+    openRename,
+  } = useAssetBrowser();
   const { path: projectPath } = useProject();
   const data = React.useMemo<TreeItem[]>(() => buildTree(files), [files]);
   const [menuInfo, setMenuInfo] = useState<{

--- a/src/renderer/components/providers/AssetBrowserProvider.tsx
+++ b/src/renderer/components/providers/AssetBrowserProvider.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+interface AssetBrowserContextValue {
+  selected: Set<string>;
+  setSelected: React.Dispatch<React.SetStateAction<Set<string>>>;
+  noExport: Set<string>;
+  toggleNoExport: (files: string[], flag: boolean) => void;
+  deleteFiles: (files: string[]) => void;
+  openRename: (file: string) => void;
+}
+
+const noop = () => {
+  /* noop */
+};
+
+const AssetBrowserContext = createContext<AssetBrowserContextValue>({
+  selected: new Set<string>(),
+  setSelected: () => {
+    /* noop */
+  },
+  noExport: new Set<string>(),
+  toggleNoExport: noop,
+  deleteFiles: noop,
+  openRename: noop,
+});
+
+export function useAssetBrowser() {
+  return useContext(AssetBrowserContext);
+}
+
+interface ProviderProps {
+  children: React.ReactNode;
+  noExport: Set<string>;
+  toggleNoExport: (files: string[], flag: boolean) => void;
+  openRename: (file: string) => void;
+  onSelectionChange?: (sel: string[]) => void;
+}
+
+export function AssetBrowserProvider({
+  children,
+  noExport,
+  toggleNoExport,
+  openRename,
+  onSelectionChange,
+}: ProviderProps) {
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    onSelectionChange?.(Array.from(selected));
+  }, [selected, onSelectionChange]);
+
+  const deleteFiles = (files: string[]) => {
+    files.forEach((f) => window.electronAPI?.deleteFile(f));
+    setSelected(new Set());
+  };
+
+  return (
+    <AssetBrowserContext.Provider
+      value={{
+        selected,
+        setSelected,
+        noExport,
+        toggleNoExport,
+        deleteFiles,
+        openRename,
+      }}
+    >
+      {children}
+    </AssetBrowserContext.Provider>
+  );
+}
+
+export { AssetBrowserContext };


### PR DESCRIPTION
## Summary
- add `AssetBrowserProvider` for shared asset browser state
- wrap asset browser children with provider and refactor to use context
- update `AssetBrowserItem` and `FileTree` to consume provider
- adjust related unit tests

## Testing
- `npm run lint`
- `npm run format`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685241a580408331b385e780292b8801