### PR TITLE
Implement warning for missing project metadata

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -101,6 +101,7 @@ describe('App', () => {
       setEditorLayout: vi.fn(),
       loadPackMeta: vi.fn(async () => ({ version: '1.21.1', description: '' })),
       getConfetti,
+      onPackMetaMissing: vi.fn(),
     };
     getConfetti.mockResolvedValue(true);
   });

--- a/__tests__/projectIPC.test.ts
+++ b/__tests__/projectIPC.test.ts
@@ -1,4 +1,19 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { v4 as uuid } from 'uuid';
+var sendMock: ReturnType<typeof vi.fn>;
+vi.mock('electron', () => {
+  const send = vi.fn();
+  sendMock = send;
+  return {
+    BrowserWindow: {
+      getAllWindows: () => [{ webContents: { send } }],
+    },
+    app: { getPath: () => '/tmp', whenReady: () => Promise.resolve(), on: vi.fn() },
+  };
+});
 vi.mock('../src/main/icon', () => ({
   generatePackIcon: vi.fn().mockResolvedValue(undefined),
 }));
@@ -7,19 +22,52 @@ import * as projects from '../src/main/projects';
 let createHandler:
   | ((e: unknown, name: string, version: string) => void | Promise<void>)
   | undefined;
+let openHandler:
+  | ((e: unknown, name: string) => Promise<void> | void)
+  | undefined;
+let loadHandler: ((e: unknown, name: string) => Promise<unknown>) | undefined;
 
 const ipcMainMock: {
   handle: (channel: string, fn: (...a: unknown[]) => unknown) => void;
 } = {
   handle: (channel: string, fn: (...a: unknown[]) => unknown) => {
     if (channel === 'create-project') createHandler = fn;
+    if (channel === 'open-project') openHandler = fn as typeof openHandler;
+    if (channel === 'load-pack-meta') loadHandler = fn as typeof loadHandler;
   },
 };
 
+const baseDir = path.join(os.tmpdir(), `proj-${uuid()}`);
+
+beforeAll(() => {
+  fs.mkdirSync(baseDir, { recursive: true });
+});
+
+afterAll(() => {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+});
+
 describe('create-project IPC', () => {
   it('registers handler and executes without error', async () => {
-    projects.registerProjectHandlers(ipcMainMock, '/tmp/base', vi.fn());
+    projects.registerProjectHandlers(ipcMainMock, baseDir, vi.fn());
     expect(createHandler).toBeTypeOf('function');
     await expect(createHandler?.({}, 'Test', '1.21')).resolves.toBeUndefined();
+  });
+});
+
+describe('open-project IPC', () => {
+  it('emits pack-meta-missing when metadata absent', async () => {
+    projects.registerProjectHandlers(ipcMainMock, baseDir, vi.fn());
+    await openHandler?.({}, 'Missing').catch(() => {});
+    expect(sendMock).toHaveBeenCalledWith(
+      'pack-meta-missing',
+      path.join(baseDir, 'Missing')
+    );
+    sendMock.mockClear();
+    await loadHandler?.({}, 'Missing');
+    expect(sendMock).toHaveBeenCalledWith(
+      'pack-meta-missing',
+      path.join(baseDir, 'Missing')
+    );
   });
 });

--- a/src/main/projects/manager.ts
+++ b/src/main/projects/manager.ts
@@ -3,6 +3,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { BrowserWindow } from 'electron';
 import { generatePackIcon } from '../icon';
 import type { ProjectMetadata } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
@@ -84,6 +85,10 @@ export async function openProject(
     } catch {
       // ignore corrupted metadata
     }
+  } else {
+    BrowserWindow.getAllWindows().forEach((w) =>
+      w.webContents.send('pack-meta-missing', projectPath)
+    );
   }
   return projectPath;
 }

--- a/src/main/projects/meta.ts
+++ b/src/main/projects/meta.ts
@@ -3,6 +3,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import { BrowserWindow } from 'electron';
 import type { PackMeta, ProjectMetadata } from '../../shared/project';
 import { PackMetaSchema } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
@@ -19,6 +20,10 @@ export async function loadPackMeta(
     } catch {
       // ignore malformed data
     }
+  } else {
+    BrowserWindow.getAllWindows().forEach((w) =>
+      w.webContents.send('pack-meta-missing', projectPath)
+    );
   }
   return {
     version: 'unknown',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -108,6 +108,8 @@ const api = {
   onFileChanged: (
     listener: (e: unknown, args: { path: string; stamp: number }) => void
   ) => on('file-changed', listener),
+  onPackMetaMissing: (listener: (e: unknown, path: string) => void) =>
+    on('pack-meta-missing', listener),
   loadPackMeta: (name: string) => invoke('load-pack-meta', name),
   savePackMeta: (name: string, meta: import('../main/projects').PackMeta) =>
     invoke('save-pack-meta', name, meta),

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -14,9 +14,11 @@ const SettingsView = lazy(() => import('../views/SettingsView'));
 const AboutView = lazy(() => import('../views/AboutView'));
 
 import { ProjectProvider, useProject } from './providers/ProjectProvider';
+import { useToast } from './providers/ToastProvider';
 
 function AppContent() {
   const { path: projectPath, setPath: setProjectPath } = useProject();
+  const toast = useToast();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -24,7 +26,10 @@ function AppContent() {
       setProjectPath(path);
       navigate('/editor');
     });
-  }, [navigate, setProjectPath]);
+    window.electronAPI?.onPackMetaMissing(() => {
+      toast({ message: 'project.json not found', type: 'warning' });
+    });
+  }, [navigate, setProjectPath, toast]);
 
   const toManager = () => {
     setProjectPath(null);

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -71,6 +71,7 @@ declare global {
       setLastProject: IpcInvoke<'set-last-project'>;
       openExternalEditor: IpcInvoke<'open-external-editor'>;
       onOpenProject: IpcListener<'project-opened'>;
+      onPackMetaMissing: IpcListener<'pack-meta-missing'>;
       onFileAdded: IpcListener<'file-added'>;
       onFileRemoved: IpcListener<'file-removed'>;
       onFileRenamed: IpcListener<'file-renamed'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -124,6 +124,7 @@ export interface IpcResponseMap {
 
 export interface IpcEventMap {
   'project-opened': string;
+  'pack-meta-missing': string;
   'file-added': string;
   'file-removed': string;
   'file-renamed': { oldPath: string; newPath: string };


### PR DESCRIPTION
## Summary
- emit `pack-meta-missing` IPC event when `project.json` is absent
- forward this event from preload and show a toast in the renderer
- update types for the new IPC event
- add unit tests covering the new behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685298a676bc8331bed8d0722b0a5907