### PR TITLE
Add file moving option

### DIFF
--- a/__tests__/AssetContextMenu.test.tsx
+++ b/__tests__/AssetContextMenu.test.tsx
@@ -8,6 +8,7 @@ describe('AssetContextMenu', () => {
     const reveal = vi.fn();
     const open = vi.fn();
     const rename = vi.fn();
+    const move = vi.fn();
     const del = vi.fn();
     const toggle = vi.fn();
     render(
@@ -19,6 +20,7 @@ describe('AssetContextMenu', () => {
         onOpen={open}
         onRename={rename}
         onDelete={del}
+        onMove={move}
         onToggleNoExport={toggle}
       />
     );
@@ -28,6 +30,8 @@ describe('AssetContextMenu', () => {
     expect(open).toHaveBeenCalledWith('/proj/a.txt');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Rename' }));
     expect(rename).toHaveBeenCalledWith('/proj/a.txt');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move…' }));
+    expect(move).toHaveBeenCalledWith('/proj/a.txt');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
     expect(del).toHaveBeenCalledWith('/proj/a.txt');
     fireEvent.click(screen.getByRole('checkbox', { name: /No Export/i }));

--- a/__tests__/FileTree.test.tsx
+++ b/__tests__/FileTree.test.tsx
@@ -34,6 +34,7 @@ describe('FileTree', () => {
           noExport={new Set()}
           toggleNoExport={vi.fn()}
           openRename={vi.fn()}
+          openMove={vi.fn()}
         >
           <Wrapper />
         </AssetBrowserProvider>
@@ -66,6 +67,7 @@ describe('FileTree', () => {
           noExport={new Set()}
           toggleNoExport={vi.fn()}
           openRename={vi.fn()}
+          openMove={vi.fn()}
         >
           <Wrapper />
         </AssetBrowserProvider>

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import path from 'path';
 import RenameModal from '../modals/RenameModal';
+import MoveFileModal from '../modals/MoveFileModal';
 import AssetBrowserItem from './AssetBrowserItem';
 import { useProjectFiles } from '../file/useProjectFiles';
 import FileTree from './FileTree';
@@ -176,6 +177,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
   const { path: projectPath } = useProject();
   const { files, noExport, toggleNoExport, versions } = useProjectFiles();
   const [renameTarget, setRenameTarget] = useState<string | null>(null);
+  const [moveTarget, setMoveTarget] = useState<string | null>(null);
   const [query, setQuery] = useState('');
   const [zoom, setZoom] = useState(64);
   const [filters, setFilters] = useState<Filter[]>([]);
@@ -225,6 +227,7 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
       noExport={noExport}
       toggleNoExport={toggleNoExport}
       openRename={(file) => setRenameTarget(file)}
+      openMove={(file) => setMoveTarget(file)}
       onSelectionChange={onSelectionChange}
     >
       <BrowserBody
@@ -247,6 +250,22 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
             const target = path.join(path.dirname(full), n);
             window.electronAPI?.renameFile(full, target);
             setRenameTarget(null);
+          }}
+        />
+      )}
+      {moveTarget && (
+        <MoveFileModal
+          current={moveTarget}
+          onCancel={() => setMoveTarget(null)}
+          onMove={(dest) => {
+            const full = path.join(projectPath, moveTarget);
+            const target = path.join(
+              projectPath,
+              dest,
+              path.basename(moveTarget)
+            );
+            window.electronAPI?.renameFile(full, target);
+            setMoveTarget(null);
           }}
         />
       )}

--- a/src/renderer/components/assets/AssetBrowserItem.tsx
+++ b/src/renderer/components/assets/AssetBrowserItem.tsx
@@ -25,6 +25,7 @@ const AssetBrowserItem: React.FC<Props> = ({
     toggleNoExport,
     deleteFiles,
     openRename,
+    openMove,
   } = useAssetBrowser();
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const firstItem = useRef<HTMLButtonElement>(null);
@@ -130,6 +131,7 @@ const AssetBrowserItem: React.FC<Props> = ({
         onReveal={() => window.electronAPI?.openInFolder(full)}
         onOpen={() => window.electronAPI?.openFile(full)}
         onRename={() => openRename(file)}
+        onMove={() => openMove(file)}
         onDelete={() =>
           deleteFiles(
             selected.size > 1

--- a/src/renderer/components/assets/FileTree.tsx
+++ b/src/renderer/components/assets/FileTree.tsx
@@ -20,6 +20,7 @@ export default function FileTree({ files, versions }: Props) {
     toggleNoExport,
     deleteFiles,
     openRename,
+    openMove,
   } = useAssetBrowser();
   const { path: projectPath } = useProject();
   const data = React.useMemo<TreeItem[]>(() => buildTree(files), [files]);
@@ -109,6 +110,7 @@ export default function FileTree({ files, versions }: Props) {
             onReveal={(f) => window.electronAPI?.openInFolder(f)}
             onOpen={(f) => window.electronAPI?.openFile(f)}
             onRename={() => openRename(menuInfo.file)}
+            onMove={() => openMove(menuInfo.file)}
             onDelete={() =>
               deleteFiles(
                 selected.size > 1
@@ -203,6 +205,7 @@ export default function FileTree({ files, versions }: Props) {
           onReveal={(f) => window.electronAPI?.openInFolder(f)}
           onOpen={(f) => window.electronAPI?.openFile(f)}
           onRename={() => openRename(menuInfo.file)}
+          onMove={() => openMove(menuInfo.file)}
           onDelete={() =>
             deleteFiles(
               selected.size > 1

--- a/src/renderer/components/file/AssetContextMenu.tsx
+++ b/src/renderer/components/file/AssetContextMenu.tsx
@@ -11,6 +11,7 @@ interface Props {
   onReveal: (file: string) => void;
   onOpen: (file: string) => void;
   onRename: (file: string) => void;
+  onMove: (file: string) => void;
   onDelete: (file: string) => void;
   onToggleNoExport: (checked: boolean) => void;
 }
@@ -24,6 +25,7 @@ export default function AssetContextMenu({
   onReveal,
   onOpen,
   onRename,
+  onMove,
   onDelete,
   onToggleNoExport,
 }: Props) {
@@ -54,6 +56,15 @@ export default function AssetContextMenu({
           disabled={selectionCount > 1}
         >
           Rename
+        </Button>
+      </li>
+      <li>
+        <Button
+          role="menuitem"
+          onClick={() => onMove(filePath)}
+          disabled={selectionCount > 1}
+        >
+          Move…
         </Button>
       </li>
       <li>

--- a/src/renderer/components/modals/MoveFileModal.tsx
+++ b/src/renderer/components/modals/MoveFileModal.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef, useState } from 'react';
+import path from 'path';
+import { Modal, Button } from '../daisy/actions';
+import { InputField } from '../daisy/input';
+
+export default function MoveFileModal({
+  current,
+  onCancel,
+  onMove,
+  title = 'Move File',
+  confirmText = 'Move',
+}: {
+  current: string;
+  onCancel: () => void;
+  onMove: (dest: string) => void;
+  title?: string;
+  confirmText?: string;
+}) {
+  const [dest, setDest] = useState(path.dirname(current));
+  const inputRef = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onCancel();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        formRef.current?.requestSubmit();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onCancel]);
+
+  return (
+    <Modal open>
+      <form
+        ref={formRef}
+        className="flex flex-col gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          onMove(dest);
+        }}
+      >
+        <h3 className="font-bold text-lg">{title}</h3>
+        <InputField
+          ref={inputRef}
+          className="input-bordered"
+          value={dest}
+          onChange={(e) => setDest(e.target.value)}
+        />
+        <div className="modal-action">
+          <Button type="button" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button type="submit" className="btn-primary">
+            {confirmText}
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/renderer/components/providers/AssetBrowserProvider.tsx
+++ b/src/renderer/components/providers/AssetBrowserProvider.tsx
@@ -7,6 +7,7 @@ interface AssetBrowserContextValue {
   toggleNoExport: (files: string[], flag: boolean) => void;
   deleteFiles: (files: string[]) => void;
   openRename: (file: string) => void;
+  openMove: (file: string) => void;
 }
 
 const noop = () => {
@@ -22,6 +23,7 @@ const AssetBrowserContext = createContext<AssetBrowserContextValue>({
   toggleNoExport: noop,
   deleteFiles: noop,
   openRename: noop,
+  openMove: noop,
 });
 
 export function useAssetBrowser() {
@@ -33,6 +35,7 @@ interface ProviderProps {
   noExport: Set<string>;
   toggleNoExport: (files: string[], flag: boolean) => void;
   openRename: (file: string) => void;
+  openMove: (file: string) => void;
   onSelectionChange?: (sel: string[]) => void;
 }
 
@@ -41,6 +44,7 @@ export function AssetBrowserProvider({
   noExport,
   toggleNoExport,
   openRename,
+  openMove,
   onSelectionChange,
 }: ProviderProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -63,6 +67,7 @@ export function AssetBrowserProvider({
         toggleNoExport,
         deleteFiles,
         openRename,
+        openMove,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- add Move… option in asset context menu
- implement MoveFileModal for selecting destination directory
- support move workflow across asset components and provider
- test new move behavior in AssetBrowserItem

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685298997e588331b62da0da537b3e3d