### PR TITLE
Fix temp dir usage in tests

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,8 @@
 import React, { Suspense } from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, act, fireEvent } from '@testing-library/react';
+import os from 'os';
+import path from 'path';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import App from '../src/renderer/components/App';
@@ -67,6 +69,8 @@ const renderApp = () =>
     </MemoryRouter>
   );
 
+const proj = path.join(os.tmpdir(), 'proj');
+
 describe('App', () => {
   let openHandler: ((e: unknown, path: string) => void) | undefined;
   const exportProject = vi.fn();
@@ -109,16 +113,16 @@ describe('App', () => {
     renderApp();
     await screen.findByText('manager');
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
-    await screen.findByText('/tmp/proj');
+    await screen.findByText(proj);
     expect(window.location.hash).toBe('#/editor');
   });
 
   it('invokes exportProject when button clicked', async () => {
     renderApp();
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
     await screen.findByText('Export Pack');
     const btn = screen.getByText('Export Pack');
@@ -129,13 +133,13 @@ describe('App', () => {
       warnings: [],
     });
     fireEvent.click(btn);
-    expect(exportProject).toHaveBeenCalledWith('/tmp/proj');
+    expect(exportProject).toHaveBeenCalledWith(proj);
   });
 
   it('fires confetti after successful export', async () => {
     renderApp();
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
     exportProject.mockResolvedValueOnce({
       fileCount: 1,
@@ -160,7 +164,7 @@ describe('App', () => {
     });
     renderApp();
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
     exportProject.mockResolvedValueOnce({
       fileCount: 1,
@@ -181,7 +185,7 @@ describe('App', () => {
     getConfetti.mockResolvedValueOnce(false);
     renderApp();
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
     await screen.findByText('Export Pack');
     await act(async () => {
@@ -205,7 +209,7 @@ describe('App', () => {
   it('shows summary modal after export', async () => {
     renderApp();
     act(() => {
-      openHandler?.({}, '/tmp/proj');
+      openHandler?.({}, proj);
     });
     exportProject.mockResolvedValueOnce({
       fileCount: 2,

--- a/__tests__/EditorView.test.tsx
+++ b/__tests__/EditorView.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
+import os from 'os';
+import path from 'path';
 import {
   ProjectProvider,
   useProject,
@@ -72,20 +74,21 @@ describe('EditorView', () => {
   });
 
   it('shows project path and exports pack', async () => {
+    const proj = path.join(os.tmpdir(), 'proj');
     render(
       <ProjectProvider>
-        <SetPath path="/tmp/proj">
+        <SetPath path={proj}>
           <EditorView onBack={() => undefined} />
         </SetPath>
       </ProjectProvider>
     );
-    expect(screen.getByText('/tmp/proj')).toBeInTheDocument();
+    expect(screen.getByText(proj)).toBeInTheDocument();
     const btn = screen.getByText('Export Pack');
     await act(async () => {
       fireEvent.click(btn);
       await Promise.resolve();
     });
-    expect(exportProject).toHaveBeenCalledWith('/tmp/proj');
+    expect(exportProject).toHaveBeenCalledWith(proj);
     expect(screen.getByTestId('daisy-modal')).toBeInTheDocument();
   });
 
@@ -93,7 +96,7 @@ describe('EditorView', () => {
     const back = vi.fn();
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
+        <SetPath path={os.tmpdir()}>
           <EditorView onBack={back} />
         </SetPath>
       </ProjectProvider>
@@ -105,7 +108,7 @@ describe('EditorView', () => {
   it('opens help link externally', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
+        <SetPath path={os.tmpdir()}>
           <EditorView onBack={() => undefined} />
         </SetPath>
       </ProjectProvider>
@@ -122,7 +125,7 @@ describe('EditorView', () => {
   it('opens asset selector modal', () => {
     render(
       <ProjectProvider>
-        <SetPath path="/tmp">
+        <SetPath path={os.tmpdir()}>
           <EditorView onBack={() => undefined} />
         </SetPath>
       </ProjectProvider>

--- a/__tests__/ExporterTab.test.tsx
+++ b/__tests__/ExporterTab.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import os from 'os';
+import path from 'path';
 import ExporterTab from '../src/renderer/components/editor/ExporterTab';
 import { ProjectProvider } from '../src/renderer/components/providers/ProjectProvider';
 import { EditorProvider } from '../src/renderer/components/editor';
@@ -11,7 +13,7 @@ describe('ExporterTab', () => {
     const onExport = vi.fn();
     render(
       <ProjectProvider>
-        <SetPath path="/tmp/proj">
+        <SetPath path={path.join(os.tmpdir(), 'proj')}>
           <EditorProvider value={{ selected: [], setSelected: vi.fn() }}>
             <ExporterTab onExport={onExport} />
           </EditorProvider>

--- a/__tests__/PackIconEditor.test.tsx
+++ b/__tests__/PackIconEditor.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import os from 'os';
+import path from 'path';
 import PackIconEditor from '../src/renderer/components/project/PackIconEditor';
 
 describe('PackIconEditor', () => {
@@ -17,9 +19,10 @@ describe('PackIconEditor', () => {
       randomizeIcon: randomise,
       savePackIcon: vi.fn(),
     } as never;
-    render(<PackIconEditor project="/tmp/proj" onClose={() => undefined} />);
+    const proj = path.join(os.tmpdir(), 'proj');
+    render(<PackIconEditor project={proj} onClose={() => undefined} />);
     fireEvent.click(screen.getByText('Randomise'));
-    expect(randomise).toHaveBeenCalledWith('/tmp/proj');
+    expect(randomise).toHaveBeenCalledWith(proj);
   });
 
   it('saves uploaded file with border colour', () => {
@@ -32,9 +35,11 @@ describe('PackIconEditor', () => {
       randomizeIcon: vi.fn(),
       savePackIcon: save,
     } as never;
-    render(<PackIconEditor project="/tmp/proj" onClose={() => undefined} />);
+    const proj = path.join(os.tmpdir(), 'proj');
+    render(<PackIconEditor project={proj} onClose={() => undefined} />);
     const file = new File(['a'], 'icon.png', { type: 'image/png' });
-    Object.defineProperty(file, 'path', { value: '/tmp/icon.png' });
+    const iconPath = path.join(os.tmpdir(), 'icon.png');
+    Object.defineProperty(file, 'path', { value: iconPath });
     fireEvent.change(screen.getByTestId('file-input'), {
       target: { files: [file] },
     });
@@ -45,6 +50,6 @@ describe('PackIconEditor', () => {
       .getByTestId('file-input')
       .closest('form') as HTMLFormElement;
     fireEvent.submit(form);
-    expect(save).toHaveBeenCalledWith('/tmp/proj', '/tmp/icon.png', '#ff00ff');
+    expect(save).toHaveBeenCalledWith(proj, iconPath, '#ff00ff');
   });
 });

--- a/__tests__/PackMetaModal.randomize.test.tsx
+++ b/__tests__/PackMetaModal.randomize.test.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 import { render, fireEvent, screen } from '@testing-library/react';
 import path from 'path';
 import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('PackMetaModal randomize regression', () => {
   it('sends absolute path to randomizeIcon', () => {
@@ -32,7 +33,7 @@ describe('PackMetaModal randomize regression', () => {
     );
     fireEvent.click(screen.getByText('Randomize Icon'));
     expect(randomize).toHaveBeenCalledWith(
-      path.join('/tmp', 'projects', 'Pack')
+      path.join(os.tmpdir(), 'projects', 'Pack')
     );
   });
 });

--- a/__tests__/PackMetaModal.test.tsx
+++ b/__tests__/PackMetaModal.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 import { fireEvent, render, screen } from '@testing-library/react';
 import path from 'path';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';
 
@@ -61,7 +62,7 @@ describe('PackMetaModal', () => {
     );
     fireEvent.click(screen.getByText('Randomize Icon'));
     expect(randomize).toHaveBeenCalledWith(
-      path.join('/tmp', 'projects', 'Pack')
+      path.join(os.tmpdir(), 'projects', 'Pack')
     );
   });
 

--- a/__tests__/confettiPersistence.test.ts
+++ b/__tests__/confettiPersistence.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 
 import { setConfetti } from '../src/main/layout';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('confetti persistence', () => {
   it('persists across reloads', async () => {

--- a/__tests__/defaultExportDirPersistence.test.ts
+++ b/__tests__/defaultExportDirPersistence.test.ts
@@ -1,13 +1,16 @@
 import { describe, it, expect, vi } from 'vitest';
 import { setDefaultExportDir } from '../src/main/layout';
-
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+import os from 'os';
+vi.mock('electron', async () => {
+  const osModule = await import('os');
+  return { app: { getPath: () => osModule.tmpdir() } };
+});
 
 describe('default export dir persistence', () => {
   it('persists across reloads', async () => {
-    setDefaultExportDir('/tmp');
+    setDefaultExportDir(os.tmpdir());
     vi.resetModules();
     const { getDefaultExportDir } = await import('../src/main/layout');
-    expect(getDefaultExportDir()).toBe('/tmp');
+    expect(getDefaultExportDir()).toBe(os.tmpdir());
   });
 });

--- a/__tests__/exportDirPersistence.test.tsx
+++ b/__tests__/exportDirPersistence.test.tsx
@@ -17,7 +17,7 @@ vi.mock('electron', () => {
       showOpenDialog: showOpenDialogMock,
       showSaveDialog: showSaveDialogMock,
     },
-    app: { getPath: () => '/tmp' },
+    app: { getPath: () => os.tmpdir() },
   };
 });
 

--- a/__tests__/exportProjects.test.ts
+++ b/__tests__/exportProjects.test.ts
@@ -17,7 +17,7 @@ vi.mock('electron', () => {
   showOpenDialogMock = vi.fn();
   return {
     dialog: { showOpenDialog: showOpenDialogMock },
-    app: { getPath: () => '/tmp' },
+    app: { getPath: () => os.tmpdir() },
   };
 });
 

--- a/__tests__/exporter.test.ts
+++ b/__tests__/exporter.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+import os from 'os';
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 import { exportPack } from '../src/main/exporter';
 import unzipper from 'unzipper';
-import os from 'os';
 import { v4 as uuid } from 'uuid';
 
 const tmpDir = path.join(os.tmpdir(), `packtest-${uuid()}`);

--- a/__tests__/externalEditorIPC.test.ts
+++ b/__tests__/externalEditorIPC.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
 
 // Capture the IPC handler registered by registerExternalEditorHandlers
 // eslint-disable-next-line no-var
@@ -33,10 +35,11 @@ registerExternalEditorHandlers(
 describe('open-external-editor IPC', () => {
   it('spawns configured editor with file path', async () => {
     expect(handler).toBeTypeOf('function');
-    await handler?.({}, '/tmp/a.png');
+    const file = path.join(os.tmpdir(), 'a.png');
+    await handler?.({}, file);
     const { saveRevisionForFile } = await import('../src/main/revision');
-    expect(saveRevisionForFile).toHaveBeenCalledWith('/tmp/a.png');
-    expect(spawnMock).toHaveBeenCalledWith('/usr/bin/gimp', ['/tmp/a.png'], {
+    expect(saveRevisionForFile).toHaveBeenCalledWith(file);
+    expect(spawnMock).toHaveBeenCalledWith('/usr/bin/gimp', [file], {
       detached: true,
       stdio: 'ignore',
     });

--- a/__tests__/importZipVersion.test.ts
+++ b/__tests__/importZipVersion.test.ts
@@ -12,7 +12,7 @@ vi.mock('electron', () => {
   showOpenDialogMock = vi.fn();
   return {
     dialog: { showOpenDialog: showOpenDialogMock },
-    app: { getPath: () => '/tmp' },
+    app: { getPath: () => os.tmpdir() },
   };
 });
 

--- a/__tests__/jsonEditor.test.tsx
+++ b/__tests__/jsonEditor.test.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import os from 'os';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 import PackMetaModal from '../src/renderer/components/modals/PackMetaModal';
 import type { PackMeta } from '../src/main/projects';

--- a/__tests__/openFile.test.ts
+++ b/__tests__/openFile.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
 
 // Capture the IPC handler registered by registerFileHandlers
 // eslint-disable-next-line no-var
@@ -11,7 +13,7 @@ vi.mock('electron', () => {
   openPathMock = vi.fn();
   return {
     app: {
-      getPath: () => '/tmp',
+      getPath: () => os.tmpdir(),
       whenReady: () => Promise.resolve(),
       on: vi.fn(),
     },
@@ -38,7 +40,8 @@ registerFileHandlers(ipcMainMock as unknown as import('electron').IpcMain);
 describe('open-file IPC', () => {
   it('calls shell.openPath with the provided path', async () => {
     expect(openHandler).toBeTypeOf('function');
-    await openHandler?.({}, '/tmp/foo.txt');
-    expect(openPathMock).toHaveBeenCalledWith('/tmp/foo.txt');
+    const file = path.join(os.tmpdir(), 'foo.txt');
+    await openHandler?.({}, file);
+    expect(openPathMock).toHaveBeenCalledWith(file);
   });
 });

--- a/__tests__/openLastProject.test.tsx
+++ b/__tests__/openLastProject.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import os from 'os';
 
 import SettingsView from '../src/renderer/views/SettingsView';
 import ToastProvider from '../src/renderer/components/providers/ToastProvider';
@@ -43,7 +44,7 @@ beforeEach(() => {
   getTextureEditor.mockResolvedValue('');
   getTheme.mockResolvedValue('system');
   getConfetti.mockResolvedValue(true);
-  getDefaultExportDir.mockResolvedValue('/tmp');
+  getDefaultExportDir.mockResolvedValue(os.tmpdir());
   getOpenLastProject.mockResolvedValue(true);
   setOpenLastProject.mockResolvedValue(undefined);
 });

--- a/__tests__/projectIPC.test.ts
+++ b/__tests__/projectIPC.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
 vi.mock('../src/main/icon', () => ({
   generatePackIcon: vi.fn().mockResolvedValue(undefined),
 }));
@@ -18,7 +20,11 @@ const ipcMainMock: {
 
 describe('create-project IPC', () => {
   it('registers handler and executes without error', async () => {
-    projects.registerProjectHandlers(ipcMainMock, '/tmp/base', vi.fn());
+    projects.registerProjectHandlers(
+      ipcMainMock,
+      path.join(os.tmpdir(), 'base'),
+      vi.fn()
+    );
     expect(createHandler).toBeTypeOf('function');
     await expect(createHandler?.({}, 'Test', '1.21')).resolves.toBeUndefined();
   });

--- a/__tests__/projectSortPersistence.test.ts
+++ b/__tests__/projectSortPersistence.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 import { setProjectSort } from '../src/main/layout';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('project sort persistence', () => {
   it('persists across reloads', async () => {

--- a/__tests__/themePersistence.test.ts
+++ b/__tests__/themePersistence.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 
 import { setTheme } from '../src/main/layout';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('theme persistence', () => {
   it('persists across reloads', async () => {

--- a/__tests__/windowBounds.test.ts
+++ b/__tests__/windowBounds.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
 import { setWindowBounds, setMaximized } from '../src/main/windowBounds';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('window bounds persistence', () => {
   it('persists across reloads', async () => {

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -2,7 +2,9 @@ import { afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 
-vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }));
+import os from 'os';
+
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary
- ensure tests use `os.tmpdir()` via electron mock
- refactor various tests to construct paths with `os.tmpdir()`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Unable to find option name in ProjectManagerView)*

------
https://chatgpt.com/codex/tasks/task_e_6852b5d677588331b768beb080350cb3