### PR TITLE
Simplify project metadata creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ A task is _complete_ when:
 3. The feature appears in the UI without console errors,
 4. All files lint clean (`npm run lint`),
 5. There are no type errors (`npm run typecheck`),
-5. Code is formatted (`npm run format`).
+6. Code is formatted (`npm run format`).
 
 ## Bad practices to avoid
 

--- a/docs/custom_sounds_tutorial.md
+++ b/docs/custom_sounds_tutorial.md
@@ -1,12 +1,12 @@
 # Custom Sounds Tutorial
 
-Getting custom audio into Minecraft boils down to four repeatable steps—convert → place → reference → test.  You put `.ogg` files under `assets/<namespace>/sounds/…`, list the file-paths in `sounds.json` under a **sound-event key** (such as `entity.wolf.howl`), zip the pack, press **F3 + T** to reload, and Minecraft plays your sound instead of vanilla’s.  The guide below walks through every step—including how to discover the right event names, convert audio to Ogg Vorbis, debug silent files, and handle multiple variants—so you can drop it straight into a `docs/sound-pack-tutorial.md` file.
+Getting custom audio into Minecraft boils down to four repeatable steps—convert → place → reference → test. You put `.ogg` files under `assets/<namespace>/sounds/…`, list the file-paths in `sounds.json` under a **sound-event key** (such as `entity.wolf.howl`), zip the pack, press **F3 + T** to reload, and Minecraft plays your sound instead of vanilla’s. The guide below walks through every step—including how to discover the right event names, convert audio to Ogg Vorbis, debug silent files, and handle multiple variants—so you can drop it straight into a `docs/sound-pack-tutorial.md` file.
 
 ## 1 — Prerequisites
 
-* Minecraft Java Edition 1.6 or newer (asset-index system).
-* Audio in **Ogg Vorbis** format—MP3/WAV will be ignored. ([mcreator.net][1])
-* A zip-ready resource-pack folder with a valid `pack.mcmeta`.
+- Minecraft Java Edition 1.6 or newer (asset-index system).
+- Audio in **Ogg Vorbis** format—MP3/WAV will be ignored. ([mcreator.net][1])
+- A zip-ready resource-pack folder with a valid `pack.mcmeta`.
 
 > **Tip:** Keep filenames lowercase and avoid spaces; Minecraft doesn’t care, but command blocks and mods often do.
 
@@ -24,8 +24,8 @@ YourPack/
 └─ pack.mcmeta
 ```
 
-* Everything lives inside `assets/<namespace>/sounds/` ([reddit.com][2]).
-* Sub-folders are arbitrary; Mojang’s convention is `category/subfolder/file.ogg`. ([modrinth.com][3])
+- Everything lives inside `assets/<namespace>/sounds/` ([reddit.com][2]).
+- Sub-folders are arbitrary; Mojang’s convention is `category/subfolder/file.ogg`. ([modrinth.com][3])
 
 ---
 
@@ -44,23 +44,21 @@ YourPack/
 ```json
 {
   "ambient.cave": {
-    "sounds": [
-      { "name": "ambient/cave/cave1", "stream": false, "volume": 0.8 }
-    ]
+    "sounds": [{ "name": "ambient/cave/cave1", "stream": false, "volume": 0.8 }]
   }
 }
 ```
 
-* Omit the `.ogg` extension in `name`. ([reddit.com][6])
-* `"volume"` (0 – 1 +) and `"pitch"` (default 1) tweak playback.
-* Add multiple entries to randomize: `["random/explode1", "random/explode2"]`. ([youtube.com][7])
+- Omit the `.ogg` extension in `name`. ([reddit.com][6])
+- `"volume"` (0 – 1 +) and `"pitch"` (default 1) tweak playback.
+- Add multiple entries to randomize: `["random/explode1", "random/explode2"]`. ([youtube.com][7])
 
 ---
 
 ## 5 — Converting audio to Ogg Vorbis
 
-* Use Audacity or online converters; export **44.1 kHz/16-bit** or **48 kHz** mono/stereo. Minecraft ignores Opus-in-Ogg. ([reddit.com][8])
-* Keep file size modest (< 1 MB) to avoid RAM spikes on servers.
+- Use Audacity or online converters; export **44.1 kHz/16-bit** or **48 kHz** mono/stereo. Minecraft ignores Opus-in-Ogg. ([reddit.com][8])
+- Keep file size modest (< 1 MB) to avoid RAM spikes on servers.
 
 ---
 
@@ -78,7 +76,7 @@ YourPack/
 
 ### 7.1 Multiple quality variants
 
-Use sub-packs (`pack_format` array) or separate top-level packs (e.g., *HQ Sounds*).
+Use sub-packs (`pack_format` array) or separate top-level packs (e.g., _HQ Sounds_).
 
 ### 7.2 Streaming music
 
@@ -107,28 +105,28 @@ Original files live under hashed names in `.minecraft/assets/objects/`; the inde
 
 ## 9 — Useful references
 
-* **Minecraft Wiki – `sounds.json` spec** ([minecraft.fandom.com][10])
-* **Reddit tutorial** on editing sounds (step-by-step) ([reddit.com][6])
-* **DigMinecraft sound list** for quick event lookup ([digminecraft.com][5])
-* **F3 + T reload explanation** ([reddit.com][9])
-* **Assets cache layout** thread ([reddit.com][4])
-* **Folder path example** on r/mcresourcepack ([reddit.com][2])
-* **Video tutorial** (YouTube) for visual learners ([youtube.com][7])
-* **Vorbis-only requirement** (MCreator wiki) ([mcreator.net][1])
-* **Streaming flag** covered in Minecraft Wiki examples ([minecraft.fandom.com][10])
-* **Debug Keys mod (reload outside world)** for pack devs ([modrinth.com][3])
+- **Minecraft Wiki – `sounds.json` spec** ([minecraft.fandom.com][10])
+- **Reddit tutorial** on editing sounds (step-by-step) ([reddit.com][6])
+- **DigMinecraft sound list** for quick event lookup ([digminecraft.com][5])
+- **F3 + T reload explanation** ([reddit.com][9])
+- **Assets cache layout** thread ([reddit.com][4])
+- **Folder path example** on r/mcresourcepack ([reddit.com][2])
+- **Video tutorial** (YouTube) for visual learners ([youtube.com][7])
+- **Vorbis-only requirement** (MCreator wiki) ([mcreator.net][1])
+- **Streaming flag** covered in Minecraft Wiki examples ([minecraft.fandom.com][10])
+- **Debug Keys mod (reload outside world)** for pack devs ([modrinth.com][3])
 
 ---
 
 Drop this markdown into `/docs/resource-pack-sounds.md` (or anywhere in your repo) and you’ll have a ready reference for every future audio tweak. Happy sound-crafting!
 
-[1]: https://mcreator.net/wiki/how-convert-mp3-or-wav-file-ogg-minecraft-sounds?utm_source=chatgpt.com "How to convert MP3 or WAV file to OGG for Minecraft sounds"
-[2]: https://www.reddit.com/r/mcresourcepack/comments/w8gewq/directories_of_sound_files_within_a_resource_pack/?utm_source=chatgpt.com "Directories of sound files within a resource pack. : r/mcresourcepack"
-[3]: https://modrinth.com/mod/f3-t-everywhere?utm_source=chatgpt.com "Debug Keys (F3+T) Everywhere - Minecraft Mod - Modrinth"
-[4]: https://www.reddit.com/r/Minecraft/comments/4w1ytl/where_do_i_located_default_soundmusic_files/?utm_source=chatgpt.com "Where do I located default sound/music files. - Minecraft - Reddit"
-[5]: https://www.digminecraft.com/lists/sound_list_pc.php?utm_source=chatgpt.com "Sound Effect List (Java Edition) - DigMinecraft"
-[6]: https://www.reddit.com/r/Minecraft/comments/bmyort/finally_figured_out_how_to_edit_sounds_in_a/?utm_source=chatgpt.com "Finally figured out how to edit sounds in a Resource pack. : r/Minecraft"
-[7]: https://www.youtube.com/watch?v=pSlbpvjt1zw&utm_source=chatgpt.com "Minecraft - How to Replace Sounds! (Resource Pack Tutorial)"
-[8]: https://www.reddit.com/r/MinecraftCommands/comments/lnnru7/does_minecraft_support_opus_encoding_in_ogg_files/?utm_source=chatgpt.com "Does Minecraft support opus encoding in .ogg files in resource ..."
-[9]: https://www.reddit.com/r/Minecraft/comments/f9vy3u/reload_resource_pack/?utm_source=chatgpt.com "Reload Resource Pack : r/Minecraft - Reddit"
-[10]: https://minecraft.fandom.com/wiki/Sounds.json?utm_source=chatgpt.com "Sounds.json - Minecraft Wiki"
+[1]: https://mcreator.net/wiki/how-convert-mp3-or-wav-file-ogg-minecraft-sounds?utm_source=chatgpt.com 'How to convert MP3 or WAV file to OGG for Minecraft sounds'
+[2]: https://www.reddit.com/r/mcresourcepack/comments/w8gewq/directories_of_sound_files_within_a_resource_pack/?utm_source=chatgpt.com 'Directories of sound files within a resource pack. : r/mcresourcepack'
+[3]: https://modrinth.com/mod/f3-t-everywhere?utm_source=chatgpt.com 'Debug Keys (F3+T) Everywhere - Minecraft Mod - Modrinth'
+[4]: https://www.reddit.com/r/Minecraft/comments/4w1ytl/where_do_i_located_default_soundmusic_files/?utm_source=chatgpt.com 'Where do I located default sound/music files. - Minecraft - Reddit'
+[5]: https://www.digminecraft.com/lists/sound_list_pc.php?utm_source=chatgpt.com 'Sound Effect List (Java Edition) - DigMinecraft'
+[6]: https://www.reddit.com/r/Minecraft/comments/bmyort/finally_figured_out_how_to_edit_sounds_in_a/?utm_source=chatgpt.com 'Finally figured out how to edit sounds in a Resource pack. : r/Minecraft'
+[7]: https://www.youtube.com/watch?v=pSlbpvjt1zw&utm_source=chatgpt.com 'Minecraft - How to Replace Sounds! (Resource Pack Tutorial)'
+[8]: https://www.reddit.com/r/MinecraftCommands/comments/lnnru7/does_minecraft_support_opus_encoding_in_ogg_files/?utm_source=chatgpt.com 'Does Minecraft support opus encoding in .ogg files in resource ...'
+[9]: https://www.reddit.com/r/Minecraft/comments/f9vy3u/reload_resource_pack/?utm_source=chatgpt.com 'Reload Resource Pack : r/Minecraft - Reddit'
+[10]: https://minecraft.fandom.com/wiki/Sounds.json?utm_source=chatgpt.com 'Sounds.json - Minecraft Wiki'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -36,6 +36,6 @@ module.exports = [
     rules: {
       '@typescript-eslint/no-unused-vars': 'warn',
       '@typescript-eslint/no-explicit-any': 'warn',
-    }
+    },
   }),
 ];

--- a/src/main/projects/importer.ts
+++ b/src/main/projects/importer.ts
@@ -5,7 +5,10 @@ import fs from 'fs';
 import path from 'path';
 import { dialog } from 'electron';
 import unzipper from 'unzipper';
-import type { ProjectMetadata } from '../../shared/project';
+import {
+  createDefaultProjectMeta,
+  type ProjectMetadata,
+} from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
 import { versionForFormat } from '../../shared/packFormat';
 
@@ -41,22 +44,6 @@ async function extractZip(src: string, dest: string): Promise<number> {
       .on('error', reject);
   });
   return count;
-}
-
-function defaultMeta(name: string, version: string): ProjectMetadata {
-  return {
-    name,
-    minecraft_version: version,
-    version: '1.0.0',
-    assets: [],
-    noExport: [],
-    lastOpened: Date.now(),
-    description: '',
-    author: '',
-    urls: [],
-    created: Date.now(),
-    license: '',
-  };
 }
 
 async function detectVersion(dir: string): Promise<string | null> {
@@ -95,10 +82,10 @@ export async function importProject(
     try {
       meta = await readProjectMeta(dest);
     } catch {
-      meta = defaultMeta(name, version);
+      meta = createDefaultProjectMeta(name, version);
     }
   } else {
-    meta = defaultMeta(name, version);
+    meta = createDefaultProjectMeta(name, version);
   }
   meta.minecraft_version = version;
   await writeProjectMeta(dest, meta);

--- a/src/main/projects/manager.ts
+++ b/src/main/projects/manager.ts
@@ -4,7 +4,10 @@
 import fs from 'fs';
 import path from 'path';
 import { generatePackIcon } from '../icon';
-import type { ProjectMetadata } from '../../shared/project';
+import {
+  createDefaultProjectMeta,
+  type ProjectMetadata,
+} from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
 
 export interface ProjectInfo {
@@ -21,19 +24,10 @@ export async function createProject(
 ): Promise<void> {
   const dir = path.join(baseDir, name);
   if (!fs.existsSync(dir)) await fs.promises.mkdir(dir, { recursive: true });
-  const meta: ProjectMetadata = {
+  const meta: ProjectMetadata = createDefaultProjectMeta(
     name,
-    minecraft_version: minecraftVersion,
-    version: '1.0.0',
-    assets: [],
-    noExport: [],
-    lastOpened: Date.now(),
-    description: '',
-    author: '',
-    urls: [],
-    created: Date.now(),
-    license: '',
-  };
+    minecraftVersion
+  );
   await fs.promises.writeFile(
     path.join(dir, 'project.json'),
     JSON.stringify(meta, null, 2)

--- a/src/main/projects/meta.ts
+++ b/src/main/projects/meta.ts
@@ -4,7 +4,7 @@
 import fs from 'fs';
 import path from 'path';
 import type { PackMeta, ProjectMetadata } from '../../shared/project';
-import { PackMetaSchema } from '../../shared/project';
+import { PackMetaSchema, createDefaultProjectMeta } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
 
 export async function loadPackMeta(
@@ -45,19 +45,8 @@ export async function savePackMeta(
     }
   }
   if (!data) {
-    data = {
-      name,
-      minecraft_version: 'unknown',
-      version: meta.version ?? 'unknown',
-      assets: [],
-      noExport: [],
-      lastOpened: Date.now(),
-      description: '',
-      author: '',
-      urls: [],
-      created: Date.now(),
-      license: '',
-    };
+    data = createDefaultProjectMeta(name, 'unknown');
+    data.version = meta.version ?? 'unknown';
   }
   if (meta.version) data.version = meta.version;
   data.description = meta.description;

--- a/src/shared/project.ts
+++ b/src/shared/project.ts
@@ -17,6 +17,19 @@ export const ProjectMetadataSchema = z.object({
 
 export type ProjectMetadata = z.infer<typeof ProjectMetadataSchema>;
 
+/** Create a default project metadata object. */
+export function createDefaultProjectMeta(
+  name: string,
+  minecraftVersion: string
+): ProjectMetadata {
+  return ProjectMetadataSchema.parse({
+    name,
+    minecraft_version: minecraftVersion,
+    created: Date.now(),
+    lastOpened: Date.now(),
+  });
+}
+
 export const PackMetaSchema = z.object({
   version: z.string().default('unknown'),
   description: z.string().default(''),


### PR DESCRIPTION
## Summary
- create `createDefaultProjectMeta` helper
- use helper when creating or saving project metadata
- update docs and lint config via `npm run format`

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c17219e48331a1323b42df9c8f3f