### PR TITLE
Await project creation refresh

### DIFF
--- a/__tests__/ProjectManagerView.test.tsx
+++ b/__tests__/ProjectManagerView.test.tsx
@@ -212,4 +212,31 @@ describe('ProjectManagerView', () => {
     const input = screen.getByPlaceholderText('Search');
     expect(input).toHaveClass('w-40');
   });
+
+  it('shows newly created project in the table', async () => {
+    listProjects.mockResolvedValueOnce([
+      { name: 'Pack', version: '1.20', assets: 2, lastOpened: 0 },
+      { name: 'Alpha', version: '1.21', assets: 5, lastOpened: 1 },
+    ]);
+    listProjects.mockResolvedValueOnce([
+      { name: 'Pack', version: '1.20', assets: 2, lastOpened: 0 },
+      { name: 'Alpha', version: '1.21', assets: 5, lastOpened: 1 },
+      { name: 'New', version: '1.21.1', assets: 0, lastOpened: 2 },
+    ]);
+
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    fireEvent.click(screen.getByText('New Project'));
+    const modal = await screen.findByTestId('daisy-modal');
+    fireEvent.change(within(modal).getByPlaceholderText('Name'), {
+      target: { value: 'New' },
+    });
+    fireEvent.change(within(modal).getByRole('combobox'), {
+      target: { value: '34' },
+    });
+    fireEvent.click(within(modal).getByRole('button', { name: 'Create' }));
+
+    await screen.findByText('New');
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
 });

--- a/src/renderer/hooks/useProjectList.ts
+++ b/src/renderer/hooks/useProjectList.ts
@@ -8,8 +8,10 @@ export default function useProjectList() {
   const [sortKey, setSortKey] = useState<keyof ProjectInfo>('name');
   const [asc, setAsc] = useState(true);
 
-  const refresh = useCallback(() => {
-    window.electronAPI?.listProjects().then(setProjects);
+  const refresh = useCallback((): Promise<void> => {
+    return (
+      window.electronAPI?.listProjects().then(setProjects) ?? Promise.resolve()
+    );
   }, []);
 
   useEffect(() => {

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -53,11 +53,10 @@ const ProjectManagerView: React.FC = () => {
       .finally(() => setImporting(false));
   };
 
-  const handleCreate = (name: string, minecraftVersion: string) => {
-    window.electronAPI?.createProject(name, minecraftVersion).then(() => {
-      refresh();
-      toast({ message: 'Project created', type: 'success' });
-    });
+  const handleCreate = async (name: string, minecraftVersion: string) => {
+    await window.electronAPI?.createProject(name, minecraftVersion);
+    await refresh();
+    toast({ message: 'Project created', type: 'success' });
   };
 
   let clearSelection: () => void = () => {};


### PR DESCRIPTION
## Summary
- await `refresh()` after project creation
- return a promise from `useProjectList` refresh
- add regression test for automatically showing newly created projects

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685255ec150c8331bf1ae39386292ace