### PR TITLE
Add context menu for asset selector

### DIFF
--- a/__tests__/AssetSelector.test.tsx
+++ b/__tests__/AssetSelector.test.tsx
@@ -139,4 +139,29 @@ describe('AssetSelector', () => {
     expect(screen.getByText('block')).toBeInTheDocument();
     expect(screen.getByText('grass.png')).toBeInTheDocument();
   });
+
+  it('opens context menu and fires callbacks', async () => {
+    const openInFolder = vi.fn();
+    const getTexturePath = vi.fn().mockResolvedValue('/proj/block/grass.png');
+    electronAPI.openInFolder.mockImplementation(openInFolder);
+    electronAPI.getTexturePath.mockImplementation(getTexturePath);
+    render(
+      <ProjectProvider>
+        <SetPath path="/proj">
+          <AssetSelector />
+        </SetPath>
+      </ProjectProvider>
+    );
+    const input = screen.getByPlaceholderText('Search texture');
+    fireEvent.change(input, { target: { value: 'grass' } });
+    const btn = await screen.findByRole('button', { name: 'block/grass.png' });
+    fireEvent.contextMenu(btn);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add to Project' }));
+    expect(addTexture).toHaveBeenCalledWith('/proj', 'block/grass.png');
+    fireEvent.contextMenu(btn);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
+    await Promise.resolve();
+    expect(getTexturePath).toHaveBeenCalledWith('/proj', 'block/grass.png');
+    expect(openInFolder).toHaveBeenCalledWith('/proj/block/grass.png');
+  });
 });

--- a/src/renderer/components/assets/AssetSelectorContextMenu.tsx
+++ b/src/renderer/components/assets/AssetSelectorContextMenu.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Button } from '../daisy/actions';
+
+interface Props {
+  asset: string;
+  firstItemRef?: React.Ref<HTMLButtonElement>;
+  style?: React.CSSProperties;
+  onAdd: (name: string) => void;
+  onReveal: (name: string) => void;
+}
+
+export default function AssetSelectorContextMenu({
+  asset,
+  firstItemRef,
+  style,
+  onAdd,
+  onReveal,
+}: Props) {
+  return (
+    <ul
+      className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
+      style={style}
+      role="menu"
+    >
+      <li>
+        <Button ref={firstItemRef} role="menuitem" onClick={() => onAdd(asset)}>
+          Add to Project
+        </Button>
+      </li>
+      <li>
+        <Button role="menuitem" onClick={() => onReveal(asset)}>
+          Reveal
+        </Button>
+      </li>
+    </ul>
+  );
+}

--- a/src/renderer/components/assets/TextureGrid.tsx
+++ b/src/renderer/components/assets/TextureGrid.tsx
@@ -13,6 +13,8 @@ interface Props {
   zoom: number;
   onSelect: (name: string) => void;
   testId?: string;
+  onContextMenu?: (e: React.MouseEvent, name: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent, name: string) => void;
 }
 
 interface CellData {
@@ -20,6 +22,8 @@ interface CellData {
   columnCount: number;
   zoom: number;
   onSelect: (name: string) => void;
+  onContextMenu?: (e: React.MouseEvent, name: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent, name: string) => void;
 }
 
 const Cell: React.FC<GridChildComponentProps<CellData>> = ({
@@ -41,6 +45,11 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
         <Button
           aria-label={tex.name}
           onClick={() => data.onSelect(tex.name)}
+          onContextMenu={(e) => data.onContextMenu?.(e, tex.name)}
+          onKeyDown={(e) =>
+            (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) &&
+            data.onKeyDown?.(e, tex.name)
+          }
           className="p-1 hover:ring ring-accent rounded"
         >
           <img
@@ -62,7 +71,14 @@ const Cell: React.FC<GridChildComponentProps<CellData>> = ({
   );
 };
 
-const TextureGrid: React.FC<Props> = ({ textures, zoom, onSelect, testId }) => {
+const TextureGrid: React.FC<Props> = ({
+  textures,
+  zoom,
+  onSelect,
+  testId,
+  onContextMenu,
+  onKeyDown,
+}) => {
   const width = typeof window !== 'undefined' ? window.innerWidth : 640;
   const columnWidth = zoom + 40;
   const rowHeight = zoom + 48;
@@ -81,7 +97,14 @@ const TextureGrid: React.FC<Props> = ({ textures, zoom, onSelect, testId }) => {
         rowCount={rowCount}
         rowHeight={rowHeight}
         width={columnCount * columnWidth}
-        itemData={{ textures, columnCount, zoom, onSelect }}
+        itemData={{
+          textures,
+          columnCount,
+          zoom,
+          onSelect,
+          onContextMenu,
+          onKeyDown,
+        }}
       >
         {Cell}
       </Grid>

--- a/src/renderer/components/assets/TextureTree.tsx
+++ b/src/renderer/components/assets/TextureTree.tsx
@@ -7,9 +7,16 @@ import type { TextureInfo } from './TextureGrid';
 interface Props {
   textures: TextureInfo[];
   onSelect: (name: string) => void;
+  onContextMenu?: (e: React.MouseEvent, name: string) => void;
+  onKeyDown?: (e: React.KeyboardEvent, name: string) => void;
 }
 
-export default function TextureTree({ textures, onSelect }: Props) {
+export default function TextureTree({
+  textures,
+  onSelect,
+  onContextMenu,
+  onKeyDown,
+}: Props) {
   const data = React.useMemo<TreeItem[]>(
     () => buildTree(textures.map((t) => t.name)),
     [textures]
@@ -36,6 +43,13 @@ export default function TextureTree({ textures, onSelect }: Props) {
             onClick={() => {
               if (node.isLeaf) onSelect(node.id);
             }}
+            onContextMenu={(e) => node.isLeaf && onContextMenu?.(e, node.id)}
+            onKeyDown={(e) =>
+              node.isLeaf &&
+              (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) &&
+              onKeyDown?.(e, node.id)
+            }
+            tabIndex={node.isLeaf ? 0 : undefined}
           >
             {node.isLeaf && (
               <img


### PR DESCRIPTION
## Summary
- add `AssetSelectorContextMenu` for adding vanilla textures
- support context menu in `AssetSelector` via right-click or keyboard
- update `TextureGrid` and `TextureTree` to forward context menu events
- test opening the menu and firing callbacks

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685298866fe483318f14297f1628f6eb