### PR TITLE
Fix context menu focus blur

### DIFF
--- a/src/renderer/components/assets/AssetBrowserItem.tsx
+++ b/src/renderer/components/assets/AssetBrowserItem.tsx
@@ -91,7 +91,12 @@ const AssetBrowserItem: React.FC<Props> = ({
       onContextMenu={handleContext}
       onKeyDown={handleKey}
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        const overlay = document.getElementById('overlay-root');
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(overlay && overlay.contains(next))
+        ) {
           closeMenu();
         }
       }}

--- a/src/renderer/components/assets/AssetSelector.tsx
+++ b/src/renderer/components/assets/AssetSelector.tsx
@@ -130,7 +130,12 @@ const AssetSelector: React.FC<Props> = ({ onAssetSelect }) => {
       className="mb-4"
       tabIndex={0}
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+        const overlay = document.getElementById('overlay-root');
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(overlay && overlay.contains(next))
+        ) {
           closeMenu();
         }
       }}

--- a/src/renderer/components/assets/FileTree.tsx
+++ b/src/renderer/components/assets/FileTree.tsx
@@ -64,7 +64,13 @@ export default function FileTree({ files, versions }: Props) {
         data-testid="file-tree"
         tabIndex={0}
         onBlur={(e) => {
-          if (!e.currentTarget.contains(e.relatedTarget as Node)) closeMenu();
+          const overlay = document.getElementById('overlay-root');
+          const next = e.relatedTarget as Node | null;
+          if (
+            !e.currentTarget.contains(next) &&
+            !(overlay && overlay.contains(next))
+          )
+            closeMenu();
         }}
       >
         {files.map((f) => (
@@ -136,7 +142,13 @@ export default function FileTree({ files, versions }: Props) {
       data-testid="file-tree"
       tabIndex={0}
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) closeMenu();
+        const overlay = document.getElementById('overlay-root');
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(overlay && overlay.contains(next))
+        )
+          closeMenu();
       }}
     >
       <Tree

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -81,7 +81,13 @@ export default function ProjectTable({
       className="flex-1 overflow-x-auto"
       tabIndex={0}
       onBlur={(e) => {
-        if (!e.currentTarget.contains(e.relatedTarget as Node)) closeMenu();
+        const overlay = document.getElementById('overlay-root');
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(overlay && overlay.contains(next))
+        )
+          closeMenu();
       }}
     >
       <table className="table table-zebra w-full">


### PR DESCRIPTION
## Summary
- prevent blur handlers from hiding context menus when focus moves to overlay

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852b20933f4833181e86043a648ff92