### PR TITLE
Remove accordions from asset browser

### DIFF
--- a/__tests__/AssetBrowser.test.tsx
+++ b/__tests__/AssetBrowser.test.tsx
@@ -76,7 +76,7 @@ describe('AssetBrowser', () => {
     );
     await screen.findAllByText('a.txt');
     const wrapper = screen.getByTestId('asset-browser');
-    expect(wrapper.className).toMatch(/overflow-auto/);
+    expect(wrapper.className).toMatch(/overflow-y-auto/);
   });
 
   it('context menu triggers IPC calls', async () => {

--- a/__tests__/AssetCategorySection.test.tsx
+++ b/__tests__/AssetCategorySection.test.tsx
@@ -9,7 +9,7 @@ vi.mock('../src/renderer/components/assets/AssetBrowserItem', () => ({
 }));
 
 describe('AssetCategorySection', () => {
-  it('renders items inside accordion', () => {
+  it('renders items with header', () => {
     render(
       <AssetCategorySection
         title="blocks"
@@ -19,7 +19,7 @@ describe('AssetCategorySection', () => {
         zoom={64}
       />
     );
-    expect(screen.getByText('blocks')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'blocks' })).toBeInTheDocument();
     expect(screen.getByTestId('item')).toHaveTextContent('a.png');
   });
 

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -70,7 +70,7 @@ const BrowserBody: React.FC<{
     <div
       data-testid="asset-browser"
       ref={wrapperRef}
-      className="overflow-auto"
+      className="h-full overflow-y-auto"
       onKeyDown={(e) => {
         if (e.key === 'Delete' && selected.size > 0) {
           e.preventDefault();

--- a/src/renderer/components/assets/AssetCategorySection.tsx
+++ b/src/renderer/components/assets/AssetCategorySection.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Accordion } from '../daisy/display';
 import AssetBrowserItem from './AssetBrowserItem';
 import { Filter } from './AssetBrowserControls';
 
@@ -20,7 +19,8 @@ export default function AssetCategorySection({
 }: Props) {
   if (files.length === 0) return null;
   return (
-    <Accordion title={title} className="mb-2" defaultOpen>
+    <div className="mb-2">
+      <h3 className="text-lg font-medium capitalize mb-1">{title}</h3>
       <div className="grid grid-cols-6 gap-2">
         {files.map((f) => (
           <AssetBrowserItem
@@ -32,6 +32,6 @@ export default function AssetCategorySection({
           />
         ))}
       </div>
-    </Accordion>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- simplify asset browser category layout and make it scrollable
- update tests for the new layout

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852f5d0082c83318c0a02554fa9d719