### PR TITLE
Improve protocol and watcher docs

### DIFF
--- a/src/main/assets/protocols.ts
+++ b/src/main/assets/protocols.ts
@@ -1,5 +1,8 @@
 /**
  * Custom file protocols used by the renderer to load assets.
+ *
+ * `vanilla://` serves cached vanilla textures, while `asset://` resolves files
+ * from the currently active project directory.
  */
 import path from 'path';
 import type { Protocol } from 'electron';
@@ -10,12 +13,15 @@ import { ensureAssets } from './cache';
 let cacheTexturesDir = '';
 let activeProjectDir = '';
 
-/** Update cached texture directory used by vanilla protocol. */
+/** Update cached texture directory used by the `vanilla` protocol. */
 export function setCacheTexturesDir(dir: string): void {
   cacheTexturesDir = dir;
 }
 
-/** Register the `vanilla` protocol so it serves files directly from disk. */
+/**
+ * Register a file protocol that maps `vanilla://` URLs to cached vanilla
+ * texture files on disk.
+ */
 export function registerVanillaProtocol(protocol: Protocol): void {
   protocol.registerFileProtocol('vanilla', (request, callback) => {
     const rel = decodeURI(request.url.replace('vanilla://', ''));
@@ -24,7 +30,10 @@ export function registerVanillaProtocol(protocol: Protocol): void {
   });
 }
 
-/** Register the `asset` protocol to serve files from the active project. */
+/**
+ * Register a file protocol that resolves `asset://` URLs relative to the
+ * currently active project directory.
+ */
 export function registerAssetProtocol(protocol: Protocol): void {
   protocol.registerFileProtocol('asset', (request, callback) => {
     const rel = decodeURI(request.url.replace('asset://', ''));
@@ -35,7 +44,10 @@ export function registerAssetProtocol(protocol: Protocol): void {
   });
 }
 
-/** Update directories used by the custom protocols for the active project. */
+/**
+ * Point the custom protocols at a new project and ensure vanilla assets are
+ * cached for that project's Minecraft version.
+ */
 export async function setActiveProject(projectPath: string): Promise<void> {
   const meta = await readProjectMeta(projectPath);
   const cacheRoot = await ensureAssets(meta.minecraft_version);

--- a/src/main/ipc/fileWatcher.ts
+++ b/src/main/ipc/fileWatcher.ts
@@ -24,6 +24,13 @@ async function listFiles(dir: string): Promise<string[]> {
   return files;
 }
 
+/**
+ * Register IPC handlers that watch project directories for changes.
+ *
+ * - `watch-project` starts watching `projectPath` and returns the initial list
+ *   of files relative to that directory.
+ * - `unwatch-project` stops watching the previously watched path.
+ */
 export function registerFileWatcherHandlers(
   ipc: IpcMain,
   window: BrowserWindow
@@ -64,6 +71,12 @@ export function registerFileWatcherHandlers(
   });
 }
 
+/**
+ * Emit a `file-renamed` event for all open watchers.
+ *
+ * Chokidar does not report rename operations, so actions that rename files
+ * manually call this helper to notify the renderer.
+ */
 export function emitRenamed(oldPath: string, newPath: string) {
   if (!win) return;
   for (const projectPath of watchers.keys()) {

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -10,6 +10,8 @@ export function useProjectFiles() {
   const toast = useToast();
 
   useEffect(() => {
+    // Revisions live under `.history` and should never appear in the asset
+    // browser or trigger file events, so we filter those paths out.
     const isHistory = (p: string) =>
       p === '.history' || p.startsWith('.history/') || p.includes('/.history/');
     let alive = true;


### PR DESCRIPTION
## Summary
- add jsdoc on IPC file watcher functions
- clarify why `.history` files are filtered
- document custom protocol handlers

## Testing
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68524929e910833199ef7eb94071d1aa