### PR TITLE
Enhance more daisy components

### DIFF
--- a/__tests__/daisy/actions/Button.test.tsx
+++ b/__tests__/daisy/actions/Button.test.tsx
@@ -4,9 +4,14 @@ import { render, screen } from '@testing-library/react';
 import Button from '../../../src/renderer/components/daisy/actions/Button';
 describe('daisy Button', () => {
   it('renders button', () => {
-    render(<Button variant="secondary">Click</Button>);
+    render(
+      <Button variant="secondary" size="lg">
+        Click
+      </Button>
+    );
     const btn = screen.getByTestId('daisy-button');
     expect(btn).toBeInTheDocument();
     expect(btn).toHaveClass('btn-secondary');
+    expect(btn).toHaveClass('btn-lg');
   });
 });

--- a/__tests__/daisy/actions/Dropdown.test.tsx
+++ b/__tests__/daisy/actions/Dropdown.test.tsx
@@ -6,12 +6,21 @@ import Dropdown from '../../../src/renderer/components/daisy/actions/Dropdown';
 describe('daisy Dropdown', () => {
   it('renders dropdown and accepts props', () => {
     render(
-      <Dropdown label="Menu" className="extra" data-testid="drop">
+      <Dropdown
+        label="Menu"
+        className="extra"
+        variant="primary"
+        size="sm"
+        data-testid="drop"
+      >
         <li>Item</li>
       </Dropdown>
     );
     const el = screen.getByTestId('drop');
     expect(el).toBeInTheDocument();
     expect(el).toHaveClass('extra');
+    const btn = el.querySelector('.btn');
+    expect(btn).toHaveClass('btn-primary');
+    expect(btn).toHaveClass('btn-sm');
   });
 });

--- a/__tests__/daisy/display/Badge.test.tsx
+++ b/__tests__/daisy/display/Badge.test.tsx
@@ -6,13 +6,14 @@ import Badge from '../../../src/renderer/components/daisy/display/Badge';
 describe('Badge', () => {
   it('renders and accepts props', () => {
     render(
-      <Badge variant="accent" id="b1" className="extra">
+      <Badge variant="accent" size="lg" id="b1" className="extra">
         Hi
       </Badge>
     );
     const badge = screen.getByTestId('badge');
     expect(badge).toBeInTheDocument();
     expect(badge).toHaveClass('badge-accent');
+    expect(badge).toHaveClass('badge-lg');
     expect(badge).toHaveClass('extra');
     expect(badge).toHaveAttribute('id', 'b1');
   });

--- a/__tests__/daisy/display/Card.test.tsx
+++ b/__tests__/daisy/display/Card.test.tsx
@@ -4,14 +4,22 @@ import { render, screen } from '@testing-library/react';
 import Card from '../../../src/renderer/components/daisy/display/Card';
 
 describe('Card', () => {
-  it('renders and accepts props', () => {
+  it('renders variant and size', () => {
     render(
-      <Card title="Title" className="extra" id="c1">
+      <Card
+        title="Title"
+        variant="accent"
+        size="compact"
+        className="extra"
+        id="c1"
+      >
         Body
       </Card>
     );
     const card = screen.getByTestId('card');
     expect(card).toBeInTheDocument();
+    expect(card).toHaveClass('bg-accent');
+    expect(card).toHaveClass('card-compact');
     expect(card).toHaveClass('extra');
     expect(card).toHaveAttribute('id', 'c1');
   });

--- a/__tests__/daisy/feedback/Alert.test.tsx
+++ b/__tests__/daisy/feedback/Alert.test.tsx
@@ -5,15 +5,16 @@ import { render, screen } from '@testing-library/react';
 import Alert from '../../../src/renderer/components/daisy/feedback/Alert';
 
 describe('Alert', () => {
-  it('renders with variant and children', () => {
+  it('renders variant and size', () => {
     render(
-      <Alert variant="success" className="extra">
+      <Alert variant="success" size="lg" className="extra">
         done
       </Alert>
     );
     const el = screen.getByRole('alert');
     expect(el).toHaveTextContent('done');
     expect(el).toHaveClass('alert-success');
+    expect(el).toHaveClass('alert-lg');
     expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Checkbox.test.tsx
+++ b/__tests__/daisy/input/Checkbox.test.tsx
@@ -4,8 +4,11 @@ import { describe, it, expect } from 'vitest';
 import { Checkbox } from '../../../src/renderer/components/daisy/input';
 
 describe('Checkbox', () => {
-  it('renders', () => {
-    render(<Checkbox data-testid="cb" />);
-    expect(screen.getByTestId('cb')).toBeInTheDocument();
+  it('renders variant and size', () => {
+    render(<Checkbox data-testid="cb" variant="success" size="lg" />);
+    const el = screen.getByTestId('cb');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('checkbox-success');
+    expect(el).toHaveClass('checkbox-lg');
   });
 });

--- a/__tests__/daisy/input/FileInput.test.tsx
+++ b/__tests__/daisy/input/FileInput.test.tsx
@@ -4,8 +4,11 @@ import { describe, it, expect } from 'vitest';
 import { FileInput } from '../../../src/renderer/components/daisy/input';
 
 describe('FileInput', () => {
-  it('renders', () => {
-    render(<FileInput data-testid="file" />);
-    expect(screen.getByTestId('file')).toBeInTheDocument();
+  it('renders variant and size', () => {
+    render(<FileInput data-testid="file" variant="primary" size="sm" />);
+    const el = screen.getByTestId('file');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('file-input-primary');
+    expect(el).toHaveClass('file-input-sm');
   });
 });

--- a/__tests__/daisy/input/InputField.test.tsx
+++ b/__tests__/daisy/input/InputField.test.tsx
@@ -4,10 +4,19 @@ import { describe, it, expect } from 'vitest';
 import { InputField } from '../../../src/renderer/components/daisy/input';
 
 describe('InputField', () => {
-  it('renders and accepts className', () => {
-    render(<InputField data-testid="inp" className="extra" />);
+  it('renders variant and size', () => {
+    render(
+      <InputField
+        data-testid="inp"
+        variant="accent"
+        size="lg"
+        className="extra"
+      />
+    );
     const el = screen.getByTestId('inp');
     expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('input-accent');
+    expect(el).toHaveClass('input-lg');
     expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Radio.test.tsx
+++ b/__tests__/daisy/input/Radio.test.tsx
@@ -4,8 +4,11 @@ import { describe, it, expect } from 'vitest';
 import { Radio } from '../../../src/renderer/components/daisy/input';
 
 describe('Radio', () => {
-  it('renders', () => {
-    render(<Radio data-testid="radio" />);
-    expect(screen.getByTestId('radio')).toBeInTheDocument();
+  it('renders variant and size', () => {
+    render(<Radio data-testid="radio" variant="warning" size="sm" />);
+    const el = screen.getByTestId('radio');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('radio-warning');
+    expect(el).toHaveClass('radio-sm');
   });
 });

--- a/__tests__/daisy/input/Range.test.tsx
+++ b/__tests__/daisy/input/Range.test.tsx
@@ -4,10 +4,14 @@ import { describe, it, expect } from 'vitest';
 import { Range } from '../../../src/renderer/components/daisy/input';
 
 describe('Range', () => {
-  it('renders and accepts className', () => {
-    render(<Range data-testid="rng" className="extra" />);
+  it('renders variant and size', () => {
+    render(
+      <Range data-testid="rng" variant="error" size="xs" className="extra" />
+    );
     const el = screen.getByTestId('rng');
     expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('range-error');
+    expect(el).toHaveClass('range-xs');
     expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Select.test.tsx
+++ b/__tests__/daisy/input/Select.test.tsx
@@ -4,14 +4,16 @@ import { describe, it, expect } from 'vitest';
 import { Select } from '../../../src/renderer/components/daisy/input';
 
 describe('Select', () => {
-  it('renders and accepts className', () => {
+  it('renders variant and size', () => {
     render(
-      <Select data-testid="sel" className="extra">
+      <Select data-testid="sel" variant="primary" size="sm" className="extra">
         <option>1</option>
       </Select>
     );
     const el = screen.getByTestId('sel');
     expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('select-primary');
+    expect(el).toHaveClass('select-sm');
     expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Textarea.test.tsx
+++ b/__tests__/daisy/input/Textarea.test.tsx
@@ -4,10 +4,19 @@ import { describe, it, expect } from 'vitest';
 import { Textarea } from '../../../src/renderer/components/daisy/input';
 
 describe('Textarea', () => {
-  it('renders and accepts className', () => {
-    render(<Textarea data-testid="ta" className="extra" />);
+  it('renders variant and size', () => {
+    render(
+      <Textarea
+        data-testid="ta"
+        variant="secondary"
+        size="xs"
+        className="extra"
+      />
+    );
     const el = screen.getByTestId('ta');
     expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('textarea-secondary');
+    expect(el).toHaveClass('textarea-xs');
     expect(el).toHaveClass('extra');
   });
 });

--- a/__tests__/daisy/input/Toggle.test.tsx
+++ b/__tests__/daisy/input/Toggle.test.tsx
@@ -4,8 +4,11 @@ import { describe, it, expect } from 'vitest';
 import { Toggle } from '../../../src/renderer/components/daisy/input';
 
 describe('Toggle', () => {
-  it('renders', () => {
-    render(<Toggle data-testid="tog" />);
-    expect(screen.getByTestId('tog')).toBeInTheDocument();
+  it('renders variant and size', () => {
+    render(<Toggle data-testid="tog" variant="info" size="xl" />);
+    const el = screen.getByTestId('tog');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('toggle-info');
+    expect(el).toHaveClass('toggle-xl');
   });
 });

--- a/__tests__/daisy/layout/Drawer.test.tsx
+++ b/__tests__/daisy/layout/Drawer.test.tsx
@@ -4,11 +4,12 @@ import { render } from '@testing-library/react';
 import Drawer from '../../../src/renderer/components/daisy/layout/Drawer';
 
 describe('Drawer', () => {
-  it('renders drawer structure', () => {
+  it('renders variant overlay', () => {
     const { container } = render(
       <Drawer
         id="d1"
         side={<div>Side</div>}
+        variant="accent"
         className="extra"
         data-testid="drawer"
       >
@@ -21,5 +22,7 @@ describe('Drawer', () => {
     const wrapper = container.querySelector('.drawer');
     expect(wrapper).toHaveClass('extra');
     expect(wrapper).toHaveAttribute('data-testid', 'drawer');
+    const overlay = container.querySelector('.drawer-overlay');
+    expect(overlay).toHaveClass('bg-accent');
   });
 });

--- a/__tests__/daisy/navigation/Menu.test.tsx
+++ b/__tests__/daisy/navigation/Menu.test.tsx
@@ -5,13 +5,15 @@ import { describe, it, expect } from 'vitest';
 import { Menu } from '../../../src/renderer/components/daisy/navigation';
 
 describe('Menu', () => {
-  it('renders menu list', () => {
+  it('renders variant and size', () => {
     const { container } = render(
-      <Menu>
+      <Menu variant="accent" size="lg">
         <li>Item</li>
       </Menu>
     );
     expect(container.firstChild).toHaveClass('menu');
+    expect(container.firstChild).toHaveClass('menu-accent');
+    expect(container.firstChild).toHaveClass('menu-lg');
     expect(screen.getByText('Item')).toBeInTheDocument();
   });
 });

--- a/__tests__/daisy/typography/Paragraph.test.tsx
+++ b/__tests__/daisy/typography/Paragraph.test.tsx
@@ -4,8 +4,16 @@ import { describe, it, expect } from 'vitest';
 import { Paragraph } from '../../../src/renderer/components/daisy/typography';
 
 describe('Paragraph', () => {
-  it('renders', () => {
-    render(<Paragraph>Text</Paragraph>);
-    expect(screen.getByTestId('paragraph')).toBeInTheDocument();
+  it('renders variant and size', () => {
+    render(
+      <Paragraph variant="accent" size="lg" className="extra">
+        Text
+      </Paragraph>
+    );
+    const el = screen.getByTestId('paragraph');
+    expect(el).toBeInTheDocument();
+    expect(el).toHaveClass('text-accent');
+    expect(el).toHaveClass('text-lg');
+    expect(el).toHaveClass('extra');
   });
 });

--- a/src/renderer/components/daisy/actions/Button.tsx
+++ b/src/renderer/components/daisy/actions/Button.tsx
@@ -1,18 +1,21 @@
 import React from 'react';
-import type { DaisyColor } from '../types';
+import type { DaisyColor, DaisySize } from '../types';
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   className?: string;
   variant?: DaisyColor;
+  size?: DaisySize;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ children, className = '', variant, ...rest }, ref) => (
+  ({ children, className = '', variant, size, ...rest }, ref) => (
     <button
       ref={ref}
-      className={`btn ${variant ? `btn-${variant}` : ''} ${className}`.trim()}
+      className={`btn ${variant ? `btn-${variant}` : ''} ${
+        size ? `btn-${size}` : ''
+      } ${className}`.trim()}
       {...rest}
       data-testid="daisy-button"
     >

--- a/src/renderer/components/daisy/actions/Dropdown.tsx
+++ b/src/renderer/components/daisy/actions/Dropdown.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
 interface DropdownProps extends React.HTMLAttributes<HTMLDivElement> {
   label: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  variant?: DaisyColor;
+  size?: DaisySize;
 }
 
 export default function Dropdown({
   label,
   children,
   className = '',
+  variant,
+  size,
   ...rest
 }: DropdownProps) {
   return (
@@ -18,7 +23,13 @@ export default function Dropdown({
       data-testid="daisy-dropdown"
       {...rest}
     >
-      <div tabIndex={0} role="button" className="btn m-1">
+      <div
+        tabIndex={0}
+        role="button"
+        className={`btn m-1 ${variant ? `btn-${variant}` : ''} ${
+          size ? `btn-${size}` : ''
+        }`.trim()}
+      >
         {label}
       </div>
       <ul

--- a/src/renderer/components/daisy/display/Badge.tsx
+++ b/src/renderer/components/daisy/display/Badge.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
-import type { DaisyColor } from '../types';
+import type { DaisyColor, DaisySize } from '../types';
 
 interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: DaisyColor;
+  size?: DaisySize;
 }
 
 export default function Badge({
   children,
   variant,
+  size,
   className = '',
   ...rest
 }: BadgeProps) {
   return (
     <span
-      className={`badge ${variant ? `badge-${variant}` : ''} ${className}`.trim()}
+      className={`badge ${variant ? `badge-${variant}` : ''} ${
+        size ? `badge-${size}` : ''
+      } ${className}`.trim()}
       data-testid="badge"
       {...rest}
     >

--- a/src/renderer/components/daisy/display/Card.tsx
+++ b/src/renderer/components/daisy/display/Card.tsx
@@ -1,20 +1,27 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
 interface CardProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
   title?: React.ReactNode;
   children?: React.ReactNode;
+  variant?: DaisyColor;
+  size?: DaisySize;
 }
 
 export default function Card({
   title,
   children,
+  variant,
+  size,
   className = '',
   ...rest
 }: CardProps) {
   return (
     <div
-      className={`card bg-base-100 shadow ${className}`.trim()}
+      className={`card bg-base-100 shadow ${
+        variant ? `bg-${variant} text-${variant}-content` : ''
+      } ${size ? `card-${size}` : ''} ${className}`.trim()}
       data-testid="card"
       {...rest}
     >

--- a/src/renderer/components/daisy/feedback/Alert.tsx
+++ b/src/renderer/components/daisy/feedback/Alert.tsx
@@ -2,20 +2,24 @@ import React from 'react';
 
 export type AlertVariant = 'info' | 'success' | 'warning' | 'error';
 
+import type { DaisySize } from '../types';
+
 interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: AlertVariant;
+  size?: DaisySize;
 }
 
 export default function Alert({
   children,
   variant = 'info',
+  size,
   className = '',
   ...rest
 }: AlertProps) {
   return (
     <div
       role="alert"
-      className={`alert alert-${variant} ${className}`.trim()}
+      className={`alert alert-${variant} ${size ? `alert-${size}` : ''} ${className}`.trim()}
       {...rest}
     >
       {children}

--- a/src/renderer/components/daisy/input/Checkbox.tsx
+++ b/src/renderer/components/daisy/input/Checkbox.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
-export default function Checkbox(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input type="checkbox" className="checkbox" {...props} />;
+interface CheckboxProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
+
+export default function Checkbox({
+  variant,
+  size,
+  className = '',
+  ...rest
+}: CheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      className={`checkbox ${variant ? `checkbox-${variant}` : ''} ${
+        size ? `checkbox-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/input/FileInput.tsx
+++ b/src/renderer/components/daisy/input/FileInput.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
-export default function FileInput(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input type="file" className="file-input" {...props} />;
+interface FileInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
+
+export default function FileInput({
+  variant,
+  size,
+  className = '',
+  ...rest
+}: FileInputProps) {
+  return (
+    <input
+      type="file"
+      className={`file-input ${variant ? `file-input-${variant}` : ''} ${
+        size ? `file-input-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/input/InputField.tsx
+++ b/src/renderer/components/daisy/input/InputField.tsx
@@ -1,15 +1,23 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
-const InputField = React.forwardRef<
-  HTMLInputElement,
-  React.InputHTMLAttributes<HTMLInputElement>
->(({ className = '', ...rest }, ref) => (
-  <input
-    ref={ref}
-    className={`input input-bordered ${className}`.trim()}
-    {...rest}
-  />
-));
+interface InputFieldProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
+
+const InputField = React.forwardRef<HTMLInputElement, InputFieldProps>(
+  ({ className = '', variant, size, ...rest }, ref) => (
+    <input
+      ref={ref}
+      className={`input input-bordered ${variant ? `input-${variant}` : ''} ${
+        size ? `input-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  )
+);
 
 InputField.displayName = 'InputField';
 

--- a/src/renderer/components/daisy/input/Radio.tsx
+++ b/src/renderer/components/daisy/input/Radio.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
-export default function Radio(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input type="radio" className="radio" {...props} />;
+interface RadioProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
+
+export default function Radio({
+  variant,
+  size,
+  className = '',
+  ...rest
+}: RadioProps) {
+  return (
+    <input
+      type="radio"
+      className={`radio ${variant ? `radio-${variant}` : ''} ${
+        size ? `radio-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/input/Range.tsx
+++ b/src/renderer/components/daisy/input/Range.tsx
@@ -1,10 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
+
+interface RangeProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
 
 export default function Range({
   className = '',
+  variant,
+  size,
   ...rest
-}: React.InputHTMLAttributes<HTMLInputElement>) {
+}: RangeProps) {
   return (
-    <input type="range" className={`range ${className}`.trim()} {...rest} />
+    <input
+      type="range"
+      className={`range ${variant ? `range-${variant}` : ''} ${
+        size ? `range-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
   );
 }

--- a/src/renderer/components/daisy/input/Select.tsx
+++ b/src/renderer/components/daisy/input/Select.tsx
@@ -1,12 +1,26 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
+
+interface SelectProps
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
 
 export default function Select({
   children,
   className = '',
+  variant,
+  size,
   ...rest
-}: React.SelectHTMLAttributes<HTMLSelectElement>) {
+}: SelectProps) {
   return (
-    <select className={`select ${className}`.trim()} {...rest}>
+    <select
+      className={`select ${variant ? `select-${variant}` : ''} ${
+        size ? `select-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    >
       {children}
     </select>
   );

--- a/src/renderer/components/daisy/input/Textarea.tsx
+++ b/src/renderer/components/daisy/input/Textarea.tsx
@@ -1,8 +1,24 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
+
+interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
 
 export default function Textarea({
   className = '',
+  variant,
+  size,
   ...rest
-}: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
-  return <textarea className={`textarea ${className}`.trim()} {...rest} />;
+}: TextareaProps) {
+  return (
+    <textarea
+      className={`textarea ${variant ? `textarea-${variant}` : ''} ${
+        size ? `textarea-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/input/Toggle.tsx
+++ b/src/renderer/components/daisy/input/Toggle.tsx
@@ -1,7 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
 
-export default function Toggle(
-  props: React.InputHTMLAttributes<HTMLInputElement>
-) {
-  return <input type="checkbox" className="toggle" {...props} />;
+interface ToggleProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
+
+export default function Toggle({
+  variant,
+  size,
+  className = '',
+  ...rest
+}: ToggleProps) {
+  return (
+    <input
+      type="checkbox"
+      className={`toggle ${variant ? `toggle-${variant}` : ''} ${
+        size ? `toggle-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    />
+  );
 }

--- a/src/renderer/components/daisy/layout/Drawer.tsx
+++ b/src/renderer/components/daisy/layout/Drawer.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
+import type { DaisyColor } from '../types';
 
 interface DrawerProps extends React.HTMLAttributes<HTMLDivElement> {
   id: string;
   side: React.ReactNode;
   children: React.ReactNode;
   className?: string;
+  variant?: DaisyColor;
 }
 
 export default function Drawer({
   id,
   side,
   children,
+  variant,
   className = '',
   ...rest
 }: DrawerProps) {
@@ -19,7 +22,12 @@ export default function Drawer({
       <input id={id} type="checkbox" className="drawer-toggle" />
       <div className="drawer-content">{children}</div>
       <div className="drawer-side">
-        <label htmlFor={id} className="drawer-overlay" />
+        <label
+          htmlFor={id}
+          className={`drawer-overlay ${
+            variant ? `bg-${variant} bg-opacity-50` : ''
+          }`.trim()}
+        />
         {side}
       </div>
     </div>

--- a/src/renderer/components/daisy/navigation/Menu.tsx
+++ b/src/renderer/components/daisy/navigation/Menu.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
+
+interface MenuProps extends React.HTMLAttributes<HTMLUListElement> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
 
 export default function Menu({
   children,
+  variant,
+  size,
   className = '',
   ...rest
-}: React.HTMLAttributes<HTMLUListElement>) {
+}: MenuProps) {
   return (
-    <ul className={`menu ${className}`.trim()} {...rest}>
+    <ul
+      className={`menu ${variant ? `menu-${variant}` : ''} ${
+        size ? `menu-${size}` : ''
+      } ${className}`.trim()}
+      {...rest}
+    >
       {children}
     </ul>
   );

--- a/src/renderer/components/daisy/types.ts
+++ b/src/renderer/components/daisy/types.ts
@@ -7,3 +7,5 @@ export type DaisyColor =
   | 'success'
   | 'warning'
   | 'error';
+
+export type DaisySize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';

--- a/src/renderer/components/daisy/typography/Paragraph.tsx
+++ b/src/renderer/components/daisy/typography/Paragraph.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
+import type { DaisyColor, DaisySize } from '../types';
+interface ParagraphProps extends React.HTMLAttributes<HTMLParagraphElement> {
+  variant?: DaisyColor;
+  size?: DaisySize;
+}
 
 export default function Paragraph({
   children,
+  variant,
+  size,
   className = '',
   ...rest
-}: React.HTMLAttributes<HTMLParagraphElement>) {
+}: ParagraphProps) {
   return (
-    <p className={`mb-2 ${className}`.trim()} data-testid="paragraph" {...rest}>
+    <p
+      className={`mb-2 ${variant ? `text-${variant}` : ''} ${
+        size ? `text-${size}` : ''
+      } ${className}`.trim()}
+      data-testid="paragraph"
+      {...rest}
+    >
       {children}
     </p>
   );


### PR DESCRIPTION
## Summary
- extend `Card`, `Alert`, `Drawer`, `Menu` and `Paragraph` with `variant` and `size` props
- add tests verifying these new props

## Testing
- `npm run lint`
- `npm test`
- `npm run format`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6854f7bef9f883319cab764b4a264726