### PR TITLE
Introduce store-driven project actions

### DIFF
--- a/__tests__/ProjectContextMenu.test.tsx
+++ b/__tests__/ProjectContextMenu.test.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProjectContextMenu from '../src/renderer/components/project/ProjectContextMenu';
+import ProjectModals from '../src/renderer/components/project/ProjectModals';
+import { useAppStore } from '../src/renderer/store';
 
 describe('ProjectContextMenu', () => {
   it('fires callbacks and renders to overlay root', async () => {
     const open = vi.fn();
-    const dup = vi.fn();
-    const del = vi.fn();
+    (
+      window as unknown as { electronAPI: { openProject: typeof open } }
+    ).electronAPI = {
+      openProject: open,
+    } as any;
     render(
-      <ProjectContextMenu
-        project="Test"
-        onOpen={open}
-        onDuplicate={dup}
-        onDelete={del}
-      />
+      <>
+        <ProjectContextMenu project="Test" />
+        <ProjectModals refresh={() => {}} toast={() => {}} />
+      </>
     );
     const root = document.getElementById('overlay-root');
     expect(root?.querySelector('ul')).toBeInTheDocument();
@@ -24,8 +27,8 @@ describe('ProjectContextMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
     expect(open).toHaveBeenCalledWith('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
-    expect(dup).toHaveBeenCalledWith('Test');
+    expect(useAppStore.getState().duplicateTarget).toBe('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    expect(del).toHaveBeenCalledWith('Test');
+    expect(useAppStore.getState().deleteTarget).toBe('Test');
   });
 });

--- a/__tests__/ProjectRow.test.tsx
+++ b/__tests__/ProjectRow.test.tsx
@@ -3,6 +3,8 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import ProjectRow from '../src/renderer/components/project/ProjectRow';
 import type { ProjectInfo } from '../src/renderer/components/project/ProjectTable';
+import ProjectModals from '../src/renderer/components/project/ProjectModals';
+import { useAppStore } from '../src/renderer/store';
 
 describe('ProjectRow', () => {
   const projects: ProjectInfo[] = [
@@ -12,39 +14,50 @@ describe('ProjectRow', () => {
 
   it('calls button callbacks', () => {
     const open = vi.fn();
-    const dup = vi.fn();
-    const del = vi.fn();
+    (
+      window as unknown as { electronAPI: { openProject: typeof open } }
+    ).electronAPI = {
+      openProject: open,
+    } as any;
     const selected = new Set<string>();
     const last = { current: null as number | null };
     render(
-      <table>
-        <tbody>
-          <ProjectRow
-            project={projects[0]}
-            projects={projects}
-            index={0}
-            selected={selected}
-            onSelect={() => {}}
-            lastIndexRef={last}
-            onOpen={open}
-            onDuplicate={dup}
-            onDelete={del}
-            onRowClick={() => {}}
-          />
-        </tbody>
-      </table>
+      <>
+        <table>
+          <tbody>
+            <ProjectRow
+              project={projects[0]}
+              projects={projects}
+              index={0}
+              selected={selected}
+              onSelect={() => {}}
+              lastIndexRef={last}
+              onRowClick={() => {}}
+            />
+          </tbody>
+        </table>
+        <ProjectModals refresh={() => {}} toast={() => {}} />
+      </>
     );
     fireEvent.click(screen.getByRole('button', { name: 'Open' }));
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.click(screen.getByRole('button', { name: 'Duplicate' }));
-    expect(dup).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().duplicateTarget).toBe('Alpha');
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('handles double click and key', () => {
     const open = vi.fn();
     const del = vi.fn();
+    (
+      window as unknown as {
+        electronAPI: { openProject: typeof open; deleteProject: typeof del };
+      }
+    ).electronAPI = {
+      openProject: open,
+      deleteProject: del,
+    } as any;
     const selected = new Set<string>();
     const last = { current: null as number | null };
     render(
@@ -57,9 +70,6 @@ describe('ProjectRow', () => {
             selected={selected}
             onSelect={() => {}}
             lastIndexRef={last}
-            onOpen={open}
-            onDuplicate={() => {}}
-            onDelete={del}
             onRowClick={() => {}}
           />
         </tbody>
@@ -69,7 +79,8 @@ describe('ProjectRow', () => {
     fireEvent.doubleClick(row);
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.keyDown(row, { key: 'Delete' });
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(del).not.toHaveBeenCalled();
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('selects range with shift', () => {
@@ -91,9 +102,6 @@ describe('ProjectRow', () => {
               selected={selected}
               onSelect={select}
               lastIndexRef={last}
-              onOpen={() => {}}
-              onDuplicate={() => {}}
-              onDelete={() => {}}
               onRowClick={() => {}}
             />
           ))}

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -4,6 +4,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ProjectTable, {
   ProjectInfo,
 } from '../src/renderer/components/project/ProjectTable';
+import ProjectModals from '../src/renderer/components/project/ProjectModals';
+import { useAppStore } from '../src/renderer/store';
 
 describe('ProjectTable', () => {
   const projects: ProjectInfo[] = [
@@ -13,54 +15,66 @@ describe('ProjectTable', () => {
 
   it('calls row action callbacks', () => {
     const open = vi.fn();
-    const dup = vi.fn();
-    const del = vi.fn();
+    (
+      window as unknown as { electronAPI: { openProject: typeof open } }
+    ).electronAPI = {
+      openProject: open,
+    } as any;
     render(
-      <ProjectTable
-        projects={projects}
-        sortKey="name"
-        asc
-        onSort={() => {}}
-        selected={new Set()}
-        onSelect={() => {}}
-        onSelectAll={() => {}}
-        onOpen={open}
-        onDuplicate={dup}
-        onDelete={del}
-        onRowClick={() => {}}
-      />
+      <>
+        <ProjectTable
+          projects={projects}
+          sortKey="name"
+          asc
+          onSort={() => {}}
+          selected={new Set()}
+          onSelect={() => {}}
+          onSelectAll={() => {}}
+          onRowClick={() => {}}
+        />
+        <ProjectModals refresh={() => {}} toast={() => {}} />
+      </>
     );
     fireEvent.click(screen.getAllByRole('button', { name: 'Open' })[0]);
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.click(screen.getAllByRole('button', { name: 'Duplicate' })[0]);
-    expect(dup).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().duplicateTarget).toBe('Alpha');
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('opens and deletes via keyboard', () => {
     const open = vi.fn();
     const del = vi.fn();
+    (
+      window as unknown as {
+        electronAPI: { openProject: typeof open; deleteProject: typeof del };
+      }
+    ).electronAPI = {
+      openProject: open,
+      deleteProject: del,
+    } as any;
     render(
-      <ProjectTable
-        projects={projects}
-        sortKey="name"
-        asc
-        onSort={() => {}}
-        selected={new Set()}
-        onSelect={() => {}}
-        onSelectAll={() => {}}
-        onOpen={open}
-        onDuplicate={() => {}}
-        onDelete={del}
-        onRowClick={() => {}}
-      />
+      <>
+        <ProjectTable
+          projects={projects}
+          sortKey="name"
+          asc
+          onSort={() => {}}
+          selected={new Set()}
+          onSelect={() => {}}
+          onSelectAll={() => {}}
+          onRowClick={() => {}}
+        />
+        <ProjectModals refresh={() => {}} toast={() => {}} />
+      </>
     );
     const row = screen.getAllByRole('row')[1];
     fireEvent.doubleClick(row);
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.keyDown(row, { key: 'Delete' });
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(del).not.toHaveBeenCalled();
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('selects rows and toggles all', () => {
@@ -75,9 +89,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={select}
         onSelectAll={selectAll}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -98,9 +109,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -118,9 +126,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -138,9 +143,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );

--- a/src/renderer/components/project/ProjectContextMenu.tsx
+++ b/src/renderer/components/project/ProjectContextMenu.tsx
@@ -1,24 +1,22 @@
 import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { Button } from '../daisy/actions';
+import { useAppStore } from '../../store';
 
 interface Props {
   project: string;
   style?: React.CSSProperties;
   firstItemRef?: React.Ref<HTMLButtonElement>;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
 }
 
 export default function ProjectContextMenu({
   project,
   style,
   firstItemRef,
-  onOpen,
-  onDuplicate,
-  onDelete,
 }: Props) {
+  const openProject = useAppStore((s) => s.openProject);
+  const duplicateProject = useAppStore((s) => s.duplicateProject);
+  const deleteProject = useAppStore((s) => s.deleteProject);
   const root = document.getElementById('overlay-root');
   if (!root) return null;
   const fallbackRef = useRef<HTMLButtonElement>(null);
@@ -43,18 +41,18 @@ export default function ProjectContextMenu({
               : fallbackRef) as React.Ref<HTMLButtonElement>
           }
           role="menuitem"
-          onClick={() => onOpen(project)}
+          onClick={() => openProject(project)}
         >
           Open
         </Button>
       </li>
       <li>
-        <Button role="menuitem" onClick={() => onDuplicate(project)}>
+        <Button role="menuitem" onClick={() => duplicateProject(project)}>
           Duplicate
         </Button>
       </li>
       <li>
-        <Button role="menuitem" onClick={() => onDelete(project)}>
+        <Button role="menuitem" onClick={() => deleteProject(project)}>
           Delete
         </Button>
       </li>

--- a/src/renderer/components/project/ProjectRow.tsx
+++ b/src/renderer/components/project/ProjectRow.tsx
@@ -11,6 +11,7 @@ import {
 import defaultPack from '../../../../resources/default_pack.png';
 import ProjectContextMenu from './ProjectContextMenu';
 import type { ProjectInfo } from './ProjectTable';
+import { useAppStore } from '../../store';
 
 interface Props {
   project: ProjectInfo;
@@ -19,9 +20,6 @@ interface Props {
   selected: Set<string>;
   onSelect: (name: string, checked: boolean) => void;
   lastIndexRef: React.MutableRefObject<number | null>;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
 }
 
@@ -32,11 +30,11 @@ export default function ProjectRow({
   selected,
   onSelect,
   lastIndexRef,
-  onOpen,
-  onDuplicate,
-  onDelete,
   onRowClick,
 }: Props) {
+  const openProject = useAppStore((s) => s.openProject);
+  const duplicateProject = useAppStore((s) => s.duplicateProject);
+  const deleteProject = useAppStore((s) => s.deleteProject);
   const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(
     null
   );
@@ -47,19 +45,6 @@ export default function ProjectRow({
   }, [menuPos]);
 
   const closeMenu = () => setMenuPos(null);
-
-  const handleOpen = () => {
-    onOpen(project.name);
-    closeMenu();
-  };
-  const handleDuplicate = () => {
-    onDuplicate(project.name);
-    closeMenu();
-  };
-  const handleDelete = () => {
-    onDelete(project.name);
-    closeMenu();
-  };
 
   const handleCheckbox = (
     e: React.ChangeEvent<HTMLInputElement> & {
@@ -86,8 +71,8 @@ export default function ProjectRow({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && selected.size <= 1) onOpen(project.name);
-    if (e.key === 'Delete' && selected.size <= 1) onDelete(project.name);
+    if (e.key === 'Enter' && selected.size <= 1) openProject(project.name);
+    if (e.key === 'Delete' && selected.size <= 1) deleteProject(project.name);
     if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
       e.preventDefault();
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
@@ -98,7 +83,7 @@ export default function ProjectRow({
   return (
     <tr
       onClick={() => onRowClick(project.name)}
-      onDoubleClick={() => onOpen(project.name)}
+      onDoubleClick={() => openProject(project.name)}
       onContextMenu={handleContextMenu}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -138,7 +123,7 @@ export default function ProjectRow({
           className="btn-accent btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onOpen(project.name);
+            openProject(project.name);
           }}
         >
           <ArrowRightCircleIcon className="w-4 h-4" />
@@ -148,7 +133,7 @@ export default function ProjectRow({
           className="btn-info btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onDuplicate(project.name);
+            duplicateProject(project.name);
           }}
         >
           <DocumentDuplicateIcon className="w-4 h-4" />
@@ -158,7 +143,7 @@ export default function ProjectRow({
           className="btn-error btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onDelete(project.name);
+            deleteProject(project.name);
           }}
         >
           <TrashIcon className="w-4 h-4" />
@@ -174,9 +159,6 @@ export default function ProjectRow({
             display: menuPos ? 'block' : 'none',
           }}
           firstItemRef={firstItem}
-          onOpen={handleOpen}
-          onDuplicate={handleDuplicate}
-          onDelete={handleDelete}
         />
       )}
     </tr>

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -17,9 +17,6 @@ export default function ProjectTable({
   selected,
   onSelect,
   onSelectAll,
-  onOpen,
-  onDuplicate,
-  onDelete,
   onRowClick,
 }: {
   projects: ProjectInfo[];
@@ -27,9 +24,6 @@ export default function ProjectTable({
   selected: Set<string>;
   onSelect: (name: string, checked: boolean) => void;
   onSelectAll: (checked: boolean) => void;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
   sortKey: keyof ProjectInfo;
   asc: boolean;
@@ -58,9 +52,6 @@ export default function ProjectTable({
               selected={selected}
               onSelect={onSelect}
               lastIndexRef={lastIndex}
-              onOpen={onOpen}
-              onDuplicate={onDuplicate}
-              onDelete={onDelete}
               onRowClick={onRowClick}
             />
           ))}

--- a/src/renderer/components/providers/ToastProvider.tsx
+++ b/src/renderer/components/providers/ToastProvider.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
 } from 'react';
 import ReactDOM from 'react-dom';
+import { useAppStore } from '../../store';
 
 export type ToastType =
   | 'info'
@@ -44,6 +45,7 @@ export default function ToastProvider({
 }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const timeouts = useRef<Record<number, ReturnType<typeof setTimeout>>>({});
+  const setToast = useAppStore((s) => s.setToast);
 
   const removeToast = (id: number) => {
     setToasts((t) => t.filter((toast) => toast.id !== id));
@@ -70,6 +72,10 @@ export default function ToastProvider({
       timeouts.current[id] = tid;
     }
   };
+
+  useEffect(() => {
+    setToast(showToast);
+  }, [setToast]);
 
   useEffect(() => {
     return () => {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -13,6 +13,20 @@ export interface AppState {
   openRename: (file: string) => void;
   openMove: (file: string) => void;
   closeDialogs: () => void;
+  toast: (opts: {
+    message: string;
+    type?: import('./components/providers/ToastProvider').ToastType;
+  }) => void;
+  setToast: (fn: AppState['toast']) => void;
+  duplicateTarget: string | null;
+  deleteTarget: string | null;
+  deleteMany: string[] | null;
+  deleteManyAfter: (() => void) | null;
+  openProject: (name: string) => void;
+  duplicateProject: (name: string) => void;
+  deleteProject: (name: string) => void;
+  deleteProjects: (names: string[], after?: () => void) => void;
+  closeProjectModals: () => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -44,4 +58,27 @@ export const useAppStore = create<AppState>((set, get) => ({
   openRename: (file) => set({ renameTarget: file }),
   openMove: (file) => set({ moveTarget: file }),
   closeDialogs: () => set({ renameTarget: null, moveTarget: null }),
+  toast: () => {},
+  setToast: (fn) => set({ toast: fn }),
+  duplicateTarget: null,
+  deleteTarget: null,
+  deleteMany: null,
+  deleteManyAfter: null,
+  openProject: (name) => {
+    const res = window.electronAPI?.openProject(name);
+    res?.catch?.(() =>
+      get().toast({ message: 'Invalid project.json', type: 'error' })
+    );
+  },
+  duplicateProject: (name) => set({ duplicateTarget: name }),
+  deleteProject: (name) => set({ deleteTarget: name }),
+  deleteProjects: (names, after) =>
+    set({ deleteMany: names, deleteManyAfter: after ?? null }),
+  closeProjectModals: () =>
+    set({
+      duplicateTarget: null,
+      deleteTarget: null,
+      deleteMany: null,
+      deleteManyAfter: null,
+    }),
 }));

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -6,7 +6,7 @@ import ProjectSidebar from '../components/project/ProjectSidebar';
 import ProjectForm from '../components/project/ProjectForm';
 import ProjectTable from '../components/project/ProjectTable';
 import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline';
-import { useProjectModals } from '../components/project/ProjectModals';
+import ProjectModals from '../components/project/ProjectModals';
 import SearchToolbar from '../components/project/SearchToolbar';
 import ExportWizardModal, {
   BulkProgress,
@@ -15,6 +15,7 @@ import useProjectList from '../hooks/useProjectList';
 import useProjectSelection from '../hooks/useProjectSelection';
 import ImportWizardModal from '../components/modals/ImportWizardModal';
 import type { ImportSummary } from '../../main/projects';
+import { useAppStore } from '../store';
 
 // Lists all available projects and lets the user open them.
 
@@ -32,14 +33,13 @@ const ProjectManagerView: React.FC = () => {
 
   const toast = useToast();
 
-  const { modals, openDuplicate, openDelete, openDeleteMany } =
-    useProjectModals(refresh, toast);
+  const openProject = useAppStore((s) => s.openProject);
+  const duplicateProject = useAppStore((s) => s.duplicateProject);
+  const deleteProject = useAppStore((s) => s.deleteProject);
+  const deleteProjects = useAppStore((s) => s.deleteProjects);
 
   const handleOpen = (n: string) => {
-    const res = window.electronAPI?.openProject(n);
-    res?.catch?.(() =>
-      toast({ message: 'Invalid project.json', type: 'error' })
-    );
+    openProject(n);
   };
 
   const handleImport = () => {
@@ -62,12 +62,12 @@ const ProjectManagerView: React.FC = () => {
   let clearSelection: () => void = () => {};
   const handleDeleteSelected = (names: string[]) => {
     if (names.length > 1) {
-      openDeleteMany(names, () => {
+      deleteProjects(names, () => {
         clearSelection();
         refresh();
       });
     } else if (names.length === 1) {
-      openDelete(names[0]);
+      deleteProject(names[0]);
       clearSelection();
     }
   };
@@ -155,9 +155,6 @@ const ProjectManagerView: React.FC = () => {
               c
             )
           }
-          onOpen={handleOpen}
-          onDuplicate={openDuplicate}
-          onDelete={openDelete}
           onRowClick={setActiveProject}
         />
         {(importing || importSummary) && (
@@ -170,7 +167,7 @@ const ProjectManagerView: React.FC = () => {
         {progress && (
           <ExportWizardModal progress={progress} onClose={() => {}} />
         )}
-        {modals}
+        <ProjectModals refresh={refresh} toast={toast} />
       </div>
       <ProjectSidebar project={activeProject} />
     </section>


### PR DESCRIPTION
## Summary
- move project action logic to Zustand store
- provide toast handler via store
- update `ProjectModals` to read state from store
- wire up new store methods in `ProjectManagerView`
- adjust related tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: maximum update depth exceeded)*
- `npm run format`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6854fa51ee348331b410edde5824febe