### PR TITLE
Refactor context menus to use portal

### DIFF
--- a/__tests__/AssetContextMenu.test.tsx
+++ b/__tests__/AssetContextMenu.test.tsx
@@ -24,6 +24,8 @@ describe('AssetContextMenu', () => {
         onToggleNoExport={toggle}
       />
     );
+    const root = document.getElementById('overlay-root');
+    expect(root?.querySelector('ul')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
     expect(reveal).toHaveBeenCalledWith('/proj/a.txt');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));

--- a/__tests__/AssetSelectorContextMenu.test.tsx
+++ b/__tests__/AssetSelectorContextMenu.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AssetSelectorContextMenu from '../src/renderer/components/assets/AssetSelectorContextMenu';
+
+describe('AssetSelectorContextMenu', () => {
+  it('fires callbacks and renders to overlay root', () => {
+    const add = vi.fn();
+    const reveal = vi.fn();
+    render(
+      <AssetSelectorContextMenu
+        asset="grass.png"
+        onAdd={add}
+        onReveal={reveal}
+      />
+    );
+    const root = document.getElementById('overlay-root');
+    expect(root?.querySelector('ul')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add to Project' }));
+    expect(add).toHaveBeenCalledWith('grass.png');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Reveal' }));
+    expect(reveal).toHaveBeenCalledWith('grass.png');
+  });
+});

--- a/__tests__/ProjectContextMenu.test.tsx
+++ b/__tests__/ProjectContextMenu.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectContextMenu from '../src/renderer/components/project/ProjectContextMenu';
+
+describe('ProjectContextMenu', () => {
+  it('fires callbacks and renders to overlay root', () => {
+    const open = vi.fn();
+    const dup = vi.fn();
+    const del = vi.fn();
+    render(
+      <ProjectContextMenu
+        project="Test"
+        onOpen={open}
+        onDuplicate={dup}
+        onDelete={del}
+      />
+    );
+    const root = document.getElementById('overlay-root');
+    expect(root?.querySelector('ul')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
+    expect(open).toHaveBeenCalledWith('Test');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
+    expect(dup).toHaveBeenCalledWith('Test');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+    expect(del).toHaveBeenCalledWith('Test');
+  });
+});

--- a/src/renderer/components/assets/AssetSelectorContextMenu.tsx
+++ b/src/renderer/components/assets/AssetSelectorContextMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '../daisy/actions';
 
 interface Props {
@@ -16,7 +17,9 @@ export default function AssetSelectorContextMenu({
   onAdd,
   onReveal,
 }: Props) {
-  return (
+  const root = document.getElementById('overlay-root');
+  if (!root) return null;
+  return ReactDOM.createPortal(
     <ul
       className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
       style={style}
@@ -32,6 +35,7 @@ export default function AssetSelectorContextMenu({
           Reveal
         </Button>
       </li>
-    </ul>
+    </ul>,
+    root
   );
 }

--- a/src/renderer/components/file/AssetContextMenu.tsx
+++ b/src/renderer/components/file/AssetContextMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '../daisy/actions';
 import { Checkbox } from '../daisy/input';
 
@@ -29,7 +30,9 @@ export default function AssetContextMenu({
   onDelete,
   onToggleNoExport,
 }: Props) {
-  return (
+  const root = document.getElementById('overlay-root');
+  if (!root) return null;
+  return ReactDOM.createPortal(
     <ul
       className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
       style={style}
@@ -83,6 +86,7 @@ export default function AssetContextMenu({
           {selectionCount > 1 ? 'Delete Selected' : 'Delete'}
         </Button>
       </li>
-    </ul>
+    </ul>,
+    root
   );
 }

--- a/src/renderer/components/project/ProjectContextMenu.tsx
+++ b/src/renderer/components/project/ProjectContextMenu.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { Button } from '../daisy/actions';
 
 interface Props {
@@ -18,7 +19,9 @@ export default function ProjectContextMenu({
   onDuplicate,
   onDelete,
 }: Props) {
-  return (
+  const root = document.getElementById('overlay-root');
+  if (!root) return null;
+  return ReactDOM.createPortal(
     <ul
       className="menu dropdown-content bg-base-200 rounded-box fixed z-50 w-40 p-1 shadow"
       style={style}
@@ -43,6 +46,7 @@ export default function ProjectContextMenu({
           Delete
         </Button>
       </li>
-    </ul>
+    </ul>,
+    root
   );
 }


### PR DESCRIPTION
## Summary
- render `AssetContextMenu` in portal to `#overlay-root`
- render `AssetSelectorContextMenu` and `ProjectContextMenu` in portal
- add tests for the new context menus
- update `AssetContextMenu` test for portal rendering

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a88d102883319a18a21b9a96f56a