### PR TITLE
Fix IPC listener cleanup

### DIFF
--- a/__tests__/AssetBrowser.persist.test.tsx
+++ b/__tests__/AssetBrowser.persist.test.tsx
@@ -7,10 +7,10 @@ import AssetBrowser from '../src/renderer/components/assets/AssetBrowser';
 
 const watchProject = vi.fn(async () => []);
 const unwatchProject = vi.fn();
-const onFileAdded = vi.fn();
-const onFileRemoved = vi.fn();
-const onFileRenamed = vi.fn();
-const onFileChanged = vi.fn();
+const onFileAdded = vi.fn(() => () => undefined);
+const onFileRemoved = vi.fn(() => () => undefined);
+const onFileRenamed = vi.fn(() => () => undefined);
+const onFileChanged = vi.fn(() => () => undefined);
 
 const getAssetSearch = vi.fn();
 const setAssetSearch = vi.fn();

--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -9,10 +9,10 @@ import AssetBrowser from '../src/renderer/components/assets/AssetBrowser';
 
 const watchProject = vi.fn(async () => ['a.txt', 'b.png']);
 const unwatchProject = vi.fn();
-const onFileAdded = vi.fn();
-const onFileRemoved = vi.fn();
-const onFileRenamed = vi.fn();
-const onFileChanged = vi.fn();
+const onFileAdded = vi.fn(() => () => undefined);
+const onFileRemoved = vi.fn(() => () => undefined);
+const onFileRenamed = vi.fn(() => () => undefined);
+const onFileChanged = vi.fn(() => () => undefined);
 
 describe('AssetBrowser', () => {
   beforeEach(() => {

--- a/__tests__/AssetInfo.test.tsx
+++ b/__tests__/AssetInfo.test.tsx
@@ -36,7 +36,7 @@ describe('AssetInfo', () => {
     electronAPI.readFile.mockResolvedValue('');
     electronAPI.saveRevision.mockResolvedValue(undefined);
     electronAPI.openExternalEditor.mockResolvedValue(undefined);
-    electronAPI.onFileChanged.mockImplementation(() => undefined);
+    electronAPI.onFileChanged.mockImplementation(() => () => undefined);
   });
 
   it('shows placeholder when no asset', () => {
@@ -152,5 +152,20 @@ describe('AssetInfo', () => {
     });
     expect(img.src).not.toBe(before);
     expect(img.src).toContain('t=2');
+  });
+
+  it('cleans up listener on unmount', async () => {
+    const off = vi.fn();
+    onFileChanged.mockReturnValue(off);
+    const { unmount } = render(
+      <ProjectProvider>
+        <SetPath path="/p">
+          <AssetInfo asset="foo.png" />
+        </SetPath>
+      </ProjectProvider>
+    );
+    await screen.findByTestId('preview-pane');
+    unmount();
+    expect(off).toHaveBeenCalled();
   });
 });

--- a/__tests__/SettingsView.test.tsx
+++ b/__tests__/SettingsView.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import SettingsView from '../src/renderer/views/SettingsView';
 import ToastProvider from '../src/renderer/components/providers/ToastProvider';
@@ -109,7 +109,7 @@ describe('SettingsView', () => {
       </ToastProvider>
     );
     const input = await screen.findByLabelText('Default export folder');
-    expect(input).toHaveValue('/home');
+    await waitFor(() => expect(input).toHaveValue('/home'));
     fireEvent.change(input, { target: { value: '/out' } });
     const btn = screen.getAllByRole('button', { name: 'Save' })[1];
     fireEvent.click(btn);

--- a/__tests__/TextureLab.test.tsx
+++ b/__tests__/TextureLab.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import TextureLab from '../src/renderer/components/assets/TextureLab';
 import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
@@ -29,5 +29,20 @@ describe('TextureLab', () => {
       changed?.({}, { path: 'foo.png', stamp: 1 });
     });
     expect(img.src).toContain('t=1');
+  });
+
+  it('cleans up listener on unmount', () => {
+    const off = vi.fn();
+    electronAPI.onFileChanged.mockReturnValue(off);
+
+    const { unmount } = render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <TextureLab file="/proj/foo.png" onClose={() => {}} />
+        </SetPath>
+      </ProjectProvider>
+    );
+    unmount();
+    expect(off).toHaveBeenCalled();
   });
 });

--- a/__tests__/TextureLabTab.test.tsx
+++ b/__tests__/TextureLabTab.test.tsx
@@ -21,7 +21,7 @@ describe('TextureLabTab', () => {
   });
 
   it('renders controls for selected texture', () => {
-    electronAPI.onFileChanged.mockImplementation(() => {});
+    electronAPI.onFileChanged.mockImplementation(() => () => undefined);
     render(
       <ProjectProvider>
         <SetPath path="/proj">

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -19,7 +19,9 @@ function on<C extends keyof IpcEventMap>(
   channel: C,
   listener: (event: unknown, data: IpcEventMap[C]) => void
 ) {
-  ipcRenderer.on(channel, (_e, d) => listener(_e, d));
+  const handler = (_e: unknown, d: IpcEventMap[C]) => listener(_e, d);
+  ipcRenderer.on(channel, handler);
+  return () => ipcRenderer.removeListener(channel, handler);
 }
 
 const api = {

--- a/src/renderer/components/assets/AssetInfo.tsx
+++ b/src/renderer/components/assets/AssetInfo.tsx
@@ -37,8 +37,11 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
     const listener = (_e: unknown, args: { path: string; stamp: number }) => {
       if (args.path === asset) setStamp(args.stamp);
     };
-    window.electronAPI?.onFileChanged(listener);
+    const off = window.electronAPI?.onFileChanged(listener);
     setStamp(undefined);
+    return () => {
+      off?.();
+    };
   }, [asset]);
 
   const isText = asset

--- a/src/renderer/components/assets/TextureLab.tsx
+++ b/src/renderer/components/assets/TextureLab.tsx
@@ -34,7 +34,10 @@ export default function TextureLab({
     const listener = (_e: unknown, args: { path: string; stamp: number }) => {
       if (args.path === relPath) setVersion(args.stamp);
     };
-    window.electronAPI?.onFileChanged(listener);
+    const off = window.electronAPI?.onFileChanged(listener);
+    return () => {
+      off?.();
+    };
   }, [file, projectPath]);
 
   const rel = toPosixPath(path.relative(projectPath, file));

--- a/src/renderer/components/file/useProjectFiles.ts
+++ b/src/renderer/components/file/useProjectFiles.ts
@@ -45,13 +45,17 @@ export function useProjectFiles() {
       if (isHistory(args.path)) return;
       setVersions((v) => ({ ...v, [args.path]: args.stamp }));
     };
-    window.electronAPI?.onFileAdded(add);
-    window.electronAPI?.onFileRemoved(remove);
-    window.electronAPI?.onFileRenamed(rename);
-    window.electronAPI?.onFileChanged(change);
+    const offAdd = window.electronAPI?.onFileAdded(add);
+    const offRemove = window.electronAPI?.onFileRemoved(remove);
+    const offRename = window.electronAPI?.onFileRenamed(rename);
+    const offChange = window.electronAPI?.onFileChanged(change);
     return () => {
       alive = false;
       window.electronAPI?.unwatchProject(projectPath);
+      offAdd?.();
+      offRemove?.();
+      offRename?.();
+      offChange?.();
     };
   }, [projectPath]);
 

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -9,7 +9,7 @@ type IpcInvoke<C extends keyof IpcRequestMap> = (
 
 type IpcListener<C extends keyof IpcEventMap> = (
   listener: (event: unknown, data: IpcEventMap[C]) => void
-) => void;
+) => () => void;
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary
- return cleanup functions from `on` in the preload API
- expose those cleanup functions in `electronAPI`
- unsubscribe file event listeners in `useProjectFiles`, `AssetInfo` and `TextureLab`
- test that cleanup callbacks run on unmount

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68529e6b317c8331907264f5e48ec48e