### PR TITLE
Add tabbed editor modes

### DIFF
--- a/__tests__/ExporterTab.test.tsx
+++ b/__tests__/ExporterTab.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ExporterTab from '../src/renderer/components/editor/ExporterTab';
+import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
+import { EditorProvider } from '../src/renderer/components/editor';
+import { SetPath } from './test-utils';
+
+describe('ExporterTab', () => {
+  it('calls onExport when button clicked', () => {
+    const onExport = vi.fn();
+    render(
+      <ProjectProvider>
+        <SetPath path="/tmp/proj">
+          <EditorProvider value={{ selected: [], setSelected: vi.fn() }}>
+            <ExporterTab onExport={onExport} />
+          </EditorProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    fireEvent.click(screen.getByText('Export Pack'));
+    expect(onExport).toHaveBeenCalled();
+  });
+});

--- a/__tests__/TextureLabTab.test.tsx
+++ b/__tests__/TextureLabTab.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import TextureLabTab from '../src/renderer/components/editor/TextureLabTab';
+import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
+import { EditorProvider } from '../src/renderer/components/editor';
+import { SetPath, electronAPI } from './test-utils';
+
+describe('TextureLabTab', () => {
+  it('shows hint when no texture selected', () => {
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <EditorProvider value={{ selected: [], setSelected: vi.fn() }}>
+            <TextureLabTab />
+          </EditorProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    expect(screen.getByText(/Select a PNG/)).toBeInTheDocument();
+  });
+
+  it('renders controls for selected texture', () => {
+    electronAPI.onFileChanged.mockImplementation(() => {});
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <EditorProvider
+            value={{ selected: ['foo.png'], setSelected: vi.fn() }}
+          >
+            <TextureLabTab />
+          </EditorProvider>
+        </SetPath>
+      </ProjectProvider>
+    );
+    expect(screen.getByTestId('texture-lab-view')).toBeInTheDocument();
+    expect(screen.getByAltText('preview')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/editor/AssetBrowserTab.tsx
+++ b/src/renderer/components/editor/AssetBrowserTab.tsx
@@ -1,0 +1,131 @@
+import React, { Suspense, useEffect, useRef, useState } from 'react';
+import AssetBrowser from '../assets/AssetBrowser';
+import AssetSelector from '../assets/AssetSelector';
+import AssetInfo from '../assets/AssetInfo';
+import ProjectInfoPanel from '../project/ProjectInfoPanel';
+import AssetSelectorInfoPanel from '../assets/AssetSelectorInfoPanel';
+import { Skeleton } from '../daisy/feedback';
+import ExternalLink from '../common/ExternalLink';
+import { Modal, Button } from '../daisy/actions';
+import { useEditor } from './EditorContext';
+/* eslint-disable import/no-unresolved */
+import {
+  PanelGroup,
+  Panel,
+  PanelResizeHandle,
+  ImperativePanelGroupHandle,
+} from 'react-resizable-panels';
+/* eslint-enable import/no-unresolved */
+
+interface Props {
+  onBack: () => void;
+  onSettings: () => void;
+  onExport: () => void;
+}
+
+export default function AssetBrowserTab({
+  onBack,
+  onSettings,
+  onExport,
+}: Props) {
+  const { selected, setSelected } = useEditor();
+  const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
+  const [layout, setLayout] = useState<number[]>([20, 80]);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const groupRef = useRef<ImperativePanelGroupHandle>(null);
+
+  useEffect(() => {
+    window.electronAPI?.getEditorLayout().then((l) => {
+      if (Array.isArray(l)) {
+        if (l.length === 2) setLayout(l);
+        else if (l.length === 3) setLayout([l[0], l[1] + l[2]]);
+      }
+    });
+  }, []);
+
+  return (
+    <div
+      className="flex flex-col gap-4 flex-1 min-h-0"
+      data-testid="asset-browser-tab"
+    >
+      <div className="flex items-center justify-end mb-2 gap-2">
+        <Button
+          className="btn-primary btn-sm"
+          onClick={() => setSelectorOpen(true)}
+        >
+          Add From Vanilla
+        </Button>
+        <ExternalLink
+          href="https://minecraft.wiki/w/Resource_pack"
+          aria-label="Help"
+          className="btn btn-circle btn-ghost btn-sm"
+        >
+          ?
+        </ExternalLink>
+      </div>
+      <PanelGroup
+        ref={groupRef}
+        direction="horizontal"
+        onLayout={(l) => {
+          setLayout(l);
+          window.electronAPI?.setEditorLayout(l);
+        }}
+        className="flex-1 min-h-0"
+      >
+        <Panel
+          minSize={15}
+          defaultSize={layout[0]}
+          className="bg-base-100 border border-base-300 rounded flex flex-col"
+        >
+          <ProjectInfoPanel
+            onExport={onExport}
+            onBack={onBack}
+            onSettings={onSettings}
+          />
+        </Panel>
+        <PanelResizeHandle className="flex items-center" tagName="div">
+          <div className="w-1 bg-base-content h-full mx-auto"></div>
+        </PanelResizeHandle>
+        <Panel
+          minSize={20}
+          defaultSize={layout[1]}
+          className="overflow-hidden bg-base-100 border border-base-300 rounded"
+        >
+          <PanelGroup direction="vertical" className="h-full">
+            <Panel defaultSize={70} className="overflow-y-auto">
+              <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+                <AssetBrowser onSelectionChange={setSelected} />
+              </Suspense>
+            </Panel>
+            <PanelResizeHandle className="flex items-center" tagName="div">
+              <div className="w-full h-px bg-base-content"></div>
+            </PanelResizeHandle>
+            <Panel defaultSize={30} className="overflow-y-auto">
+              <AssetInfo asset={selected[0] ?? null} count={selected.length} />
+            </Panel>
+          </PanelGroup>
+        </Panel>
+      </PanelGroup>
+      {selectorOpen && (
+        <Modal open testId="asset-selector-modal" className="max-w-[1200px]">
+          <div className="w-[95%] h-[800px]">
+            <h3 className="font-bold text-lg mb-2">Add Assets</h3>
+            <div className="flex gap-4 max-h-[70vh]">
+              <div className="flex-1 overflow-y-auto">
+                <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
+                  <AssetSelector onAssetSelect={(n) => setSelectorAsset(n)} />
+                </Suspense>
+              </div>
+              <div className="w-48 overflow-y-auto">
+                <AssetSelectorInfoPanel asset={selectorAsset} />
+              </div>
+            </div>
+            <div className="modal-action">
+              <Button onClick={() => setSelectorOpen(false)}>Close</Button>
+            </div>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/editor/EditorContext.tsx
+++ b/src/renderer/components/editor/EditorContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext } from 'react';
+
+export interface EditorContextValue {
+  selected: string[];
+  setSelected: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const EditorContext = createContext<EditorContextValue>({
+  selected: [],
+  setSelected: () => {
+    /* noop */
+  },
+});
+
+export function useEditor() {
+  return useContext(EditorContext);
+}
+
+export function EditorProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: EditorContextValue;
+}) {
+  return (
+    <EditorContext.Provider value={value}>{children}</EditorContext.Provider>
+  );
+}
+
+export { EditorContext };

--- a/src/renderer/components/editor/ExporterTab.tsx
+++ b/src/renderer/components/editor/ExporterTab.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Button } from '../daisy/actions';
+import { useProject } from '../providers/ProjectProvider';
+
+export default function ExporterTab({ onExport }: { onExport: () => void }) {
+  const { path: projectPath } = useProject();
+  return (
+    <div className="p-4 flex flex-col gap-2" data-testid="exporter-tab">
+      <p>{projectPath}</p>
+      <Button className="btn-primary self-start" onClick={onExport}>
+        Export Pack
+      </Button>
+    </div>
+  );
+}

--- a/src/renderer/components/editor/TextureLabTab.tsx
+++ b/src/renderer/components/editor/TextureLabTab.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import path from 'path';
+import { toPosixPath } from '../../../shared/toPosixPath';
+import { Loading } from '../daisy/feedback';
+import type { TextureEditOptions } from '../../../shared/texture';
+import { Button } from '../daisy/actions';
+import { Range, Select, Checkbox } from '../daisy/input';
+import { useProject } from '../providers/ProjectProvider';
+import { useEditor } from './EditorContext';
+
+export default function TextureLabTab() {
+  const { path: projectPath } = useProject();
+  const { selected } = useEditor();
+  const file =
+    selected.length === 1 ? path.join(projectPath, selected[0]) : null;
+  const [hue, setHue] = useState(0);
+  const [rotate, setRotate] = useState(0);
+  const [gray, setGray] = useState(false);
+  const [sat, setSat] = useState(1);
+  const [bright, setBright] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const [version, setVersion] = useState<number>();
+
+  useEffect(() => {
+    if (!file) return;
+    const relPath = toPosixPath(path.relative(projectPath, file));
+    const listener = (_e: unknown, args: { path: string; stamp: number }) => {
+      if (args.path === relPath) setVersion(args.stamp);
+    };
+    window.electronAPI?.onFileChanged(listener);
+    return () => {
+      // no cleanup because onFileChanged doesn't return unsubscribe
+    };
+  }, [file, projectPath]);
+
+  if (!file || path.extname(file).toLowerCase() !== '.png') {
+    return (
+      <div className="p-4">Select a PNG texture in the Asset Browser.</div>
+    );
+  }
+
+  const rel = toPosixPath(path.relative(projectPath, file));
+  const filter = `hue-rotate(${hue}deg) saturate(${sat}) brightness(${bright})${
+    gray ? ' grayscale(1)' : ''
+  }`;
+
+  const apply = () => {
+    const opts: TextureEditOptions = {
+      hue,
+      rotate,
+      grayscale: gray,
+      saturation: sat,
+      brightness: bright,
+    };
+    setBusy(true);
+    window.electronAPI?.editTexture(file, opts).finally(() => setBusy(false));
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-2 p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        apply();
+      }}
+      data-testid="texture-lab-view"
+    >
+      <h3 className="font-bold text-lg">Texture Lab</h3>
+      <div style={{ height: '64px' }} className="flex justify-center">
+        <img
+          src={`asset://${rel}${version ? `?t=${version}` : ''}`}
+          alt="preview"
+          style={{
+            imageRendering: 'pixelated',
+            transform: `rotate(${rotate}deg)`,
+            filter,
+            height: '64px',
+            width: '64px',
+          }}
+        />
+      </div>
+      <label className="flex items-center gap-2">
+        Hue
+        <Range
+          min={-180}
+          max={180}
+          value={hue}
+          onChange={(e) => setHue(Number(e.target.value))}
+          className="range-xs flex-1"
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        Rotation
+        <Select
+          className="select-sm"
+          value={rotate}
+          onChange={(e) => setRotate(Number(e.target.value))}
+        >
+          <option value={0}>0°</option>
+          <option value={90}>90°</option>
+          <option value={180}>180°</option>
+          <option value={270}>270°</option>
+        </Select>
+      </label>
+      <label className="flex items-center gap-2">
+        <Checkbox checked={gray} onChange={(e) => setGray(e.target.checked)} />
+        Grayscale
+      </label>
+      <label className="flex items-center gap-2">
+        Saturation
+        <Range
+          min={0}
+          max={2}
+          step={0.1}
+          value={sat}
+          onChange={(e) => setSat(Number(e.target.value))}
+          className="range-xs flex-1"
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        Brightness
+        <Range
+          min={0}
+          max={2}
+          step={0.1}
+          value={bright}
+          onChange={(e) => setBright(Number(e.target.value))}
+          className="range-xs flex-1"
+        />
+      </label>
+      <div className="flex justify-end">
+        <Button type="submit" className="btn-primary" disabled={busy}>
+          Apply
+        </Button>
+      </div>
+      {busy && (
+        <div data-testid="spinner" className="flex justify-center p-2">
+          <Loading />
+        </div>
+      )}
+    </form>
+  );
+}

--- a/src/renderer/components/editor/index.ts
+++ b/src/renderer/components/editor/index.ts
@@ -1,0 +1,4 @@
+export { EditorProvider, useEditor } from './EditorContext';
+export { default as AssetBrowserTab } from './AssetBrowserTab';
+export { default as TextureLabTab } from './TextureLabTab';
+export { default as ExporterTab } from './ExporterTab';


### PR DESCRIPTION
## Summary
- split editor into Asset Browser, Texture Lab and Exporter tabs
- provide `EditorContext` for sharing selection
- implement AssetBrowserTab, TextureLabTab and ExporterTab components
- update EditorView to show the new modes
- add tests for ExporterTab and TextureLabTab

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run dev:headless` *(fails: Failed to find xvfb-run)*

------
https://chatgpt.com/codex/tasks/task_e_68528dc4e93483319ad262d28950c7f3