### PR TITLE
Add project context menu

### DIFF
--- a/__tests__/ProjectManagerView.test.tsx
+++ b/__tests__/ProjectManagerView.test.tsx
@@ -239,4 +239,35 @@ describe('ProjectManagerView', () => {
     await screen.findByText('New');
     expect(screen.getByText('New')).toBeInTheDocument();
   });
+
+  it('shows context menu on right click', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const row = screen.getAllByRole('row')[1];
+    fireEvent.contextMenu(row);
+    expect(screen.getByRole('menuitem', { name: 'Open' })).toBeInTheDocument();
+  });
+
+  it('context menu actions work', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const row = screen.getAllByRole('row')[1];
+    fireEvent.contextMenu(row);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
+    expect(openProject).toHaveBeenCalledWith('Alpha');
+
+    fireEvent.contextMenu(row);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
+    const modal = await screen.findByTestId('daisy-modal');
+    const input = modal.querySelector('input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Alpha Copy' } });
+    fireEvent.submit(input.closest('form') as HTMLFormElement);
+    expect(duplicateProject).toHaveBeenCalledWith('Alpha', 'Alpha Copy');
+
+    fireEvent.contextMenu(row);
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    const delModal = await screen.findByTestId('daisy-modal');
+    fireEvent.click(within(delModal).getByText('Delete'));
+    expect(deleteProject).toHaveBeenCalledWith('Alpha');
+  });
 });

--- a/src/renderer/components/project/ProjectContextMenu.tsx
+++ b/src/renderer/components/project/ProjectContextMenu.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Button } from '../daisy/actions';
+
+interface Props {
+  project: string;
+  style?: React.CSSProperties;
+  firstItemRef?: React.Ref<HTMLButtonElement>;
+  onOpen: (name: string) => void;
+  onDuplicate: (name: string) => void;
+  onDelete: (name: string) => void;
+}
+
+export default function ProjectContextMenu({
+  project,
+  style,
+  firstItemRef,
+  onOpen,
+  onDuplicate,
+  onDelete,
+}: Props) {
+  return (
+    <ul
+      className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
+      style={style}
+      role="menu"
+    >
+      <li>
+        <Button
+          ref={firstItemRef}
+          role="menuitem"
+          onClick={() => onOpen(project)}
+        >
+          Open
+        </Button>
+      </li>
+      <li>
+        <Button role="menuitem" onClick={() => onDuplicate(project)}>
+          Duplicate
+        </Button>
+      </li>
+      <li>
+        <Button role="menuitem" onClick={() => onDelete(project)}>
+          Delete
+        </Button>
+      </li>
+    </ul>
+  );
+}

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -15,7 +15,6 @@ import useProjectList from '../hooks/useProjectList';
 import useProjectSelection from '../hooks/useProjectSelection';
 import ImportWizardModal from '../components/modals/ImportWizardModal';
 import type { ImportSummary } from '../../main/projects';
-import useProjectHotkeys from '../hooks/useProjectHotkeys';
 
 // Lists all available projects and lets the user open them.
 


### PR DESCRIPTION
## Summary
- add `ProjectContextMenu` with Open, Duplicate, Delete actions
- show this menu from `ProjectTable` on right-click or ContextMenu key
- support menu focus handling and action callbacks
- test menu appearance and actions in ProjectManagerView
- clean unused import

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685298b96d008331ad52b3b02c15d1f3