### PR TITLE
Add onClose callback to Modal

### DIFF
--- a/__tests__/ConfirmModal.test.tsx
+++ b/__tests__/ConfirmModal.test.tsx
@@ -34,7 +34,8 @@ describe('ConfirmModal', () => {
     );
     const confirmBtn = screen.getByText('OK');
     expect(confirmBtn).toHaveFocus();
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(cancel).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(confirm).toHaveBeenCalled();

--- a/__tests__/ExportWizardModal.test.tsx
+++ b/__tests__/ExportWizardModal.test.tsx
@@ -43,7 +43,8 @@ describe('ExportWizardModal', () => {
   it('handles Escape and Enter', () => {
     const onClose = vi.fn();
     render(<ExportWizardModal summary={summary} onClose={onClose} />);
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onClose).toHaveBeenCalledTimes(2);

--- a/__tests__/ImportWizardModal.test.tsx
+++ b/__tests__/ImportWizardModal.test.tsx
@@ -24,7 +24,8 @@ describe('ImportWizardModal', () => {
     const onClose = vi.fn();
     const summary = { name: 'Pack', fileCount: 3, durationMs: 1000 };
     render(<ImportWizardModal summary={summary} onClose={onClose} />);
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onClose).toHaveBeenCalledTimes(2);

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -84,7 +84,8 @@ describe('PackMetaModal', () => {
         onCancel={onCancel}
       />
     );
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(onCancel).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onSave).toHaveBeenCalled();

--- a/__tests__/RenameModal.test.tsx
+++ b/__tests__/RenameModal.test.tsx
@@ -34,7 +34,8 @@ describe('RenameModal', () => {
     const cancel = vi.fn();
     const rename = vi.fn();
     render(<RenameModal current="a.txt" onCancel={cancel} onRename={rename} />);
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(cancel).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(rename).toHaveBeenCalledWith('a.txt');

--- a/__tests__/daisy/actions/Modal.test.tsx
+++ b/__tests__/daisy/actions/Modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
 import Modal from '../../../src/renderer/components/daisy/actions/Modal';
 
 describe('daisy Modal', () => {
@@ -13,5 +13,19 @@ describe('daisy Modal', () => {
     expect(screen.getByTestId('custom')).toBeInTheDocument();
     const root = document.getElementById('overlay-root');
     expect(root?.querySelector('dialog')).toBeInTheDocument();
+  });
+
+  it('calls onClose with Escape and backdrop click', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose}>
+        <p>Content</p>
+      </Modal>
+    );
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalled();
+    fireEvent.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(2);
   });
 });

--- a/__tests__/revisions.test.tsx
+++ b/__tests__/revisions.test.tsx
@@ -85,7 +85,8 @@ describe('Revision history', () => {
         </SetPath>
       </ProjectProvider>
     );
-    fireEvent.keyDown(window, { key: 'Escape' });
+    const dialog = screen.getByTestId('daisy-modal');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
     expect(onClose).toHaveBeenCalled();
     fireEvent.keyDown(window, { key: 'Enter' });
     expect(onClose).toHaveBeenCalledTimes(2);

--- a/src/renderer/components/daisy/actions/Modal.tsx
+++ b/src/renderer/components/daisy/actions/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 
 interface ModalProps {
@@ -6,6 +6,7 @@ interface ModalProps {
   children: React.ReactNode;
   className?: string;
   testId?: string;
+  onClose?: () => void;
 }
 
 export default function Modal({
@@ -13,12 +14,40 @@ export default function Modal({
   children,
   className = '',
   testId = 'daisy-modal',
+  onClose,
 }: ModalProps) {
   if (!open) return null;
   const root = document.getElementById('overlay-root');
   if (!root) return null;
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  useEffect(() => {
+    if (!onClose || !dialogRef.current) return;
+    const dialog = dialogRef.current;
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    const handleClick = (e: MouseEvent) => {
+      if (e.target === dialog) {
+        onClose();
+      }
+    };
+    dialog.addEventListener('keydown', handleKey);
+    dialog.addEventListener('click', handleClick);
+    return () => {
+      dialog.removeEventListener('keydown', handleKey);
+      dialog.removeEventListener('click', handleClick);
+    };
+  }, [onClose]);
   return ReactDOM.createPortal(
-    <dialog open className="modal modal-open" data-testid={testId}>
+    <dialog
+      ref={dialogRef}
+      open
+      className="modal modal-open"
+      data-testid={testId}
+    >
       <div className={`modal-box ${className}`.trim()}>{children}</div>
     </dialog>,
     root

--- a/src/renderer/components/modals/ConfirmModal.tsx
+++ b/src/renderer/components/modals/ConfirmModal.tsx
@@ -22,20 +22,17 @@ export default function ConfirmModal({
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onCancel();
-      } else if (e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         onConfirm();
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onCancel, onConfirm]);
+  }, [onConfirm]);
 
   return (
-    <Modal open>
+    <Modal open onClose={onCancel}>
       <h3 className="font-bold text-lg mb-2">{title}</h3>
       <div>{message}</div>
       <div className="modal-action">

--- a/src/renderer/components/modals/ExportWizardModal.tsx
+++ b/src/renderer/components/modals/ExportWizardModal.tsx
@@ -30,7 +30,7 @@ export default function ExportWizardModal({
   useEffect(() => {
     if (!summary) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' || e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         onClose();
       }
@@ -59,7 +59,7 @@ export default function ExportWizardModal({
     const sizeMB = (summary.totalSize / (1024 * 1024)).toFixed(2);
     const seconds = (summary.durationMs / 1000).toFixed(1);
     return (
-      <Modal open>
+      <Modal open onClose={onClose}>
         <h3 className="font-bold text-lg mb-2">Export Complete</h3>
         <p>
           {summary.fileCount} files, {sizeMB} MB

--- a/src/renderer/components/modals/ImportWizardModal.tsx
+++ b/src/renderer/components/modals/ImportWizardModal.tsx
@@ -23,7 +23,7 @@ export default function ImportWizardModal({
   useEffect(() => {
     if (!summary) return;
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' || e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         onClose();
       }
@@ -43,7 +43,7 @@ export default function ImportWizardModal({
   if (summary) {
     const seconds = (summary.durationMs / 1000).toFixed(1);
     return (
-      <Modal open>
+      <Modal open onClose={onClose}>
         <h3 className="font-bold text-lg mb-2">Import Complete</h3>
         <p>
           Imported {summary.fileCount} files into {summary.name}

--- a/src/renderer/components/modals/PackMetaModal.tsx
+++ b/src/renderer/components/modals/PackMetaModal.tsx
@@ -30,17 +30,14 @@ export function PackMetaForm({
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onCancel?.();
-      } else if (e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         formRef.current?.requestSubmit();
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onCancel]);
+  }, []);
 
   return (
     <form
@@ -147,7 +144,7 @@ export default function PackMetaModal(props: {
   onCancel: () => void;
 }) {
   return (
-    <Modal open>
+    <Modal open onClose={props.onCancel}>
       <PackMetaForm {...props} />
     </Modal>
   );

--- a/src/renderer/components/modals/RenameModal.tsx
+++ b/src/renderer/components/modals/RenameModal.tsx
@@ -26,20 +26,17 @@ export default function RenameModal({
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onCancel();
-      } else if (e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         formRef.current?.requestSubmit();
       }
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onCancel]);
+  }, []);
 
   return (
-    <Modal open>
+    <Modal open onClose={onCancel}>
       <form
         ref={formRef}
         className="flex flex-col gap-2"

--- a/src/renderer/components/modals/RevisionsModal.tsx
+++ b/src/renderer/components/modals/RevisionsModal.tsx
@@ -22,7 +22,7 @@ export default function RevisionsModal({
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' || e.key === 'Enter') {
+      if (e.key === 'Enter') {
         e.preventDefault();
         onClose();
       }
@@ -54,7 +54,7 @@ export default function RevisionsModal({
   const basename = (rev: string) => path.parse(rev).name;
 
   return (
-    <Modal open className="max-w-sm">
+    <Modal open onClose={onClose} className="max-w-sm">
       <h3 className="font-bold text-lg mb-2">Revisions</h3>
       <ul className="menu bg-base-200 rounded-box mb-2 max-h-60 overflow-y-auto">
         {list.map((rev) => (


### PR DESCRIPTION
## Summary
- support `onClose` in `Modal` component
- update modal components to use new close callback
- handle closing via Escape or backdrop in Modal
- adjust tests for new close behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852989e55d08331b9b872eacdea18b4