### PR TITLE
Add tabbed editor modes

### DIFF
--- a/__tests__/AssetInfoHeader.test.tsx
+++ b/__tests__/AssetInfoHeader.test.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import AssetInfoHeader from '../src/renderer/components/assets/AssetInfoHeader';
+import {
+  EditorContext,
+  EditorTab,
+} from '../src/renderer/components/providers/EditorProvider';
 
 vi.mock('../src/renderer/components/assets/PreviewPane', () => ({
   __esModule: true,
@@ -13,29 +17,38 @@ vi.mock('../src/renderer/components/assets/PreviewPane', () => ({
 describe('AssetInfoHeader', () => {
   it('shows png actions and fires callbacks', async () => {
     const ext = vi.fn();
-    const lab = vi.fn();
+    const openLab = vi.fn();
     const diff = vi.fn();
     const revs = vi.fn();
     render(
-      <AssetInfoHeader
-        asset="foo.png"
-        count={1}
-        isText={false}
-        isPng
-        isAudio={false}
-        stamp={1}
-        onOpenExternal={ext}
-        onOpenLab={lab}
-        onOpenDiff={diff}
-        onOpenRevisions={revs}
-      />
+      <EditorContext.Provider
+        value={{
+          tab: 'browser' as EditorTab,
+          setTab: vi.fn(),
+          labFile: null,
+          labStamp: undefined,
+          openLab,
+        }}
+      >
+        <AssetInfoHeader
+          asset="foo.png"
+          count={1}
+          isText={false}
+          isPng
+          isAudio={false}
+          stamp={1}
+          onOpenExternal={ext}
+          onOpenDiff={diff}
+          onOpenRevisions={revs}
+        />
+      </EditorContext.Provider>
     );
     screen.getByText('Edit Externally').click();
     screen.getByText('Open Texture Lab').click();
     screen.getByText('Compare with Vanilla').click();
     screen.getByText('Revisions').click();
     expect(ext).toHaveBeenCalled();
-    expect(lab).toHaveBeenCalled();
+    expect(openLab).toHaveBeenCalled();
     expect(diff).toHaveBeenCalled();
     expect(revs).toHaveBeenCalled();
     const preview = await screen.findByTestId('preview');
@@ -46,15 +59,25 @@ describe('AssetInfoHeader', () => {
     const save = vi.fn();
     const reset = vi.fn();
     render(
-      <AssetInfoHeader
-        asset="a.txt"
-        count={1}
-        isText
-        isPng={false}
-        isAudio={false}
-        onSave={save}
-        onReset={reset}
-      />
+      <EditorContext.Provider
+        value={{
+          tab: 'browser' as EditorTab,
+          setTab: vi.fn(),
+          labFile: null,
+          labStamp: undefined,
+          openLab: vi.fn(),
+        }}
+      >
+        <AssetInfoHeader
+          asset="a.txt"
+          count={1}
+          isText
+          isPng={false}
+          isAudio={false}
+          onSave={save}
+          onReset={reset}
+        />
+      </EditorContext.Provider>
     );
     screen.getByText('Save').click();
     screen.getByText('Reset').click();

--- a/src/renderer/components/assets/AssetInfo.tsx
+++ b/src/renderer/components/assets/AssetInfo.tsx
@@ -9,7 +9,6 @@ import TextPanel from './assetInfo/TextPanel';
 import PngPanel from './assetInfo/PngPanel';
 import AudioPanel from './assetInfo/AudioPanel';
 
-const TextureLab = lazy(() => import('./TextureLab'));
 const TextureDiff = lazy(() => import('./TextureDiff'));
 const AudioPreview = lazy(() => import('./AudioPreview'));
 
@@ -24,7 +23,6 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
   const [text, setText] = useState('');
   const [orig, setOrig] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [lab, setLab] = useState(false);
   const [diff, setDiff] = useState(false);
   const [audio, setAudio] = useState(false);
   const [stamp, setStamp] = useState<number>();
@@ -99,7 +97,6 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
         stamp={stamp}
         onSave={handleSave}
         onReset={handleReset}
-        onOpenLab={() => setLab(true)}
         onOpenDiff={() => setDiff(true)}
         onOpenAudio={() => setAudio(true)}
         onOpenRevisions={() => setRevs(true)}
@@ -122,11 +119,6 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
       )}
       {isPng && count === 1 && <PngPanel />}
       {isAudio && count === 1 && <AudioPanel />}
-      {lab && (
-        <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-          <TextureLab file={full} onClose={() => setLab(false)} stamp={stamp} />
-        </Suspense>
-      )}
       {diff && (
         <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
           <TextureDiff asset={asset} onClose={() => setDiff(false)} />

--- a/src/renderer/components/assets/AssetInfoHeader.tsx
+++ b/src/renderer/components/assets/AssetInfoHeader.tsx
@@ -1,5 +1,6 @@
 import React, { Suspense, lazy } from 'react';
 import { Button } from '../daisy/actions';
+import { useEditor } from '../providers/EditorProvider';
 
 const PreviewPane = lazy(() => import('./PreviewPane'));
 
@@ -12,7 +13,6 @@ interface Props {
   stamp?: number;
   onSave?: () => void;
   onReset?: () => void;
-  onOpenLab?: () => void;
   onOpenDiff?: () => void;
   onOpenAudio?: () => void;
   onOpenRevisions?: () => void;
@@ -28,12 +28,12 @@ export default function AssetInfoHeader({
   stamp,
   onSave,
   onReset,
-  onOpenLab,
   onOpenDiff,
   onOpenAudio,
   onOpenRevisions,
   onOpenExternal,
 }: Props) {
+  const { openLab } = useEditor();
   return (
     <div className="flex gap-2 mb-2" data-testid="asset-info-header">
       <Suspense
@@ -65,7 +65,10 @@ export default function AssetInfoHeader({
         )}
         {isPng && count === 1 && (
           <div className="flex flex-col gap-2 mt-2" data-testid="png-actions">
-            <Button className="btn-secondary btn-sm" onClick={onOpenLab}>
+            <Button
+              className="btn-secondary btn-sm"
+              onClick={() => openLab(asset, stamp)}
+            >
               Open Texture Lab
             </Button>
             <Button className="btn-secondary btn-sm" onClick={onOpenExternal}>

--- a/src/renderer/components/providers/EditorProvider.tsx
+++ b/src/renderer/components/providers/EditorProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext, useContext, useState } from 'react';
+
+export type EditorTab = 'browser' | 'lab' | 'exporter';
+
+interface EditorContextValue {
+  tab: EditorTab;
+  setTab: (t: EditorTab) => void;
+  labFile: string | null;
+  labStamp?: number;
+  openLab: (file: string, stamp?: number) => void;
+}
+
+export const EditorContext = createContext<EditorContextValue>({
+  tab: 'browser',
+  setTab: () => {
+    /* noop */
+  },
+  labFile: null,
+  labStamp: undefined,
+  openLab: () => {
+    /* noop */
+  },
+});
+
+export const useEditor = () => useContext(EditorContext);
+
+export function EditorProvider({ children }: { children: React.ReactNode }) {
+  const [tab, setTab] = useState<EditorTab>('browser');
+  const [labFile, setLabFile] = useState<string | null>(null);
+  const [labStamp, setLabStamp] = useState<number | undefined>(undefined);
+
+  const openLab = (file: string, stamp?: number) => {
+    setLabFile(file);
+    setLabStamp(stamp);
+    setTab('lab');
+  };
+
+  return (
+    <EditorContext.Provider value={{ tab, setTab, labFile, labStamp, openLab }}>
+      {children}
+    </EditorContext.Provider>
+  );
+}

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -1,17 +1,8 @@
-import React, { Suspense, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ReactCanvasConfetti from 'react-canvas-confetti';
-import AssetBrowser from '../components/assets/AssetBrowser';
-import AssetSelector from '../components/assets/AssetSelector';
-import AssetInfo from '../components/assets/AssetInfo';
 import ProjectInfoPanel from '../components/project/ProjectInfoPanel';
-import AssetSelectorInfoPanel from '../components/assets/AssetSelectorInfoPanel';
-import { Skeleton } from '../components/daisy/feedback';
-import ExportWizardModal, {
-  BulkProgress,
-} from '../components/modals/ExportWizardModal';
 import ExternalLink from '../components/common/ExternalLink';
-import { Modal, Button } from '../components/daisy/actions';
-import type { ExportSummary } from '../../main/exporter';
+import { Tab } from '../components/daisy/navigation';
 /* eslint-disable import/no-unresolved */
 import {
   PanelGroup,
@@ -20,22 +11,28 @@ import {
   ImperativePanelGroupHandle,
 } from 'react-resizable-panels';
 /* eslint-enable import/no-unresolved */
+import AssetBrowserTab from './editor/AssetBrowserTab';
+import TextureLabTab from './editor/TextureLabTab';
+import ExporterTab from './editor/ExporterTab';
+import {
+  EditorProvider,
+  useEditor,
+} from '../components/providers/EditorProvider';
+import type { ExportSummary } from '../../main/exporter';
+import { BulkProgress } from '../components/modals/ExportWizardModal';
+import { useProject } from '../components/providers/ProjectProvider';
 
-interface EditorViewProps {
+interface Props {
   onBack: () => void;
   onSettings: () => void;
 }
 
-import { useProject } from '../components/providers/ProjectProvider';
-
-export default function EditorView({ onBack, onSettings }: EditorViewProps) {
+function EditorContent({ onBack, onSettings }: Props) {
   const { path: projectPath } = useProject();
-  const [selected, setSelected] = useState<string[]>([]);
-  const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
+  const { tab, setTab } = useEditor();
   const [layout, setLayout] = useState<number[]>([20, 80]);
   const [summary, setSummary] = useState<ExportSummary | null>(null);
   const [progress, setProgress] = useState<BulkProgress | null>(null);
-  const [selectorOpen, setSelectorOpen] = useState(false);
   const [allowConfetti, setAllowConfetti] = useState(true);
   const confetti = useRef<((opts: unknown) => void) | null>(null);
   const groupRef = useRef<ImperativePanelGroupHandle>(null);
@@ -51,6 +48,7 @@ export default function EditorView({ onBack, onSettings }: EditorViewProps) {
   }, []);
 
   const handleExport = () => {
+    setTab('exporter');
     setProgress({ current: 0, total: 0 });
     window.electronAPI
       ?.exportProject(projectPath)
@@ -79,12 +77,6 @@ export default function EditorView({ onBack, onSettings }: EditorViewProps) {
       data-testid="editor-view"
     >
       <div className="flex items-center justify-end mb-2 gap-2">
-        <Button
-          className="btn-primary btn-sm"
-          onClick={() => setSelectorOpen(true)}
-        >
-          Add From Vanilla
-        </Button>
         <ExternalLink
           href="https://minecraft.wiki/w/Resource_pack"
           aria-label="Help"
@@ -121,48 +113,41 @@ export default function EditorView({ onBack, onSettings }: EditorViewProps) {
           defaultSize={layout[1]}
           className="overflow-hidden bg-base-100 border border-base-300 rounded"
         >
-          <PanelGroup direction="vertical" className="h-full">
-            <Panel defaultSize={70} className="overflow-y-auto">
-              <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-                <AssetBrowser onSelectionChange={(sel) => setSelected(sel)} />
-              </Suspense>
-            </Panel>
-            <PanelResizeHandle className="flex items-center" tagName="div">
-              <div className="w-full h-px bg-base-content"></div>
-            </PanelResizeHandle>
-            <Panel defaultSize={30} className="overflow-y-auto">
-              <AssetInfo asset={selected[0] ?? null} count={selected.length} />
-            </Panel>
-          </PanelGroup>
-        </Panel>
-      </PanelGroup>
-      {(progress || summary) && (
-        <ExportWizardModal
-          progress={progress ?? undefined}
-          summary={summary ?? undefined}
-          onClose={() => setSummary(null)}
-        />
-      )}
-      {selectorOpen && (
-        <Modal open testId="asset-selector-modal" className="max-w-[1200px]">
-          <div className="w-[95%] h-[800px]">
-            <h3 className="font-bold text-lg mb-2">Add Assets</h3>
-            <div className="flex gap-4 max-h-[70vh]">
-              <div className="flex-1 overflow-y-auto">
-                <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-                  <AssetSelector onAssetSelect={(n) => setSelectorAsset(n)} />
-                </Suspense>
-              </div>
-              <div className="w-48 overflow-y-auto">
-                <AssetSelectorInfoPanel asset={selectorAsset} />
-              </div>
+          <div className="flex flex-col h-full">
+            <div role="tablist" className="tabs tabs-bordered mb-2">
+              <Tab
+                className={tab === 'browser' ? 'tab-active' : ''}
+                onClick={() => setTab('browser')}
+              >
+                Asset Browser
+              </Tab>
+              <Tab
+                className={tab === 'lab' ? 'tab-active' : ''}
+                onClick={() => setTab('lab')}
+              >
+                Texture Lab
+              </Tab>
+              <Tab
+                className={tab === 'exporter' ? 'tab-active' : ''}
+                onClick={() => setTab('exporter')}
+              >
+                Exporter
+              </Tab>
             </div>
-            <div className="modal-action">
-              <Button onClick={() => setSelectorOpen(false)}>Close</Button>
+            <div className="flex-1 min-h-0 overflow-y-auto">
+              {tab === 'browser' && <AssetBrowserTab />}
+              {tab === 'lab' && <TextureLabTab />}
+              {tab === 'exporter' && (
+                <ExporterTab
+                  progress={progress}
+                  summary={summary}
+                  onClose={() => setSummary(null)}
+                />
+              )}
             </div>
           </div>
-        </Modal>
-      )}
+        </Panel>
+      </PanelGroup>
       <ReactCanvasConfetti
         onInit={({ confetti: c }) => {
           confetti.current = c;
@@ -177,5 +162,13 @@ export default function EditorView({ onBack, onSettings }: EditorViewProps) {
         }}
       />
     </main>
+  );
+}
+
+export default function EditorView(props: Props) {
+  return (
+    <EditorProvider>
+      <EditorContent {...props} />
+    </EditorProvider>
   );
 }

--- a/src/renderer/views/editor/AssetBrowserTab.tsx
+++ b/src/renderer/views/editor/AssetBrowserTab.tsx
@@ -1,0 +1,62 @@
+import React, { Suspense, useState } from 'react';
+/* eslint-disable import/no-unresolved */
+import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels';
+/* eslint-enable import/no-unresolved */
+import AssetBrowser from '../../components/assets/AssetBrowser';
+import AssetInfo from '../../components/assets/AssetInfo';
+import AssetSelector from '../../components/assets/AssetSelector';
+import AssetSelectorInfoPanel from '../../components/assets/AssetSelectorInfoPanel';
+import { Skeleton } from '../../components/daisy/feedback';
+import { Modal, Button } from '../../components/daisy/actions';
+
+export default function AssetBrowserTab() {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-end mb-2 gap-2">
+        <Button
+          className="btn-primary btn-sm"
+          onClick={() => setSelectorOpen(true)}
+        >
+          Add From Vanilla
+        </Button>
+      </div>
+      <PanelGroup direction="vertical" className="flex-1">
+        <Panel defaultSize={70} className="overflow-y-auto">
+          <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+            <AssetBrowser onSelectionChange={(sel) => setSelected(sel)} />
+          </Suspense>
+        </Panel>
+        <PanelResizeHandle className="flex items-center" tagName="div">
+          <div className="w-full h-px bg-base-content"></div>
+        </PanelResizeHandle>
+        <Panel defaultSize={30} className="overflow-y-auto">
+          <AssetInfo asset={selected[0] ?? null} count={selected.length} />
+        </Panel>
+      </PanelGroup>
+      {selectorOpen && (
+        <Modal open testId="asset-selector-modal" className="max-w-[1200px]">
+          <div className="w-[95%] h-[800px]">
+            <h3 className="font-bold text-lg mb-2">Add Assets</h3>
+            <div className="flex gap-4 max-h-[70vh]">
+              <div className="flex-1 overflow-y-auto">
+                <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+                  <AssetSelector onAssetSelect={(n) => setSelectorAsset(n)} />
+                </Suspense>
+              </div>
+              <div className="w-48 overflow-y-auto">
+                <AssetSelectorInfoPanel asset={selectorAsset} />
+              </div>
+            </div>
+            <div className="modal-action">
+              <Button onClick={() => setSelectorOpen(false)}>Close</Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/views/editor/ExporterTab.tsx
+++ b/src/renderer/views/editor/ExporterTab.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ExportWizardModal, {
+  BulkProgress,
+} from '../../components/modals/ExportWizardModal';
+import type { ExportSummary } from '../../../main/exporter';
+
+interface Props {
+  progress: BulkProgress | null;
+  summary: ExportSummary | null;
+  onClose: () => void;
+}
+
+export default function ExporterTab({ progress, summary, onClose }: Props) {
+  if (!progress && !summary)
+    return <div className="p-4">No export running</div>;
+  return (
+    <ExportWizardModal
+      progress={progress ?? undefined}
+      summary={summary ?? undefined}
+      onClose={onClose}
+    />
+  );
+}

--- a/src/renderer/views/editor/TextureLabTab.tsx
+++ b/src/renderer/views/editor/TextureLabTab.tsx
@@ -1,0 +1,18 @@
+import React, { Suspense } from 'react';
+import { Skeleton } from '../../components/daisy/feedback';
+import TextureLab from '../../components/assets/TextureLab';
+import { useEditor } from '../../components/providers/EditorProvider';
+
+export default function TextureLabTab() {
+  const { labFile, labStamp, setTab } = useEditor();
+  if (!labFile) return <div className="p-4">No texture selected</div>;
+  return (
+    <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+      <TextureLab
+        file={labFile}
+        stamp={labStamp}
+        onClose={() => setTab('browser')}
+      />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## Summary
- create EditorProvider context
- break editor into Asset Browser, Texture Lab and Exporter modes
- implement tabbed EditorView and new mode components
- update AssetInfo and header to use context
- adjust tests for new context

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68528dc4e93483319ad262d28950c7f3