### PR TITLE
Improve Daisy component prop support

### DIFF
--- a/__tests__/daisy/actions/Dropdown.test.tsx
+++ b/__tests__/daisy/actions/Dropdown.test.tsx
@@ -4,12 +4,14 @@ import { render, screen } from '@testing-library/react';
 import Dropdown from '../../../src/renderer/components/daisy/actions/Dropdown';
 
 describe('daisy Dropdown', () => {
-  it('renders dropdown', () => {
+  it('renders dropdown and accepts props', () => {
     render(
-      <Dropdown label="Menu">
+      <Dropdown label="Menu" className="extra" data-testid="drop">
         <li>Item</li>
       </Dropdown>
     );
-    expect(screen.getByTestId('daisy-dropdown')).toBeInTheDocument();
+    const el = screen.getByTestId('drop');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/actions/Modal.test.tsx
+++ b/__tests__/daisy/actions/Modal.test.tsx
@@ -6,13 +6,14 @@ import Modal from '../../../src/renderer/components/daisy/actions/Modal';
 describe('daisy Modal', () => {
   it('renders modal when open and uses custom test id', async () => {
     render(
-      <Modal open testId="custom" variant="success">
+      <Modal open testId="custom" variant="success" id="modal1">
         <p>Content</p>
       </Modal>
     );
     expect(screen.getByTestId('custom')).toBeInTheDocument();
     const root = document.getElementById('overlay-root');
     expect(root?.querySelector('dialog')).toBeInTheDocument();
+    expect(root?.querySelector('dialog')).toHaveAttribute('id', 'modal1');
     await waitFor(() => expect(screen.getByTestId('custom')).toHaveFocus());
     const box = screen.getByTestId('custom').querySelector('.modal-box');
     expect(box).toHaveClass('bg-success');

--- a/__tests__/daisy/display/Avatar.test.tsx
+++ b/__tests__/daisy/display/Avatar.test.tsx
@@ -4,8 +4,10 @@ import { render, screen } from '@testing-library/react';
 import Avatar from '../../../src/renderer/components/daisy/display/Avatar';
 
 describe('Avatar', () => {
-  it('renders', () => {
-    render(<Avatar src="a.png" />);
-    expect(screen.getByTestId('avatar')).toBeInTheDocument();
+  it('renders and accepts className', () => {
+    render(<Avatar src="a.png" className="extra" />);
+    const el = screen.getByTestId('avatar');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/display/Badge.test.tsx
+++ b/__tests__/daisy/display/Badge.test.tsx
@@ -4,10 +4,16 @@ import { render, screen } from '@testing-library/react';
 import Badge from '../../../src/renderer/components/daisy/display/Badge';
 
 describe('Badge', () => {
-  it('renders', () => {
-    render(<Badge variant="accent">Hi</Badge>);
+  it('renders and accepts props', () => {
+    render(
+      <Badge variant="accent" id="b1" className="extra">
+        Hi
+      </Badge>
+    );
     const badge = screen.getByTestId('badge');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveClass('badge-accent');
+    expect(badge).toHaveClass('extra');
+    expect(badge).toHaveAttribute('id', 'b1');
   });
 });

--- a/__tests__/daisy/display/Card.test.tsx
+++ b/__tests__/daisy/display/Card.test.tsx
@@ -4,8 +4,15 @@ import { render, screen } from '@testing-library/react';
 import Card from '../../../src/renderer/components/daisy/display/Card';
 
 describe('Card', () => {
-  it('renders', () => {
-    render(<Card title="Title">Body</Card>);
-    expect(screen.getByTestId('card')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(
+      <Card title="Title" className="extra" id="c1">
+        Body
+      </Card>
+    );
+    const card = screen.getByTestId('card');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveClass('extra');
+    expect(card).toHaveAttribute('id', 'c1');
   });
 });

--- a/__tests__/daisy/display/Carousel.test.tsx
+++ b/__tests__/daisy/display/Carousel.test.tsx
@@ -4,12 +4,15 @@ import { render, screen } from '@testing-library/react';
 import Carousel from '../../../src/renderer/components/daisy/display/Carousel';
 
 describe('Carousel', () => {
-  it('renders', () => {
+  it('renders and accepts props', () => {
     render(
-      <Carousel>
+      <Carousel className="extra" id="car1">
         <div>Item</div>
       </Carousel>
     );
-    expect(screen.getByTestId('carousel')).toBeInTheDocument();
+    const el = screen.getByTestId('carousel');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'car1');
   });
 });

--- a/__tests__/daisy/display/ChatBubble.test.tsx
+++ b/__tests__/daisy/display/ChatBubble.test.tsx
@@ -4,8 +4,15 @@ import { render, screen } from '@testing-library/react';
 import ChatBubble from '../../../src/renderer/components/daisy/display/ChatBubble';
 
 describe('ChatBubble', () => {
-  it('renders', () => {
-    render(<ChatBubble>Hi</ChatBubble>);
-    expect(screen.getByTestId('chat-bubble')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(
+      <ChatBubble id="cb1" className="extra">
+        Hi
+      </ChatBubble>
+    );
+    const bubble = screen.getByTestId('chat-bubble');
+    expect(bubble).toBeInTheDocument();
+    expect(bubble).toHaveClass('extra');
+    expect(bubble).toHaveAttribute('id', 'cb1');
   });
 });

--- a/__tests__/daisy/display/Collapse.test.tsx
+++ b/__tests__/daisy/display/Collapse.test.tsx
@@ -6,13 +6,14 @@ import Collapse from '../../../src/renderer/components/daisy/display/Collapse';
 describe('Collapse', () => {
   it('renders and accepts props', () => {
     render(
-      <Collapse title="Title" className="extra" defaultOpen>
+      <Collapse title="Title" className="extra" id="col1" defaultOpen>
         Content
       </Collapse>
     );
     const col = screen.getByTestId('collapse');
     expect(col).toBeInTheDocument();
     expect(col).toHaveClass('extra');
+    expect(col).toHaveAttribute('id', 'col1');
     const checkbox = col.querySelector(
       'input[type="checkbox"]'
     ) as HTMLInputElement;

--- a/__tests__/daisy/display/Countdown.test.tsx
+++ b/__tests__/daisy/display/Countdown.test.tsx
@@ -4,8 +4,11 @@ import { render, screen } from '@testing-library/react';
 import Countdown from '../../../src/renderer/components/daisy/display/Countdown';
 
 describe('Countdown', () => {
-  it('renders', () => {
-    render(<Countdown value={10} />);
-    expect(screen.getByTestId('countdown')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(<Countdown value={10} className="extra" id="cd1" />);
+    const el = screen.getByTestId('countdown');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'cd1');
   });
 });

--- a/__tests__/daisy/display/Diff.test.tsx
+++ b/__tests__/daisy/display/Diff.test.tsx
@@ -4,8 +4,11 @@ import { render, screen } from '@testing-library/react';
 import Diff from '../../../src/renderer/components/daisy/display/Diff';
 
 describe('Diff', () => {
-  it('renders', () => {
-    render(<Diff before="a" after="b" />);
-    expect(screen.getByTestId('diff')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(<Diff before="a" after="b" className="extra" id="d1" />);
+    const el = screen.getByTestId('diff');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'd1');
   });
 });

--- a/__tests__/daisy/display/List.test.tsx
+++ b/__tests__/daisy/display/List.test.tsx
@@ -4,12 +4,15 @@ import { render, screen } from '@testing-library/react';
 import List from '../../../src/renderer/components/daisy/display/List';
 
 describe('List', () => {
-  it('renders', () => {
+  it('renders and accepts props', () => {
     render(
-      <List>
+      <List className="extra" id="l1">
         <li>Item</li>
       </List>
     );
-    expect(screen.getByTestId('list')).toBeInTheDocument();
+    const el = screen.getByTestId('list');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'l1');
   });
 });

--- a/__tests__/daisy/display/Stat.test.tsx
+++ b/__tests__/daisy/display/Stat.test.tsx
@@ -4,8 +4,11 @@ import { render, screen } from '@testing-library/react';
 import Stat from '../../../src/renderer/components/daisy/display/Stat';
 
 describe('Stat', () => {
-  it('renders', () => {
-    render(<Stat title="T" value="V" />);
-    expect(screen.getByTestId('stat')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(<Stat title="T" value="V" className="extra" id="s1" />);
+    const el = screen.getByTestId('stat');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 's1');
   });
 });

--- a/__tests__/daisy/display/Status.test.tsx
+++ b/__tests__/daisy/display/Status.test.tsx
@@ -4,8 +4,11 @@ import { render, screen } from '@testing-library/react';
 import Status from '../../../src/renderer/components/daisy/display/Status';
 
 describe('Status', () => {
-  it('renders', () => {
-    render(<Status />);
-    expect(screen.getByTestId('status')).toBeInTheDocument();
+  it('renders and accepts props', () => {
+    render(<Status id="st1" className="extra" />);
+    const el = screen.getByTestId('status');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'st1');
   });
 });

--- a/__tests__/daisy/display/Table.test.tsx
+++ b/__tests__/daisy/display/Table.test.tsx
@@ -4,9 +4,11 @@ import { render, screen } from '@testing-library/react';
 import Table from '../../../src/renderer/components/daisy/display/Table';
 
 describe('Table', () => {
-  it('renders', () => {
+  it('renders and accepts props', () => {
     render(
       <Table
+        id="tbl1"
+        className="extra"
         head={
           <tr>
             <th>H</th>
@@ -18,6 +20,9 @@ describe('Table', () => {
         </tr>
       </Table>
     );
-    expect(screen.getByTestId('table')).toBeInTheDocument();
+    const table = screen.getByTestId('table');
+    expect(table).toBeInTheDocument();
+    expect(table).toHaveClass('extra');
+    expect(table).toHaveAttribute('id', 'tbl1');
   });
 });

--- a/__tests__/daisy/display/Timeline.test.tsx
+++ b/__tests__/daisy/display/Timeline.test.tsx
@@ -4,12 +4,15 @@ import { render, screen } from '@testing-library/react';
 import Timeline from '../../../src/renderer/components/daisy/display/Timeline';
 
 describe('Timeline', () => {
-  it('renders', () => {
+  it('renders and accepts props', () => {
     render(
-      <Timeline>
+      <Timeline className="extra" id="tl1">
         <li>Step</li>
       </Timeline>
     );
-    expect(screen.getByTestId('timeline')).toBeInTheDocument();
+    const el = screen.getByTestId('timeline');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'tl1');
   });
 });

--- a/__tests__/daisy/feedback/Alert.test.tsx
+++ b/__tests__/daisy/feedback/Alert.test.tsx
@@ -6,9 +6,14 @@ import Alert from '../../../src/renderer/components/daisy/feedback/Alert';
 
 describe('Alert', () => {
   it('renders with variant and children', () => {
-    render(<Alert variant="success">done</Alert>);
+    render(
+      <Alert variant="success" className="extra">
+        done
+      </Alert>
+    );
     const el = screen.getByRole('alert');
     expect(el).toHaveTextContent('done');
     expect(el).toHaveClass('alert-success');
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/feedback/Loading.test.tsx
+++ b/__tests__/daisy/feedback/Loading.test.tsx
@@ -12,9 +12,10 @@ describe('Loading', () => {
   });
 
   it('supports other styles', () => {
-    render(<Loading style="dots" size="lg" />);
+    render(<Loading loadingStyle="dots" size="lg" className="extra" />);
     const el = screen.getByTestId('loading');
     expect(el).toHaveClass('loading-dots');
     expect(el).toHaveClass('loading-lg');
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/feedback/Progress.test.tsx
+++ b/__tests__/daisy/feedback/Progress.test.tsx
@@ -6,10 +6,11 @@ import Progress from '../../../src/renderer/components/daisy/feedback/Progress';
 
 describe('Progress', () => {
   it('renders progress bar', () => {
-    render(<Progress value={30} max={100} color="accent" />);
+    render(<Progress value={30} max={100} color="accent" className="extra" />);
     const bar = screen.getByTestId('progress') as HTMLProgressElement;
     expect(bar.value).toBe(30);
     expect(bar.max).toBe(100);
     expect(bar).toHaveClass('progress-accent');
+    expect(bar).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/feedback/RadialProgress.test.tsx
+++ b/__tests__/daisy/feedback/RadialProgress.test.tsx
@@ -6,9 +6,10 @@ import RadialProgress from '../../../src/renderer/components/daisy/feedback/Radi
 
 describe('RadialProgress', () => {
   it('renders radial progress', () => {
-    render(<RadialProgress value={70} size="4rem" />);
+    render(<RadialProgress value={70} size="4rem" className="extra" />);
     const el = screen.getByTestId('radial-progress');
     expect(el).toHaveTextContent('70%');
     expect(el).toHaveAttribute('aria-valuenow', '70');
+    expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/feedback/Skeleton.test.tsx
+++ b/__tests__/daisy/feedback/Skeleton.test.tsx
@@ -6,8 +6,10 @@ import Skeleton from '../../../src/renderer/components/daisy/feedback/Skeleton';
 
 describe('Skeleton', () => {
   it('renders skeleton with size', () => {
-    render(<Skeleton width="2rem" height="1rem" />);
+    render(<Skeleton width="2rem" height="1rem" className="extra" id="sk1" />);
     const el = screen.getByTestId('skeleton');
     expect(el).toHaveStyle({ width: '2rem', height: '1rem' });
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'sk1');
   });
 });

--- a/__tests__/daisy/feedback/Toast.test.tsx
+++ b/__tests__/daisy/feedback/Toast.test.tsx
@@ -7,11 +7,13 @@ import Toast from '../../../src/renderer/components/daisy/feedback/Toast';
 describe('Toast', () => {
   it('renders with position', () => {
     render(
-      <Toast position="top">
+      <Toast position="top" className="extra" id="toast1">
         <span>hello</span>
       </Toast>
     );
     const el = screen.getByText('hello').parentElement;
     expect(el).toHaveClass('toast-top');
+    expect(el).toHaveClass('extra');
+    expect(el).toHaveAttribute('id', 'toast1');
   });
 });

--- a/__tests__/daisy/feedback/Tooltip.test.tsx
+++ b/__tests__/daisy/feedback/Tooltip.test.tsx
@@ -7,12 +7,14 @@ import Tooltip from '../../../src/renderer/components/daisy/feedback/Tooltip';
 describe('Tooltip', () => {
   it('renders tooltip wrapper', () => {
     render(
-      <Tooltip tip="info" position="bottom">
+      <Tooltip tip="info" position="bottom" id="tip1" className="extra">
         <button>btn</button>
       </Tooltip>
     );
     const wrapper = screen.getByText('btn').parentElement;
     expect(wrapper).toHaveClass('tooltip-bottom');
     expect(wrapper).toHaveAttribute('data-tip', 'info');
+    expect(wrapper).toHaveClass('extra');
+    expect(wrapper).toHaveAttribute('id', 'tip1');
   });
 });

--- a/__tests__/daisy/layout/Drawer.test.tsx
+++ b/__tests__/daisy/layout/Drawer.test.tsx
@@ -6,12 +6,20 @@ import Drawer from '../../../src/renderer/components/daisy/layout/Drawer';
 describe('Drawer', () => {
   it('renders drawer structure', () => {
     const { container } = render(
-      <Drawer id="d1" side={<div>Side</div>}>
+      <Drawer
+        id="d1"
+        side={<div>Side</div>}
+        className="extra"
+        data-testid="drawer"
+      >
         <div>Content</div>
       </Drawer>
     );
     expect(container.querySelector('.drawer')).toBeInTheDocument();
     expect(container.querySelector('.drawer-content')).toBeInTheDocument();
     expect(container.querySelector('.drawer-side')).toBeInTheDocument();
+    const wrapper = container.querySelector('.drawer');
+    expect(wrapper).toHaveClass('extra');
+    expect(wrapper).toHaveAttribute('data-testid', 'drawer');
   });
 });

--- a/src/renderer/components/daisy/actions/Dropdown.tsx
+++ b/src/renderer/components/daisy/actions/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface DropdownProps {
+interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
   label: React.ReactNode;
   children: React.ReactNode;
   className?: string;
@@ -10,11 +10,13 @@ export default function Dropdown({
   label,
   children,
   className = '',
+  ...rest
 }: DropdownProps) {
   return (
     <div
       className={`dropdown ${className}`.trim()}
       data-testid="daisy-dropdown"
+      {...rest}
     >
       <div tabIndex={0} role="button" className="btn m-1">
         {label}

--- a/src/renderer/components/daisy/actions/Modal.tsx
+++ b/src/renderer/components/daisy/actions/Modal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import type { DaisyColor } from '../types';
 
-interface ModalProps {
+interface ModalProps extends React.DialogHTMLAttributes<HTMLDialogElement> {
   open?: boolean;
   children: React.ReactNode;
   className?: string;
@@ -18,6 +18,7 @@ export default function Modal({
   variant,
   testId = 'daisy-modal',
   onClose,
+  ...rest
 }: ModalProps) {
   if (!open) return null;
   const root = document.getElementById('overlay-root');
@@ -54,6 +55,7 @@ export default function Modal({
       tabIndex={-1}
       className="modal modal-open"
       data-testid={testId}
+      {...rest}
     >
       <div
         className={`modal-box ${

--- a/src/renderer/components/daisy/display/Accordion.tsx
+++ b/src/renderer/components/daisy/display/Accordion.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-interface AccordionProps {
+interface AccordionProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   title: React.ReactNode;
   children: React.ReactNode;
   className?: string;
@@ -12,11 +13,13 @@ export default function Accordion({
   children,
   className = '',
   defaultOpen = false,
+  ...rest
 }: AccordionProps) {
   return (
     <div
       className={`collapse collapse-arrow rounded-box border border-base-300 ${className}`.trim()}
       data-testid="accordion"
+      {...rest}
     >
       <input type="checkbox" defaultChecked={defaultOpen} />
       <div className="collapse-title text-lg font-medium">{title}</div>

--- a/src/renderer/components/daisy/display/Avatar.tsx
+++ b/src/renderer/components/daisy/display/Avatar.tsx
@@ -1,18 +1,28 @@
 import React from 'react';
 
-interface AvatarProps {
+interface AvatarProps extends React.HTMLAttributes<HTMLDivElement> {
   src: string;
   alt?: string;
   size?: number;
 }
 
-export default function Avatar({ src, alt, size = 64 }: AvatarProps) {
+export default function Avatar({
+  src,
+  alt,
+  size = 64,
+  className = '',
+  ...rest
+}: AvatarProps) {
   const style = {
     width: `${size}px`,
     height: `${size}px`,
   } as React.CSSProperties;
   return (
-    <div className="avatar" data-testid="avatar">
+    <div
+      className={`avatar ${className}`.trim()}
+      data-testid="avatar"
+      {...rest}
+    >
       <div className="rounded" style={style}>
         <img src={src} alt={alt} />
       </div>

--- a/src/renderer/components/daisy/display/Badge.tsx
+++ b/src/renderer/components/daisy/display/Badge.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
 import type { DaisyColor } from '../types';
+
+interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant?: DaisyColor;
+}
+
 export default function Badge({
   children,
   variant,
   className = '',
-}: {
-  children: React.ReactNode;
-  variant?: DaisyColor;
-  className?: string;
-}) {
+  ...rest
+}: BadgeProps) {
   return (
     <span
       className={`badge ${variant ? `badge-${variant}` : ''} ${className}`.trim()}
       data-testid="badge"
+      {...rest}
     >
       {children}
     </span>

--- a/src/renderer/components/daisy/display/Card.tsx
+++ b/src/renderer/components/daisy/display/Card.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
 
-interface CardProps {
+interface CardProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   title?: React.ReactNode;
   children?: React.ReactNode;
 }
 
-export default function Card({ title, children }: CardProps) {
+export default function Card({
+  title,
+  children,
+  className = '',
+  ...rest
+}: CardProps) {
   return (
-    <div className="card bg-base-100 shadow" data-testid="card">
+    <div
+      className={`card bg-base-100 shadow ${className}`.trim()}
+      data-testid="card"
+      {...rest}
+    >
       <div className="card-body">
         {title && <h2 className="card-title">{title}</h2>}
         {children}

--- a/src/renderer/components/daisy/display/Carousel.tsx
+++ b/src/renderer/components/daisy/display/Carousel.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
-export default function Carousel({ children }: { children: React.ReactNode }) {
+interface CarouselProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
+export default function Carousel({
+  children,
+  className = '',
+  ...rest
+}: CarouselProps) {
   return (
-    <div className="carousel" data-testid="carousel">
+    <div
+      className={`carousel ${className}`.trim()}
+      data-testid="carousel"
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/renderer/components/daisy/display/ChatBubble.tsx
+++ b/src/renderer/components/daisy/display/ChatBubble.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
+interface ChatBubbleProps extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode;
+}
+
 export default function ChatBubble({
   children,
-}: {
-  children: React.ReactNode;
-}) {
+  className = '',
+  ...rest
+}: ChatBubbleProps) {
   return (
-    <div className="chat-bubble" data-testid="chat-bubble">
+    <div
+      className={`chat-bubble ${className}`.trim()}
+      data-testid="chat-bubble"
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/renderer/components/daisy/display/Collapse.tsx
+++ b/src/renderer/components/daisy/display/Collapse.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-interface CollapseProps {
+interface CollapseProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   title: React.ReactNode;
   children: React.ReactNode;
   className?: string;
@@ -12,11 +13,13 @@ export default function Collapse({
   children,
   className = '',
   defaultOpen = false,
+  ...rest
 }: CollapseProps) {
   return (
     <div
       className={`collapse rounded-box border border-base-300 ${className}`.trim()}
       data-testid="collapse"
+      {...rest}
     >
       <input type="checkbox" defaultChecked={defaultOpen} />
       <div className="collapse-title text-lg font-medium">{title}</div>

--- a/src/renderer/components/daisy/display/Countdown.tsx
+++ b/src/renderer/components/daisy/display/Countdown.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
-export default function Countdown({ value }: { value: number }) {
+interface CountdownProps extends React.HTMLAttributes<HTMLSpanElement> {
+  value: number;
+}
+
+export default function Countdown({
+  value,
+  className = '',
+  ...rest
+}: CountdownProps) {
   return (
-    <span className="countdown font-mono text-2xl" data-testid="countdown">
+    <span
+      className={`countdown font-mono text-2xl ${className}`.trim()}
+      data-testid="countdown"
+      {...rest}
+    >
       <span style={{ '--value': value } as React.CSSProperties} />
     </span>
   );

--- a/src/renderer/components/daisy/display/Diff.tsx
+++ b/src/renderer/components/daisy/display/Diff.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 
-interface DiffProps {
+interface DiffProps extends React.HTMLAttributes<HTMLDivElement> {
   before: React.ReactNode;
   after: React.ReactNode;
 }
 
-export default function Diff({ before, after }: DiffProps) {
+export default function Diff({
+  before,
+  after,
+  className = '',
+  ...rest
+}: DiffProps) {
   return (
-    <div className="diff" data-testid="diff">
+    <div className={`diff ${className}`.trim()} data-testid="diff" {...rest}>
       <div className="diff-item-1">{before}</div>
       <div className="diff-item-2">{after}</div>
     </div>

--- a/src/renderer/components/daisy/display/List.tsx
+++ b/src/renderer/components/daisy/display/List.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 
-export default function List({ children }: { children: React.ReactNode }) {
+interface ListProps extends React.HTMLAttributes<HTMLUListElement> {
+  children: React.ReactNode;
+}
+
+export default function List({ children, className = '', ...rest }: ListProps) {
   return (
-    <ul className="list list-disc" data-testid="list">
+    <ul
+      className={`list list-disc ${className}`.trim()}
+      data-testid="list"
+      {...rest}
+    >
       {children}
     </ul>
   );

--- a/src/renderer/components/daisy/display/Stat.tsx
+++ b/src/renderer/components/daisy/display/Stat.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 
-interface StatProps {
+interface StatProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   title: React.ReactNode;
   value: React.ReactNode;
   desc?: React.ReactNode;
 }
 
-export default function Stat({ title, value, desc }: StatProps) {
+export default function Stat({
+  title,
+  value,
+  desc,
+  className = '',
+  ...rest
+}: StatProps) {
   return (
-    <div className="stat" data-testid="stat">
+    <div className={`stat ${className}`.trim()} data-testid="stat" {...rest}>
       <div className="stat-title">{title}</div>
       <div className="stat-value">{value}</div>
       {desc && <div className="stat-desc">{desc}</div>}

--- a/src/renderer/components/daisy/display/Status.tsx
+++ b/src/renderer/components/daisy/display/Status.tsx
@@ -1,5 +1,19 @@
 import React from 'react';
 
-export default function Status({ color = 'primary' }: { color?: string }) {
-  return <span className={`status status-${color}`} data-testid="status" />;
+interface StatusProps extends React.HTMLAttributes<HTMLSpanElement> {
+  color?: string;
+}
+
+export default function Status({
+  color = 'primary',
+  className = '',
+  ...rest
+}: StatusProps) {
+  return (
+    <span
+      className={`status status-${color} ${className}`.trim()}
+      data-testid="status"
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/display/Table.tsx
+++ b/src/renderer/components/daisy/display/Table.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 
-interface TableProps {
+interface TableProps extends React.HTMLAttributes<HTMLDivElement> {
   head?: React.ReactNode;
   children: React.ReactNode;
 }
 
-export default function Table({ head, children }: TableProps) {
+export default function Table({
+  head,
+  children,
+  className = '',
+  ...rest
+}: TableProps) {
   return (
-    <div className="overflow-x-auto" data-testid="table">
+    <div
+      className={`overflow-x-auto ${className}`.trim()}
+      data-testid="table"
+      {...rest}
+    >
       <table className="table">
         {head && <thead>{head}</thead>}
         <tbody>{children}</tbody>

--- a/src/renderer/components/daisy/display/Timeline.tsx
+++ b/src/renderer/components/daisy/display/Timeline.tsx
@@ -1,8 +1,20 @@
 import React from 'react';
 
-export default function Timeline({ children }: { children: React.ReactNode }) {
+interface TimelineProps extends React.HTMLAttributes<HTMLUListElement> {
+  children: React.ReactNode;
+}
+
+export default function Timeline({
+  children,
+  className = '',
+  ...rest
+}: TimelineProps) {
   return (
-    <ul className="timeline" data-testid="timeline">
+    <ul
+      className={`timeline ${className}`.trim()}
+      data-testid="timeline"
+      {...rest}
+    >
       {children}
     </ul>
   );

--- a/src/renderer/components/daisy/feedback/Alert.tsx
+++ b/src/renderer/components/daisy/feedback/Alert.tsx
@@ -2,15 +2,22 @@ import React from 'react';
 
 export type AlertVariant = 'info' | 'success' | 'warning' | 'error';
 
+interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: AlertVariant;
+}
+
 export default function Alert({
   children,
   variant = 'info',
-}: {
-  children: React.ReactNode;
-  variant?: AlertVariant;
-}) {
+  className = '',
+  ...rest
+}: AlertProps) {
   return (
-    <div role="alert" className={`alert alert-${variant}`}>
+    <div
+      role="alert"
+      className={`alert alert-${variant} ${className}`.trim()}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/renderer/components/daisy/feedback/Loading.tsx
+++ b/src/renderer/components/daisy/feedback/Loading.tsx
@@ -9,18 +9,24 @@ export type LoadingStyle =
   | 'infinity';
 export type LoadingSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
-export default function Loading({
-  style = 'spinner',
-  size = 'md',
-}: {
-  style?: LoadingStyle;
+interface LoadingProps
+  extends Omit<React.HTMLAttributes<HTMLSpanElement>, 'style'> {
+  loadingStyle?: LoadingStyle;
   size?: LoadingSize;
-}) {
+}
+
+export default function Loading({
+  loadingStyle = 'spinner',
+  size = 'md',
+  className = '',
+  ...rest
+}: LoadingProps) {
   return (
     <span
-      className={`loading loading-${style} loading-${size}`}
+      className={`loading loading-${loadingStyle} loading-${size} ${className}`.trim()}
       aria-label="loading"
       data-testid="loading"
+      {...rest}
     />
   );
 }

--- a/src/renderer/components/daisy/feedback/Progress.tsx
+++ b/src/renderer/components/daisy/feedback/Progress.tsx
@@ -10,21 +10,27 @@ export type ProgressColor =
   | 'warning'
   | 'error';
 
+interface ProgressProps
+  extends React.ProgressHTMLAttributes<HTMLProgressElement> {
+  value: number;
+  max: number;
+  color?: ProgressColor;
+}
+
 export default function Progress({
   value,
   max,
   color = 'primary',
-}: {
-  value: number;
-  max: number;
-  color?: ProgressColor;
-}) {
+  className = '',
+  ...rest
+}: ProgressProps) {
   return (
     <progress
-      className={`progress progress-${color}`}
+      className={`progress progress-${color} ${className}`.trim()}
       value={value}
       max={max}
       data-testid="progress"
+      {...rest}
     />
   );
 }

--- a/src/renderer/components/daisy/feedback/RadialProgress.tsx
+++ b/src/renderer/components/daisy/feedback/RadialProgress.tsx
@@ -1,17 +1,21 @@
 import React from 'react';
 
+interface RadialProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+  size?: string;
+  thickness?: string;
+}
+
 export default function RadialProgress({
   value,
   size = '5rem',
   thickness,
-}: {
-  value: number;
-  size?: string;
-  thickness?: string;
-}) {
+  className = '',
+  ...rest
+}: RadialProgressProps) {
   return (
     <div
-      className="radial-progress"
+      className={`radial-progress ${className}`.trim()}
       style={
         {
           '--value': value.toString(),
@@ -22,6 +26,7 @@ export default function RadialProgress({
       role="progressbar"
       aria-valuenow={value}
       data-testid="radial-progress"
+      {...rest}
     >
       {value}%
     </div>

--- a/src/renderer/components/daisy/feedback/Skeleton.tsx
+++ b/src/renderer/components/daisy/feedback/Skeleton.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 
+interface SkeletonProps extends React.HTMLAttributes<HTMLDivElement> {
+  width?: string;
+  height?: string;
+}
+
 export default function Skeleton({
   width,
   height,
-}: {
-  width?: string;
-  height?: string;
-}) {
+  className = '',
+  ...rest
+}: SkeletonProps) {
   return (
     <div
-      className="skeleton"
+      className={`skeleton ${className}`.trim()}
       style={{ width, height }}
       data-testid="skeleton"
+      {...rest}
     />
   );
 }

--- a/src/renderer/components/daisy/feedback/Toast.tsx
+++ b/src/renderer/components/daisy/feedback/Toast.tsx
@@ -8,12 +8,19 @@ export type ToastPosition =
   | 'middle'
   | 'bottom';
 
+interface ToastProps extends React.HTMLAttributes<HTMLDivElement> {
+  position?: ToastPosition;
+}
+
 export default function Toast({
   children,
   position = 'end',
-}: {
-  children: React.ReactNode;
-  position?: ToastPosition;
-}) {
-  return <div className={`toast toast-${position}`}>{children}</div>;
+  className = '',
+  ...rest
+}: ToastProps & { children: React.ReactNode }) {
+  return (
+    <div className={`toast toast-${position} ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
 }

--- a/src/renderer/components/daisy/feedback/Tooltip.tsx
+++ b/src/renderer/components/daisy/feedback/Tooltip.tsx
@@ -14,18 +14,25 @@ export type TooltipPosition =
   | 'right-start'
   | 'right-end';
 
+interface TooltipProps extends React.HTMLAttributes<HTMLDivElement> {
+  tip: string;
+  position?: TooltipPosition;
+}
+
 export default function Tooltip({
   tip,
   children,
   position,
-}: {
-  tip: string;
-  children: React.ReactNode;
-  position?: TooltipPosition;
-}) {
+  className = '',
+  ...rest
+}: TooltipProps & { children: React.ReactNode }) {
   const posClass = position ? `tooltip-${position}` : '';
   return (
-    <div className={`tooltip ${posClass}`.trim()} data-tip={tip}>
+    <div
+      className={`tooltip ${posClass} ${className}`.trim()}
+      data-tip={tip}
+      {...rest}
+    >
       {children}
     </div>
   );

--- a/src/renderer/components/daisy/layout/Drawer.tsx
+++ b/src/renderer/components/daisy/layout/Drawer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-interface DrawerProps {
+interface DrawerProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string;
   side: React.ReactNode;
   children: React.ReactNode;
@@ -12,9 +12,10 @@ export default function Drawer({
   side,
   children,
   className = '',
+  ...rest
 }: DrawerProps) {
   return (
-    <div className={`drawer ${className}`.trim()}>
+    <div className={`drawer ${className}`.trim()} {...rest}>
       <input id={id} type="checkbox" className="drawer-toggle" />
       <div className="drawer-content">{children}</div>
       <div className="drawer-side">

--- a/src/renderer/components/modals/ImportWizardModal.tsx
+++ b/src/renderer/components/modals/ImportWizardModal.tsx
@@ -35,7 +35,7 @@ export default function ImportWizardModal({
     return (
       <Modal open className="flex flex-col items-center">
         <h3 className="font-bold text-lg mb-2">Importing...</h3>
-        <Loading style="spinner" size="lg" />
+        <Loading loadingStyle="spinner" size="lg" />
       </Modal>
     );
   }


### PR DESCRIPTION
## Summary
- expand prop forwarding for Daisy UI components
- update related tests for new prop behavior

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685482a69f7c83319d735f6d82f21f7a