### PR TITLE
Enable keyboard shortcuts for modals

### DIFF
--- a/__tests__/ConfirmModal.test.tsx
+++ b/__tests__/ConfirmModal.test.tsx
@@ -20,4 +20,23 @@ describe('ConfirmModal', () => {
     fireEvent.click(screen.getByText('OK'));
     expect(confirm).toHaveBeenCalled();
   });
+
+  it('focuses confirm and handles keys', () => {
+    const cancel = vi.fn();
+    const confirm = vi.fn();
+    render(
+      <ConfirmModal
+        title="Delete"
+        message="Are you sure?"
+        onCancel={cancel}
+        onConfirm={confirm}
+      />
+    );
+    const confirmBtn = screen.getByText('OK');
+    expect(confirmBtn).toHaveFocus();
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(cancel).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(confirm).toHaveBeenCalled();
+  });
 });

--- a/__tests__/ExportWizardModal.test.tsx
+++ b/__tests__/ExportWizardModal.test.tsx
@@ -39,4 +39,13 @@ describe('ExportWizardModal', () => {
     fireEvent.click(screen.getByText('Open Folder'));
     expect(onOpen).toHaveBeenCalled();
   });
+
+  it('handles Escape and Enter', () => {
+    const onClose = vi.fn();
+    render(<ExportWizardModal summary={summary} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
 });

--- a/__tests__/ImportWizardModal.test.tsx
+++ b/__tests__/ImportWizardModal.test.tsx
@@ -19,4 +19,14 @@ describe('ImportWizardModal', () => {
     fireEvent.click(screen.getByText('Close'));
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('handles Escape and Enter', () => {
+    const onClose = vi.fn();
+    const summary = { name: 'Pack', fileCount: 3, durationMs: 1000 };
+    render(<ImportWizardModal summary={summary} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
 });

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -64,4 +64,29 @@ describe('PackMetaModal', () => {
       path.join('/tmp', 'projects', 'Pack')
     );
   });
+
+  it('handles Escape and Enter', () => {
+    const meta: PackMeta = {
+      version: '1.21.1',
+      description: '',
+      author: '',
+      urls: [],
+      created: 0,
+      license: '',
+    };
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+    render(
+      <PackMetaModal
+        project="Pack"
+        meta={meta}
+        onSave={onSave}
+        onCancel={onCancel}
+      />
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onSave).toHaveBeenCalled();
+  });
 });

--- a/__tests__/RenameModal.test.tsx
+++ b/__tests__/RenameModal.test.tsx
@@ -29,4 +29,14 @@ describe('RenameModal', () => {
     fireEvent.click(screen.getByText('Cancel'));
     expect(cancel).toHaveBeenCalled();
   });
+
+  it('handles Escape and Enter', () => {
+    const cancel = vi.fn();
+    const rename = vi.fn();
+    render(<RenameModal current="a.txt" onCancel={cancel} onRename={rename} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(cancel).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(rename).toHaveBeenCalledWith('a.txt');
+  });
 });

--- a/__tests__/revisions.test.tsx
+++ b/__tests__/revisions.test.tsx
@@ -73,4 +73,21 @@ describe('Revision history', () => {
     fireEvent.click(btn);
     expect(restoreRevision).toHaveBeenCalledWith('/p', 'a.txt', '1.png');
   });
+
+  it('closes on Escape or Enter', async () => {
+    const onClose = vi.fn();
+    render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <ToastProvider>
+            <RevisionsModal asset="a.txt" onClose={onClose} />
+          </ToastProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    fireEvent.keyDown(window, { key: 'Enter' });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/renderer/components/modals/ConfirmModal.tsx
+++ b/src/renderer/components/modals/ConfirmModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Modal, Button } from '../daisy/actions';
 
 export default function ConfirmModal({
@@ -14,6 +14,26 @@ export default function ConfirmModal({
   onCancel: () => void;
   onConfirm: () => void;
 }) {
+  const confirmRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    confirmRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        onConfirm();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onCancel, onConfirm]);
+
   return (
     <Modal open>
       <h3 className="font-bold text-lg mb-2">{title}</h3>
@@ -22,7 +42,7 @@ export default function ConfirmModal({
         <Button type="button" onClick={onCancel}>
           Cancel
         </Button>
-        <Button className="btn-primary" onClick={onConfirm}>
+        <Button ref={confirmRef} className="btn-primary" onClick={onConfirm}>
           {confirmText}
         </Button>
       </div>

--- a/src/renderer/components/modals/ExportWizardModal.tsx
+++ b/src/renderer/components/modals/ExportWizardModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Modal, Button } from '../daisy/actions';
 import { RadialProgress } from '../daisy/feedback';
 import type { ExportSummary } from '../../../main/exporter';
@@ -21,6 +21,23 @@ export default function ExportWizardModal({
   onClose,
   onOpenFolder,
 }: ExportWizardModalProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (summary) closeRef.current?.focus();
+  }, [summary]);
+
+  useEffect(() => {
+    if (!summary) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [summary, onClose]);
   if (progress && !summary) {
     const percent = progress.total
       ? Math.floor((progress.current / progress.total) * 100)
@@ -63,7 +80,9 @@ export default function ExportWizardModal({
               Open Folder
             </Button>
           )}
-          <Button onClick={onClose}>Close</Button>
+          <Button ref={closeRef} onClick={onClose}>
+            Close
+          </Button>
         </div>
       </Modal>
     );

--- a/src/renderer/components/modals/ImportWizardModal.tsx
+++ b/src/renderer/components/modals/ImportWizardModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Modal, Button } from '../daisy/actions';
 import { Loading } from '../daisy/feedback';
 import type { ImportSummary } from '../../../main/projects';
@@ -14,6 +14,23 @@ export default function ImportWizardModal({
   summary,
   onClose,
 }: ImportWizardModalProps) {
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (summary) closeRef.current?.focus();
+  }, [summary]);
+
+  useEffect(() => {
+    if (!summary) return;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [summary, onClose]);
   if (inProgress && !summary) {
     return (
       <Modal open className="flex flex-col items-center">
@@ -33,7 +50,9 @@ export default function ImportWizardModal({
         </p>
         <p>{seconds} seconds</p>
         <div className="modal-action">
-          <Button onClick={onClose}>Close</Button>
+          <Button ref={closeRef} onClick={onClose}>
+            Close
+          </Button>
         </div>
       </Modal>
     );

--- a/src/renderer/components/modals/PackMetaModal.tsx
+++ b/src/renderer/components/modals/PackMetaModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import path from 'path';
 import { app } from 'electron';
 import { PackMetaSchema } from '../../../shared/project';
@@ -26,9 +26,25 @@ export function PackMetaForm({
   const [author, setAuthor] = useState(meta.author);
   const [urls, setUrls] = useState(meta.urls.join('\n'));
   const [license, setLicense] = useState(meta.license);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel?.();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onCancel]);
 
   return (
     <form
+      ref={formRef}
       className="flex flex-col gap-2"
       onSubmit={(e) => {
         e.preventDefault();

--- a/src/renderer/components/modals/RenameModal.tsx
+++ b/src/renderer/components/modals/RenameModal.tsx
@@ -17,13 +17,31 @@ export default function RenameModal({
 }) {
   const [name, setName] = useState(current);
   const inputRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
   useEffect(() => {
     inputRef.current?.focus();
     inputRef.current?.select();
   }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onCancel]);
+
   return (
     <Modal open>
       <form
+        ref={formRef}
         className="flex flex-col gap-2"
         onSubmit={(e) => {
           e.preventDefault();

--- a/src/renderer/components/modals/RevisionsModal.tsx
+++ b/src/renderer/components/modals/RevisionsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import path from 'path';
 import { Modal, Button } from '../daisy/actions';
 import { useProject } from '../providers/ProjectProvider';
@@ -14,6 +14,22 @@ export default function RevisionsModal({
   const { path: projectPath } = useProject();
   const toast = useToast();
   const [list, setList] = useState<string[]>([]);
+  const closeRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    closeRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' || e.key === 'Enter') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
 
   useEffect(() => {
     if (!projectPath) return;
@@ -56,7 +72,9 @@ export default function RevisionsModal({
         {list.length === 0 && <li className="p-2">No revisions</li>}
       </ul>
       <div className="modal-action">
-        <Button onClick={onClose}>Close</Button>
+        <Button ref={closeRef} onClick={onClose}>
+          Close
+        </Button>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Summary
- focus confirm button in `ConfirmModal`
- close or confirm modals with Escape/Enter
- support keyboard shortcuts in `RenameModal`
- handle Escape/Enter in wizard, metadata and revisions modals
- extend related modal tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685255cac6ac8331b31a713667dde31d