### PR TITLE
Add type tests and bump coverage

### DIFF
--- a/__tests__/getTexture.test.ts
+++ b/__tests__/getTexture.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import getTexture from '../src/renderer/utils/getTexture';
+
+describe('getTexture', () => {
+  it('strips minecraft namespace and prefixes', () => {
+    expect(getTexture('block', 'minecraft:block/stone')).toBe(
+      'vanilla://block/stone'
+    );
+    expect(getTexture('item', '/item/diamond_sword')).toBe(
+      'vanilla://item/diamond_sword'
+    );
+  });
+});

--- a/__tests__/ipc.types.test.ts
+++ b/__tests__/ipc.types.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type { IpcRequestMap, IpcResponseMap } from '../src/shared/ipc/types';
+import type { ProjectInfo } from '../src/main/projects';
+import type { PackMeta } from '../src/shared/project';
+import type { TextureEditOptions } from '../src/shared/texture';
+
+describe('IPC type mappings', () => {
+  it('edit-texture request and response', () => {
+    expectTypeOf<IpcRequestMap['edit-texture']>().toEqualTypeOf<
+      [string, TextureEditOptions]
+    >();
+    expectTypeOf<IpcResponseMap['edit-texture']>().toEqualTypeOf<void>();
+  });
+
+  it('load-pack-meta request and response', () => {
+    expectTypeOf<IpcRequestMap['load-pack-meta']>().toEqualTypeOf<[string]>();
+    expectTypeOf<IpcResponseMap['load-pack-meta']>().toEqualTypeOf<PackMeta>();
+  });
+
+  it('list-projects maps to ProjectInfo array', () => {
+    expectTypeOf<IpcRequestMap['list-projects']>().toEqualTypeOf<[]>();
+    expectTypeOf<IpcResponseMap['list-projects']>().toEqualTypeOf<
+      ProjectInfo[]
+    >();
+  });
+});

--- a/__tests__/packFormat.test.ts
+++ b/__tests__/packFormat.test.ts
@@ -2,18 +2,42 @@ import { describe, it, expect } from 'vitest';
 import {
   packFormatForVersion,
   versionForFormat,
+  versionRangeForFormat,
+  displayForFormat,
 } from '../src/shared/packFormat';
 
 describe('packFormatForVersion', () => {
-  it('maps 1.20.1 correctly', () => {
+  it('maps release versions correctly', () => {
     expect(packFormatForVersion('1.20.1')).toBe(15);
+  });
+
+  it('maps snapshot versions', () => {
+    expect(packFormatForVersion('24w40a')).toBe(40);
   });
 
   it('returns null for unknown versions', () => {
     expect(packFormatForVersion('0.0.1')).toBeNull();
   });
+});
 
+describe('format lookups', () => {
   it('maps format to latest version', () => {
     expect(versionForFormat(15)).toBe('1.20.1');
+  });
+
+  it('returns version range for format', () => {
+    expect(versionRangeForFormat(15)).toEqual({
+      min: '1.20',
+      max: '1.20.1',
+      format: 15,
+    });
+  });
+
+  it('creates display string for ranges', () => {
+    expect(displayForFormat(15)).toBe('1.20 - 1.20.1');
+  });
+
+  it('handles unknown format', () => {
+    expect(displayForFormat(999)).toBeNull();
   });
 });

--- a/__tests__/texture.types.test.ts
+++ b/__tests__/texture.types.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, expectTypeOf } from 'vitest';
+import type { TextureEditOptions } from '../src/shared/texture';
+
+describe('TextureEditOptions', () => {
+  it('matches expected shape', () => {
+    expectTypeOf<TextureEditOptions>().toEqualTypeOf<{
+      rotate?: number;
+      hue?: number;
+      grayscale?: boolean;
+      saturation?: number;
+      brightness?: number;
+    }>();
+  });
+
+  it('allows partial option sets', () => {
+    const example: TextureEditOptions = { rotate: 90 };
+    expect(example.rotate).toBe(90);
+    expectTypeOf<typeof example.rotate>().toEqualTypeOf<number | undefined>();
+  });
+});

--- a/__tests__/themeUtils.test.ts
+++ b/__tests__/themeUtils.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { applyTheme, toggleTheme } from '../src/renderer/utils/theme';
+
+describe('theme utilities', () => {
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+  });
+
+  it('applies explicit theme', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    applyTheme('light');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('applies system theme based on media query', () => {
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    applyTheme('system');
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light');
+  });
+
+  it('toggles theme and updates storage', async () => {
+    const getTheme = vi.fn(async () => 'light');
+    const setTheme = vi.fn(async () => {});
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    (
+      window as unknown as {
+        electronAPI: { getTheme: typeof getTheme; setTheme: typeof setTheme };
+      }
+    ).electronAPI = {
+      getTheme,
+      setTheme,
+    };
+    await toggleTheme();
+    expect(setTheme).toHaveBeenCalledWith('dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'minecraft'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add type assertions for TextureEditOptions
- add IPC mapping tests
- extend packFormat tests
- test theme utilities
- test getTexture helper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npx vitest run --coverage --reporter=json`

------
https://chatgpt.com/codex/tasks/task_e_6852dde765fc83319e5662ac5b180795