### PR TITLE
Implement texture list cache

### DIFF
--- a/__tests__/fileWatcher.test.ts
+++ b/__tests__/fileWatcher.test.ts
@@ -21,6 +21,7 @@ vi.mock('electron', () => {
   sendMock = vi.fn();
   return {
     BrowserWindow: vi.fn(() => ({ webContents: { send: sendMock } })),
+    app: { getPath: vi.fn(() => os.tmpdir()) },
     ipcMain: {
       handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
         if (channel === 'watch-project')

--- a/src/main/ipc/fileWatcher.ts
+++ b/src/main/ipc/fileWatcher.ts
@@ -3,6 +3,7 @@ import { BrowserWindow } from 'electron';
 import { watch, FSWatcher } from 'chokidar';
 import fs from 'fs';
 import path from 'path';
+import { clearTextureCache } from '../assets/textures';
 
 let win: BrowserWindow | null = null;
 const watchers = new Map<string, FSWatcher>();
@@ -44,18 +45,21 @@ export function registerFileWatcherHandlers(
           'file-added',
           path.relative(projectPath, file).split(path.sep).join('/')
         );
+        clearTextureCache(projectPath);
       });
       watcher.on('unlink', (file) => {
         win?.webContents.send(
           'file-removed',
           path.relative(projectPath, file).split(path.sep).join('/')
         );
+        clearTextureCache(projectPath);
       });
       watcher.on('change', (file) => {
         win?.webContents.send('file-changed', {
           path: path.relative(projectPath, file).split(path.sep).join('/'),
           stamp: Date.now(),
         });
+        clearTextureCache(projectPath);
       });
       watchers.set(projectPath, watcher);
     }
@@ -85,6 +89,7 @@ export function emitRenamed(oldPath: string, newPath: string) {
         oldPath: path.relative(projectPath, oldPath).split(path.sep).join('/'),
         newPath: path.relative(projectPath, newPath).split(path.sep).join('/'),
       });
+      clearTextureCache(projectPath);
     }
   }
 }


### PR DESCRIPTION
## Summary
- speed up texture listings with an in-memory cache
- clear cache when watcher reports file changes
- test caching behaviour

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852dddd978c8331a647a1566264133b