### PR TITLE
Add headless development support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ The Project Manager supports a few hotkeys:
 
 - [User Guide](docs/user-guide.md)
 - [Developer Handbook](docs/developer-handbook.md)
+
+## Development
+
+Run the development build with:
+
+```bash
+npm run dev
+```
+
+On headless systems (for example in CI) use the headless variant which relies on `xvfb-maybe` to provide a virtual display:
+
+```bash
+npm run dev:headless
+```

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -22,6 +22,8 @@ Electron requires a graphical environment. Running on a headless server will fai
 npm run dev:headless
 ```
 
+This command uses [`xvfb-maybe`](https://github.com/anaisbetts/xvfb-maybe) to launch Electron under a virtual display when one is not available. See the [Electron headless CI guide](https://www.electronjs.org/docs/latest/tutorial/testing-on-headless-ci) for more details.
+
 3. Run the linter and tests:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,8 @@
         "ts-node": "^10.9.2",
         "typescript": "~5.8.3",
         "unzipper": "^0.12.3",
-        "vitest": "^3.2.3"
+        "vitest": "^3.2.3",
+        "xvfb-maybe": "^0.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -17821,6 +17822,50 @@
       "license": "MIT",
       "peerDependencies": {
         "xterm": "^4.0.0"
+      }
+    },
+    "node_modules/xvfb-maybe": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xvfb-maybe/-/xvfb-maybe-0.2.1.tgz",
+      "integrity": "sha512-9IyRz3l6Qyhl6LvnGRF5jMPB4oBEepQnuzvVAFTynP6ACLLSevqigICJ9d/+ofl29m2daeaVBChnPYUnaeJ7yA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^2.2.0",
+        "which": "^1.2.4"
+      },
+      "bin": {
+        "xvfb-maybe": "src/xvfb-maybe.js"
+      }
+    },
+    "node_modules/xvfb-maybe/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/xvfb-maybe/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/xvfb-maybe/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint --no-warn-ignored --ext .ts,.tsx src __tests__ *.ts",
     "test": "vitest run --coverage",
     "dev": "electron-forge start",
-    "dev:headless": "xvfb-run -a electron-forge start -- --no-sandbox",
+    "dev:headless": "xvfb-maybe -- electron-forge start -- --no-sandbox",
     "format": "prettier --write .",
     "typecheck": "tsc --noEmit"
   },
@@ -90,6 +90,7 @@
     "ts-node": "^10.9.2",
     "typescript": "~5.8.3",
     "unzipper": "^0.12.3",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "xvfb-maybe": "^0.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- install `xvfb-maybe`
- run Electron headlessly via `npm run dev:headless`
- document new headless workflow in README and developer handbook

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run dev:headless` *(fails to fully launch due to headless environment, but starts build)*

------
https://chatgpt.com/codex/tasks/task_e_6852475302a48331ab76e8cfbc819520