### PR TITLE
Add sort indicators to ProjectTable

### DIFF
--- a/__tests__/ProjectTable.selection.test.tsx
+++ b/__tests__/ProjectTable.selection.test.tsx
@@ -24,6 +24,8 @@ describe('ProjectTable selection', () => {
     render(
       <ProjectTable
         projects={projects}
+        sortKey="name"
+        asc
         onSort={noop}
         selected={selected}
         onSelect={select}
@@ -53,6 +55,8 @@ describe('ProjectTable selection', () => {
     const { rerender } = render(
       <ProjectTable
         projects={projects}
+        sortKey="name"
+        asc
         onSort={noop}
         selected={selected}
         onSelect={select}
@@ -71,6 +75,8 @@ describe('ProjectTable selection', () => {
     rerender(
       <ProjectTable
         projects={[...projects].reverse()}
+        sortKey="name"
+        asc
         onSort={noop}
         selected={selected}
         onSelect={select}

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -112,6 +112,8 @@ describe('ProjectTable', () => {
     render(
       <ProjectTable
         projects={projects}
+        sortKey="name"
+        asc
         onSort={() => {}}
         selected={new Set()}
         onSelect={() => {}}
@@ -124,5 +126,31 @@ describe('ProjectTable', () => {
     );
     const imgs = screen.getAllByAltText('Pack icon');
     expect(imgs.length).toBe(2);
+  });
+
+  it('shows a sort icon on the active column', () => {
+    render(
+      <ProjectTable
+        projects={projects}
+        sortKey="assets"
+        asc={false}
+        onSort={() => {}}
+        selected={new Set()}
+        onSelect={() => {}}
+        onSelectAll={() => {}}
+        onOpen={() => {}}
+        onDuplicate={() => {}}
+        onDelete={() => {}}
+        onRowClick={() => {}}
+      />
+    );
+    const assetsHeader = screen.getByText('Assets');
+    const svg = assetsHeader.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.querySelector('path')?.getAttribute('d')).toBe(
+      'm19.5 8.25-7.5 7.5-7.5-7.5'
+    );
+    const nameHeader = screen.getByText('Name');
+    expect(nameHeader.querySelector('svg')).toBeNull();
   });
 });

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -5,6 +5,8 @@ import {
   ArrowRightCircleIcon,
   DocumentDuplicateIcon,
   TrashIcon,
+  ChevronUpIcon,
+  ChevronDownIcon,
 } from '@heroicons/react/24/outline';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore - webpack replaces import with URL string
@@ -19,6 +21,8 @@ export interface ProjectInfo {
 
 export default function ProjectTable({
   projects,
+  sortKey,
+  asc,
   onSort,
   selected,
   onSelect,
@@ -37,6 +41,8 @@ export default function ProjectTable({
   onDuplicate: (name: string) => void;
   onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
+  sortKey: keyof ProjectInfo;
+  asc: boolean;
 }) {
   const lastIndex = React.useRef<number | null>(null);
   const allSelected =
@@ -58,15 +64,39 @@ export default function ProjectTable({
             </th>
             <th onClick={() => onSort('name')} className="cursor-pointer">
               Name
+              {sortKey === 'name' &&
+                (asc ? (
+                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+                ) : (
+                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+                ))}
             </th>
             <th onClick={() => onSort('version')} className="cursor-pointer">
               MC Version
+              {sortKey === 'version' &&
+                (asc ? (
+                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+                ) : (
+                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+                ))}
             </th>
             <th onClick={() => onSort('assets')} className="cursor-pointer">
               Assets
+              {sortKey === 'assets' &&
+                (asc ? (
+                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+                ) : (
+                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+                ))}
             </th>
             <th onClick={() => onSort('lastOpened')} className="cursor-pointer">
               Last opened
+              {sortKey === 'lastOpened' &&
+                (asc ? (
+                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+                ) : (
+                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+                ))}
             </th>
             <th></th>
           </tr>

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -139,6 +139,8 @@ const ProjectManagerView: React.FC = () => {
         />
         <ProjectTable
           projects={sortedProjects}
+          sortKey={sortKey}
+          asc={asc}
           onSort={handleSort}
           selected={selected}
           onSelect={toggleOne}


### PR DESCRIPTION
## Summary
- show arrow icons next to currently sorted column in ProjectTable
- pass sorting props from ProjectManagerView
- test ProjectTable sort icon rendering

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run dev` *(fails: xvfb-run not found)*

------
https://chatgpt.com/codex/tasks/task_e_685244e8982c83318a7a7d6cc390a7ab