### PR TITLE
Refactor project table into smaller components

### DIFF
--- a/__tests__/ProjectManagerView.test.tsx
+++ b/__tests__/ProjectManagerView.test.tsx
@@ -14,6 +14,7 @@ describe('ProjectManagerView', () => {
   const deleteProject = vi.fn();
   const getProjectSort = vi.fn();
   const setProjectSort = vi.fn();
+  const loadPackMeta = vi.fn();
 
   beforeEach(() => {
     interface ElectronAPI {
@@ -40,6 +41,7 @@ describe('ProjectManagerView', () => {
       deleteProject: (name: string) => Promise<void>;
       getProjectSort: () => Promise<{ key: keyof ProjectInfo; asc: boolean }>;
       setProjectSort: (key: keyof ProjectInfo, asc: boolean) => Promise<void>;
+      loadPackMeta: (name: string) => Promise<unknown>;
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       listProjects,
@@ -51,6 +53,7 @@ describe('ProjectManagerView', () => {
       deleteProject,
       getProjectSort,
       setProjectSort,
+      loadPackMeta,
     };
     listProjects.mockResolvedValue([
       { name: 'Pack', version: '1.20', assets: 2, lastOpened: 0 },
@@ -66,6 +69,12 @@ describe('ProjectManagerView', () => {
     ]);
     getProjectSort.mockResolvedValue({ key: 'name', asc: true });
     setProjectSort.mockResolvedValue(undefined);
+    loadPackMeta.mockResolvedValue({
+      description: '',
+      author: '',
+      urls: [],
+      created: 0,
+    });
     vi.clearAllMocks();
   });
 

--- a/__tests__/ProjectRow.test.tsx
+++ b/__tests__/ProjectRow.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectRow from '../src/renderer/components/project/ProjectRow';
+import type { ProjectInfo } from '../src/renderer/components/project/ProjectTable';
+
+describe('ProjectRow', () => {
+  const projects: ProjectInfo[] = [
+    { name: 'Alpha', version: '1.20', assets: 2, lastOpened: 0 },
+    { name: 'Beta', version: '1.20', assets: 3, lastOpened: 0 },
+  ];
+
+  it('calls button callbacks', () => {
+    const open = vi.fn();
+    const dup = vi.fn();
+    const del = vi.fn();
+    const selected = new Set<string>();
+    const last = { current: null as number | null };
+    render(
+      <table>
+        <tbody>
+          <ProjectRow
+            project={projects[0]}
+            projects={projects}
+            index={0}
+            selected={selected}
+            onSelect={() => {}}
+            lastIndexRef={last}
+            onOpen={open}
+            onDuplicate={dup}
+            onDelete={del}
+            onRowClick={() => {}}
+          />
+        </tbody>
+      </table>
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(open).toHaveBeenCalledWith('Alpha');
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
+    expect(dup).toHaveBeenCalledWith('Alpha');
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(del).toHaveBeenCalledWith('Alpha');
+  });
+
+  it('handles double click and key', () => {
+    const open = vi.fn();
+    const del = vi.fn();
+    const selected = new Set<string>();
+    const last = { current: null as number | null };
+    render(
+      <table>
+        <tbody>
+          <ProjectRow
+            project={projects[0]}
+            projects={projects}
+            index={0}
+            selected={selected}
+            onSelect={() => {}}
+            lastIndexRef={last}
+            onOpen={open}
+            onDuplicate={() => {}}
+            onDelete={del}
+            onRowClick={() => {}}
+          />
+        </tbody>
+      </table>
+    );
+    const row = screen.getByRole('row');
+    fireEvent.doubleClick(row);
+    expect(open).toHaveBeenCalledWith('Alpha');
+    fireEvent.keyDown(row, { key: 'Delete' });
+    expect(del).toHaveBeenCalledWith('Alpha');
+  });
+
+  it('selects range with shift', () => {
+    const selected = new Set<string>();
+    const last = { current: null as number | null };
+    const select = vi.fn((name: string, checked: boolean) => {
+      if (checked) selected.add(name);
+      else selected.delete(name);
+    });
+    render(
+      <table>
+        <tbody>
+          {projects.map((p, i) => (
+            <ProjectRow
+              key={p.name}
+              project={p}
+              projects={projects}
+              index={i}
+              selected={selected}
+              onSelect={select}
+              lastIndexRef={last}
+              onOpen={() => {}}
+              onDuplicate={() => {}}
+              onDelete={() => {}}
+              onRowClick={() => {}}
+            />
+          ))}
+        </tbody>
+      </table>
+    );
+    const boxes = screen.getAllByRole('checkbox');
+    fireEvent.click(boxes[0]);
+    expect(select).toHaveBeenCalledWith('Alpha', true);
+    fireEvent.click(boxes[1], { shiftKey: true });
+    expect(select).toHaveBeenCalledWith('Beta', true);
+  });
+});

--- a/__tests__/ProjectTableHeader.test.tsx
+++ b/__tests__/ProjectTableHeader.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ProjectTableHeader from '../src/renderer/components/project/ProjectTableHeader';
+
+describe('ProjectTableHeader', () => {
+  const noop = () => {};
+  it('fires sort callback', () => {
+    const sort = vi.fn();
+    render(
+      <table>
+        <ProjectTableHeader
+          allSelected={false}
+          onSelectAll={noop}
+          sortKey="name"
+          asc
+          onSort={sort}
+        />
+        <tbody></tbody>
+      </table>
+    );
+    fireEvent.click(screen.getByText('Assets'));
+    expect(sort).toHaveBeenCalledWith('assets');
+  });
+
+  it('toggles select all', () => {
+    const toggle = vi.fn();
+    render(
+      <table>
+        <ProjectTableHeader
+          allSelected={false}
+          onSelectAll={toggle}
+          sortKey="name"
+          asc
+          onSort={noop}
+        />
+        <tbody></tbody>
+      </table>
+    );
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(toggle).toHaveBeenCalledWith(true);
+  });
+
+  it('shows sort icon when active', () => {
+    render(
+      <table>
+        <ProjectTableHeader
+          allSelected={false}
+          onSelectAll={noop}
+          sortKey="assets"
+          asc={false}
+          onSort={noop}
+        />
+        <tbody></tbody>
+      </table>
+    );
+    const header = screen.getByText('Assets');
+    const svg = header.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.querySelector('path')?.getAttribute('d')).toBe(
+      'm19.5 8.25-7.5 7.5-7.5-7.5'
+    );
+  });
+});

--- a/src/renderer/components/project/ProjectRow.tsx
+++ b/src/renderer/components/project/ProjectRow.tsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { Checkbox } from '../daisy/input';
+import { Button } from '../daisy/actions';
+import {
+  ArrowRightCircleIcon,
+  DocumentDuplicateIcon,
+  TrashIcon,
+} from '@heroicons/react/24/outline';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - webpack replaces import with URL string
+import defaultPack from '../../../../resources/default_pack.png';
+import ProjectContextMenu from './ProjectContextMenu';
+import type { ProjectInfo } from './ProjectTable';
+
+interface Props {
+  project: ProjectInfo;
+  projects: ProjectInfo[];
+  index: number;
+  selected: Set<string>;
+  onSelect: (name: string, checked: boolean) => void;
+  lastIndexRef: React.MutableRefObject<number | null>;
+  onOpen: (name: string) => void;
+  onDuplicate: (name: string) => void;
+  onDelete: (name: string) => void;
+  onRowClick: (name: string) => void;
+}
+
+export default function ProjectRow({
+  project,
+  projects,
+  index,
+  selected,
+  onSelect,
+  lastIndexRef,
+  onOpen,
+  onDuplicate,
+  onDelete,
+  onRowClick,
+}: Props) {
+  const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(
+    null
+  );
+  const firstItem = React.useRef<HTMLButtonElement>(null);
+
+  React.useEffect(() => {
+    if (menuPos && firstItem.current) firstItem.current.focus();
+  }, [menuPos]);
+
+  const closeMenu = () => setMenuPos(null);
+
+  const handleOpen = () => {
+    onOpen(project.name);
+    closeMenu();
+  };
+  const handleDuplicate = () => {
+    onDuplicate(project.name);
+    closeMenu();
+  };
+  const handleDelete = () => {
+    onDelete(project.name);
+    closeMenu();
+  };
+
+  const handleCheckbox = (
+    e: React.ChangeEvent<HTMLInputElement> & {
+      nativeEvent: MouseEvent;
+    }
+  ) => {
+    e.stopPropagation();
+    const checked = e.target.checked;
+    if (e.nativeEvent.shiftKey && lastIndexRef.current !== null) {
+      const start = Math.min(lastIndexRef.current, index);
+      const end = Math.max(lastIndexRef.current, index);
+      for (let i = start; i <= end; i++) {
+        onSelect(projects[i].name, checked);
+      }
+    } else {
+      onSelect(project.name, checked);
+    }
+    lastIndexRef.current = index;
+  };
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    setMenuPos({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && selected.size <= 1) onOpen(project.name);
+    if (e.key === 'Delete' && selected.size <= 1) onDelete(project.name);
+    if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
+      e.preventDefault();
+      const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+      setMenuPos({ x: rect.right, y: rect.bottom });
+    }
+  };
+
+  return (
+    <tr
+      onClick={() => onRowClick(project.name)}
+      onDoubleClick={() => onOpen(project.name)}
+      onContextMenu={handleContextMenu}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      className={`cursor-pointer ${selected.has(project.name) ? 'bg-base-300' : ''}`}
+      onBlur={(e) => {
+        const overlay = document.getElementById('overlay-root');
+        const next = e.relatedTarget as Node | null;
+        if (
+          !e.currentTarget.contains(next) &&
+          !(overlay && overlay.contains(next))
+        )
+          closeMenu();
+      }}
+    >
+      <td>
+        <Checkbox
+          aria-label={`Select ${project.name}`}
+          checked={selected.has(project.name)}
+          onClick={(e) => e.stopPropagation()}
+          onChange={handleCheckbox}
+          className="checkbox checkbox-primary checkbox-sm"
+        />
+      </td>
+      <td className="flex items-center gap-2">
+        <img
+          src={defaultPack as unknown as string}
+          alt="Pack icon"
+          className="w-6 h-6"
+        />
+        {project.name}
+      </td>
+      <td>{project.version}</td>
+      <td>{project.assets}</td>
+      <td>{new Date(project.lastOpened).toLocaleDateString()}</td>
+      <td className="flex gap-1">
+        <Button
+          className="btn-accent btn-sm flex items-center gap-1"
+          onClick={(e) => {
+            e.stopPropagation();
+            onOpen(project.name);
+          }}
+        >
+          <ArrowRightCircleIcon className="w-4 h-4" />
+          Open
+        </Button>
+        <Button
+          className="btn-info btn-sm flex items-center gap-1"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDuplicate(project.name);
+          }}
+        >
+          <DocumentDuplicateIcon className="w-4 h-4" />
+          Duplicate
+        </Button>
+        <Button
+          className="btn-error btn-sm flex items-center gap-1"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(project.name);
+          }}
+        >
+          <TrashIcon className="w-4 h-4" />
+          Delete
+        </Button>
+      </td>
+      {menuPos && (
+        <ProjectContextMenu
+          project={project.name}
+          style={{
+            left: menuPos.x,
+            top: menuPos.y,
+            display: menuPos ? 'block' : 'none',
+          }}
+          firstItemRef={firstItem}
+          onOpen={handleOpen}
+          onDuplicate={handleDuplicate}
+          onDelete={handleDelete}
+        />
+      )}
+    </tr>
+  );
+}

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -1,17 +1,6 @@
 import React from 'react';
-import { Checkbox } from '../daisy/input';
-import { Button } from '../daisy/actions';
-import {
-  ArrowRightCircleIcon,
-  DocumentDuplicateIcon,
-  TrashIcon,
-  ChevronUpIcon,
-  ChevronDownIcon,
-} from '@heroicons/react/24/outline';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - webpack replaces import with URL string
-import defaultPack from '../../../../resources/default_pack.png';
-import ProjectContextMenu from './ProjectContextMenu';
+import ProjectTableHeader from './ProjectTableHeader';
+import ProjectRow from './ProjectRow';
 
 export interface ProjectInfo {
   name: string;
@@ -48,215 +37,35 @@ export default function ProjectTable({
   const lastIndex = React.useRef<number | null>(null);
   const allSelected =
     selected.size > 0 && projects.every((p) => selected.has(p.name));
-  const [menuInfo, setMenuInfo] = React.useState<{
-    name: string;
-    x: number;
-    y: number;
-  } | null>(null);
-  const firstItem = React.useRef<HTMLButtonElement>(null);
-
-  React.useEffect(() => {
-    if (menuInfo && firstItem.current) firstItem.current.focus();
-  }, [menuInfo]);
-
-  const closeMenu = () => setMenuInfo(null);
-
-  const handleOpen = (n: string) => {
-    onOpen(n);
-    closeMenu();
-  };
-
-  const handleDuplicate = (n: string) => {
-    onDuplicate(n);
-    closeMenu();
-  };
-
-  const handleDelete = (n: string) => {
-    onDelete(n);
-    closeMenu();
-  };
 
   return (
-    <div
-      className="flex-1 overflow-x-auto"
-      tabIndex={0}
-      onBlur={(e) => {
-        const overlay = document.getElementById('overlay-root');
-        const next = e.relatedTarget as Node | null;
-        if (
-          !e.currentTarget.contains(next) &&
-          !(overlay && overlay.contains(next))
-        )
-          closeMenu();
-      }}
-    >
+    <div className="flex-1 overflow-x-auto" tabIndex={0}>
       <table className="table table-zebra w-full">
-        <thead>
-          <tr>
-            <th>
-              <Checkbox
-                aria-label="Select all"
-                checked={allSelected}
-                onClick={(e) => e.stopPropagation()}
-                onChange={(e) => onSelectAll(e.target.checked)}
-                className="checkbox checkbox-primary checkbox-sm"
-              />
-            </th>
-            <th onClick={() => onSort('name')} className="cursor-pointer">
-              Name
-              {sortKey === 'name' &&
-                (asc ? (
-                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
-                ) : (
-                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
-                ))}
-            </th>
-            <th onClick={() => onSort('version')} className="cursor-pointer">
-              MC Version
-              {sortKey === 'version' &&
-                (asc ? (
-                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
-                ) : (
-                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
-                ))}
-            </th>
-            <th onClick={() => onSort('assets')} className="cursor-pointer">
-              Assets
-              {sortKey === 'assets' &&
-                (asc ? (
-                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
-                ) : (
-                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
-                ))}
-            </th>
-            <th onClick={() => onSort('lastOpened')} className="cursor-pointer">
-              Last opened
-              {sortKey === 'lastOpened' &&
-                (asc ? (
-                  <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
-                ) : (
-                  <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
-                ))}
-            </th>
-            <th></th>
-          </tr>
-        </thead>
+        <ProjectTableHeader
+          allSelected={allSelected}
+          onSelectAll={onSelectAll}
+          sortKey={sortKey}
+          asc={asc}
+          onSort={onSort}
+        />
         <tbody>
-          {projects.map((p) => (
-            <tr
+          {projects.map((p, i) => (
+            <ProjectRow
               key={p.name}
-              onClick={() => onRowClick(p.name)}
-              onDoubleClick={() => onOpen(p.name)}
-              onContextMenu={(e) => {
-                e.preventDefault();
-                setMenuInfo({ name: p.name, x: e.clientX, y: e.clientY });
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && selected.size <= 1) onOpen(p.name);
-                if (e.key === 'Delete' && selected.size <= 1) onDelete(p.name);
-                if (
-                  e.key === 'ContextMenu' ||
-                  (e.shiftKey && e.key === 'F10')
-                ) {
-                  e.preventDefault();
-                  const rect = (
-                    e.currentTarget as HTMLElement
-                  ).getBoundingClientRect();
-                  setMenuInfo({ name: p.name, x: rect.right, y: rect.bottom });
-                }
-              }}
-              tabIndex={0}
-              className={`cursor-pointer ${
-                selected.has(p.name) ? 'bg-base-300' : ''
-              }`}
-            >
-              <td>
-                <Checkbox
-                  aria-label={`Select ${p.name}`}
-                  checked={selected.has(p.name)}
-                  onClick={(e) => e.stopPropagation()}
-                  onChange={(e) => {
-                    e.stopPropagation();
-                    const idx = projects.findIndex((x) => x.name === p.name);
-                    const checked = e.target.checked;
-                    if (
-                      (e.nativeEvent as MouseEvent).shiftKey &&
-                      lastIndex.current !== null
-                    ) {
-                      const start = Math.min(lastIndex.current, idx);
-                      const end = Math.max(lastIndex.current, idx);
-                      for (let i = start; i <= end; i++) {
-                        onSelect(projects[i].name, checked);
-                      }
-                    } else {
-                      onSelect(p.name, checked);
-                    }
-                    lastIndex.current = idx;
-                  }}
-                  className="checkbox checkbox-primary checkbox-sm"
-                />
-              </td>
-              <td className="flex items-center gap-2">
-                <img
-                  src={defaultPack as unknown as string}
-                  alt="Pack icon"
-                  className="w-6 h-6"
-                />
-                {p.name}
-              </td>
-              <td>{p.version}</td>
-              <td>{p.assets}</td>
-              <td>{new Date(p.lastOpened).toLocaleDateString()}</td>
-              <td className="flex gap-1">
-                <Button
-                  className="btn-accent btn-sm flex items-center gap-1"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onOpen(p.name);
-                  }}
-                >
-                  <ArrowRightCircleIcon className="w-4 h-4" />
-                  Open
-                </Button>
-                <Button
-                  className="btn-info btn-sm flex items-center gap-1"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDuplicate(p.name);
-                  }}
-                >
-                  <DocumentDuplicateIcon className="w-4 h-4" />
-                  Duplicate
-                </Button>
-                <Button
-                  className="btn-error btn-sm flex items-center gap-1"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onDelete(p.name);
-                  }}
-                >
-                  <TrashIcon className="w-4 h-4" />
-                  Delete
-                </Button>
-              </td>
-            </tr>
+              project={p}
+              projects={projects}
+              index={i}
+              selected={selected}
+              onSelect={onSelect}
+              lastIndexRef={lastIndex}
+              onOpen={onOpen}
+              onDuplicate={onDuplicate}
+              onDelete={onDelete}
+              onRowClick={onRowClick}
+            />
           ))}
         </tbody>
       </table>
-      {menuInfo && (
-        <ProjectContextMenu
-          project={menuInfo.name}
-          style={{
-            left: menuInfo.x,
-            top: menuInfo.y,
-            display: menuInfo ? 'block' : 'none',
-          }}
-          firstItemRef={firstItem}
-          onOpen={handleOpen}
-          onDuplicate={handleDuplicate}
-          onDelete={handleDelete}
-        />
-      )}
     </div>
   );
 }

--- a/src/renderer/components/project/ProjectTableHeader.tsx
+++ b/src/renderer/components/project/ProjectTableHeader.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Checkbox } from '../daisy/input';
+import { ChevronUpIcon, ChevronDownIcon } from '@heroicons/react/24/outline';
+import type { ProjectInfo } from './ProjectTable';
+
+interface Props {
+  allSelected: boolean;
+  onSelectAll: (checked: boolean) => void;
+  sortKey: keyof ProjectInfo;
+  asc: boolean;
+  onSort: (k: keyof ProjectInfo) => void;
+}
+
+export default function ProjectTableHeader({
+  allSelected,
+  onSelectAll,
+  sortKey,
+  asc,
+  onSort,
+}: Props) {
+  return (
+    <thead>
+      <tr>
+        <th>
+          <Checkbox
+            aria-label="Select all"
+            checked={allSelected}
+            onClick={(e) => e.stopPropagation()}
+            onChange={(e) => onSelectAll(e.target.checked)}
+            className="checkbox checkbox-primary checkbox-sm"
+          />
+        </th>
+        <th onClick={() => onSort('name')} className="cursor-pointer">
+          Name
+          {sortKey === 'name' &&
+            (asc ? (
+              <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+            ) : (
+              <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+            ))}
+        </th>
+        <th onClick={() => onSort('version')} className="cursor-pointer">
+          MC Version
+          {sortKey === 'version' &&
+            (asc ? (
+              <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+            ) : (
+              <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+            ))}
+        </th>
+        <th onClick={() => onSort('assets')} className="cursor-pointer">
+          Assets
+          {sortKey === 'assets' &&
+            (asc ? (
+              <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+            ) : (
+              <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+            ))}
+        </th>
+        <th onClick={() => onSort('lastOpened')} className="cursor-pointer">
+          Last opened
+          {sortKey === 'lastOpened' &&
+            (asc ? (
+              <ChevronUpIcon className="w-3 h-3 inline-block ml-1" />
+            ) : (
+              <ChevronDownIcon className="w-3 h-3 inline-block ml-1" />
+            ))}
+        </th>
+        <th></th>
+      </tr>
+    </thead>
+  );
+}


### PR DESCRIPTION
## Summary
- extract `ProjectTableHeader` for the table head
- extract `ProjectRow` for row interactions
- refactor `ProjectTable` to use the new components
- adjust ProjectManagerView test stubs
- add RTL tests for new components

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852ddba7e708331b93466f8313db7f6