### PR TITLE
Introduce store-driven project actions

### DIFF
--- a/__tests__/ProjectContextMenu.test.tsx
+++ b/__tests__/ProjectContextMenu.test.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProjectContextMenu from '../src/renderer/components/project/ProjectContextMenu';
+import { useAppStore } from '../src/renderer/store';
 
 describe('ProjectContextMenu', () => {
   it('fires callbacks and renders to overlay root', async () => {
     const open = vi.fn();
     const dup = vi.fn();
     const del = vi.fn();
-    render(
-      <ProjectContextMenu
-        project="Test"
-        onOpen={open}
-        onDuplicate={dup}
-        onDelete={del}
-      />
-    );
+    (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
+      {
+        openProject: open,
+        duplicateProject: dup,
+        deleteProject: del,
+      } as Window['electronAPI'];
+    render(<ProjectContextMenu project="Test" />);
     const root = document.getElementById('overlay-root');
     expect(root?.querySelector('ul')).toBeInTheDocument();
     await waitFor(() =>
@@ -24,8 +24,8 @@ describe('ProjectContextMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
     expect(open).toHaveBeenCalledWith('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
-    expect(dup).toHaveBeenCalledWith('Test');
+    expect(useAppStore.getState().duplicateTarget).toBe('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
-    expect(del).toHaveBeenCalledWith('Test');
+    expect(useAppStore.getState().deleteTarget).toBe('Test');
   });
 });

--- a/__tests__/ProjectModals.test.tsx
+++ b/__tests__/ProjectModals.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { useProjectModals } from '../src/renderer/components/project/ProjectModals';
+import ProjectModals from '../src/renderer/components/project/ProjectModals';
+import { useAppStore } from '../src/renderer/store';
 
 function Wrapper({
   refresh,
@@ -10,15 +11,16 @@ function Wrapper({
   refresh: () => void;
   toast: (m: string, t: 'success' | 'info' | 'error') => void;
 }) {
-  const { modals, openDuplicate, openDelete } = useProjectModals(
-    refresh,
-    toast
-  );
+  const dup = useAppStore((s) => s.duplicateProject);
+  const del = useAppStore((s) => s.deleteProject);
   return (
     <div>
-      <button onClick={() => openDuplicate('Alpha')}>dup</button>
-      <button onClick={() => openDelete('Alpha')}>del</button>
-      {modals}
+      <button onClick={() => dup('Alpha')}>dup</button>
+      <button onClick={() => del('Alpha')}>del</button>
+      <ProjectModals
+        refresh={refresh}
+        toast={({ message, type }) => toast(message, (type ?? 'info') as any)}
+      />
     </div>
   );
 }

--- a/__tests__/ProjectTable.test.tsx
+++ b/__tests__/ProjectTable.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import ProjectTable, {
   ProjectInfo,
 } from '../src/renderer/components/project/ProjectTable';
+import { useAppStore } from '../src/renderer/store';
 
 describe('ProjectTable', () => {
   const projects: ProjectInfo[] = [
@@ -15,6 +16,12 @@ describe('ProjectTable', () => {
     const open = vi.fn();
     const dup = vi.fn();
     const del = vi.fn();
+    (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
+      {
+        openProject: open,
+        duplicateProject: dup,
+        deleteProject: del,
+      } as Window['electronAPI'];
     render(
       <ProjectTable
         projects={projects}
@@ -24,23 +31,26 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={open}
-        onDuplicate={dup}
-        onDelete={del}
         onRowClick={() => {}}
       />
     );
     fireEvent.click(screen.getAllByRole('button', { name: 'Open' })[0]);
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.click(screen.getAllByRole('button', { name: 'Duplicate' })[0]);
-    expect(dup).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().duplicateTarget).toBe('Alpha');
     fireEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]);
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('opens and deletes via keyboard', () => {
     const open = vi.fn();
     const del = vi.fn();
+    (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
+      {
+        openProject: open,
+        duplicateProject: vi.fn(),
+        deleteProject: del,
+      } as Window['electronAPI'];
     render(
       <ProjectTable
         projects={projects}
@@ -50,9 +60,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={open}
-        onDuplicate={() => {}}
-        onDelete={del}
         onRowClick={() => {}}
       />
     );
@@ -60,7 +67,7 @@ describe('ProjectTable', () => {
     fireEvent.doubleClick(row);
     expect(open).toHaveBeenCalledWith('Alpha');
     fireEvent.keyDown(row, { key: 'Delete' });
-    expect(del).toHaveBeenCalledWith('Alpha');
+    expect(useAppStore.getState().deleteTarget).toBe('Alpha');
   });
 
   it('selects rows and toggles all', () => {
@@ -75,9 +82,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={select}
         onSelectAll={selectAll}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -98,9 +102,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -118,9 +119,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );
@@ -138,9 +136,6 @@ describe('ProjectTable', () => {
         selected={new Set()}
         onSelect={() => {}}
         onSelectAll={() => {}}
-        onOpen={() => {}}
-        onDuplicate={() => {}}
-        onDelete={() => {}}
         onRowClick={() => {}}
       />
     );

--- a/src/renderer/components/project/ProjectContextMenu.tsx
+++ b/src/renderer/components/project/ProjectContextMenu.tsx
@@ -1,24 +1,22 @@
 import React, { useEffect, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { Button } from '../daisy/actions';
+import { useAppStore } from '../../store';
 
 interface Props {
   project: string;
   style?: React.CSSProperties;
   firstItemRef?: React.Ref<HTMLButtonElement>;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
 }
 
 export default function ProjectContextMenu({
   project,
   style,
   firstItemRef,
-  onOpen,
-  onDuplicate,
-  onDelete,
 }: Props) {
+  const openProject = useAppStore((s) => s.openProject);
+  const duplicateProject = useAppStore((s) => s.duplicateProject);
+  const deleteProject = useAppStore((s) => s.deleteProject);
   const root = document.getElementById('overlay-root');
   if (!root) return null;
   const fallbackRef = useRef<HTMLButtonElement>(null);
@@ -43,18 +41,18 @@ export default function ProjectContextMenu({
               : fallbackRef) as React.Ref<HTMLButtonElement>
           }
           role="menuitem"
-          onClick={() => onOpen(project)}
+          onClick={() => openProject(project)}
         >
           Open
         </Button>
       </li>
       <li>
-        <Button role="menuitem" onClick={() => onDuplicate(project)}>
+        <Button role="menuitem" onClick={() => duplicateProject(project)}>
           Duplicate
         </Button>
       </li>
       <li>
-        <Button role="menuitem" onClick={() => onDelete(project)}>
+        <Button role="menuitem" onClick={() => deleteProject(project)}>
           Delete
         </Button>
       </li>

--- a/src/renderer/components/project/ProjectModals.tsx
+++ b/src/renderer/components/project/ProjectModals.tsx
@@ -1,18 +1,25 @@
-import React, { useState, useRef } from 'react';
+import React from 'react';
 import RenameModal from '../modals/RenameModal';
 import ConfirmModal from '../modals/ConfirmModal';
 import type { ToastType } from '../providers/ToastProvider';
+import { useAppStore } from '../../store';
 
-export function useProjectModals(
-  refresh: () => void,
-  toast: (opts: { message: string; type?: ToastType }) => void
-) {
-  const [duplicateTarget, setDuplicateTarget] = useState<string | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
-  const [deleteMany, setDeleteMany] = useState<string[] | null>(null);
-  const deleteManyAfter = useRef<(() => void) | null>(null);
+export default function ProjectModals({
+  refresh,
+  toast,
+}: {
+  refresh: () => void;
+  toast: (opts: { message: string; type?: ToastType }) => void;
+}) {
+  const duplicateTarget = useAppStore((s) => s.duplicateTarget);
+  const deleteTarget = useAppStore((s) => s.deleteTarget);
+  const deleteMany = useAppStore((s) => s.deleteMany);
+  const deleteManyAfter = useAppStore((s) => s.deleteManyAfter);
+  const setDuplicateTarget = useAppStore((s) => s.setDuplicateTarget);
+  const setDeleteTarget = useAppStore((s) => s.setDeleteTarget);
+  const setDeleteMany = useAppStore((s) => s.setDeleteMany);
 
-  const modals = (
+  return (
     <>
       {duplicateTarget && (
         <RenameModal
@@ -59,7 +66,7 @@ export function useProjectModals(
               targets.map((t) => window.electronAPI?.deleteProject(t))
             ).then(() => {
               refresh();
-              deleteManyAfter.current?.();
+              deleteManyAfter?.();
               toast({ message: 'Projects deleted', type: 'info' });
             });
           }}
@@ -67,14 +74,4 @@ export function useProjectModals(
       )}
     </>
   );
-
-  return {
-    modals,
-    openDuplicate: setDuplicateTarget,
-    openDelete: setDeleteTarget,
-    openDeleteMany: (names: string[], cb?: () => void) => {
-      deleteManyAfter.current = cb ?? null;
-      setDeleteMany(names);
-    },
-  };
 }

--- a/src/renderer/components/project/ProjectRow.tsx
+++ b/src/renderer/components/project/ProjectRow.tsx
@@ -11,6 +11,7 @@ import {
 import defaultPack from '../../../../resources/default_pack.png';
 import ProjectContextMenu from './ProjectContextMenu';
 import type { ProjectInfo } from './ProjectTable';
+import { useAppStore } from '../../store';
 
 interface Props {
   project: ProjectInfo;
@@ -19,9 +20,6 @@ interface Props {
   selected: Set<string>;
   onSelect: (name: string, checked: boolean) => void;
   lastIndexRef: React.MutableRefObject<number | null>;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
 }
 
@@ -32,11 +30,11 @@ export default function ProjectRow({
   selected,
   onSelect,
   lastIndexRef,
-  onOpen,
-  onDuplicate,
-  onDelete,
   onRowClick,
 }: Props) {
+  const openProject = useAppStore((s) => s.openProject);
+  const duplicateProject = useAppStore((s) => s.duplicateProject);
+  const deleteProject = useAppStore((s) => s.deleteProject);
   const [menuPos, setMenuPos] = React.useState<{ x: number; y: number } | null>(
     null
   );
@@ -47,19 +45,6 @@ export default function ProjectRow({
   }, [menuPos]);
 
   const closeMenu = () => setMenuPos(null);
-
-  const handleOpen = () => {
-    onOpen(project.name);
-    closeMenu();
-  };
-  const handleDuplicate = () => {
-    onDuplicate(project.name);
-    closeMenu();
-  };
-  const handleDelete = () => {
-    onDelete(project.name);
-    closeMenu();
-  };
 
   const handleCheckbox = (
     e: React.ChangeEvent<HTMLInputElement> & {
@@ -86,8 +71,8 @@ export default function ProjectRow({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' && selected.size <= 1) onOpen(project.name);
-    if (e.key === 'Delete' && selected.size <= 1) onDelete(project.name);
+    if (e.key === 'Enter' && selected.size <= 1) openProject(project.name);
+    if (e.key === 'Delete' && selected.size <= 1) deleteProject(project.name);
     if (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10')) {
       e.preventDefault();
       const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
@@ -98,7 +83,7 @@ export default function ProjectRow({
   return (
     <tr
       onClick={() => onRowClick(project.name)}
-      onDoubleClick={() => onOpen(project.name)}
+      onDoubleClick={() => openProject(project.name)}
       onContextMenu={handleContextMenu}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -138,7 +123,7 @@ export default function ProjectRow({
           className="btn-accent btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onOpen(project.name);
+            openProject(project.name);
           }}
         >
           <ArrowRightCircleIcon className="w-4 h-4" />
@@ -148,7 +133,7 @@ export default function ProjectRow({
           className="btn-info btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onDuplicate(project.name);
+            duplicateProject(project.name);
           }}
         >
           <DocumentDuplicateIcon className="w-4 h-4" />
@@ -158,7 +143,7 @@ export default function ProjectRow({
           className="btn-error btn-sm flex items-center gap-1"
           onClick={(e) => {
             e.stopPropagation();
-            onDelete(project.name);
+            deleteProject(project.name);
           }}
         >
           <TrashIcon className="w-4 h-4" />
@@ -174,9 +159,6 @@ export default function ProjectRow({
             display: menuPos ? 'block' : 'none',
           }}
           firstItemRef={firstItem}
-          onOpen={handleOpen}
-          onDuplicate={handleDuplicate}
-          onDelete={handleDelete}
         />
       )}
     </tr>

--- a/src/renderer/components/project/ProjectTable.tsx
+++ b/src/renderer/components/project/ProjectTable.tsx
@@ -17,9 +17,6 @@ export default function ProjectTable({
   selected,
   onSelect,
   onSelectAll,
-  onOpen,
-  onDuplicate,
-  onDelete,
   onRowClick,
 }: {
   projects: ProjectInfo[];
@@ -27,9 +24,6 @@ export default function ProjectTable({
   selected: Set<string>;
   onSelect: (name: string, checked: boolean) => void;
   onSelectAll: (checked: boolean) => void;
-  onOpen: (name: string) => void;
-  onDuplicate: (name: string) => void;
-  onDelete: (name: string) => void;
   onRowClick: (name: string) => void;
   sortKey: keyof ProjectInfo;
   asc: boolean;
@@ -58,9 +52,6 @@ export default function ProjectTable({
               selected={selected}
               onSelect={onSelect}
               lastIndexRef={lastIndex}
-              onOpen={onOpen}
-              onDuplicate={onDuplicate}
-              onDelete={onDelete}
               onRowClick={onRowClick}
             />
           ))}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { ToastType } from './components/providers/ToastProvider';
 
 export interface AppState {
   projectPath: string | null;
@@ -13,6 +14,21 @@ export interface AppState {
   openRename: (file: string) => void;
   openMove: (file: string) => void;
   closeDialogs: () => void;
+  toast: ((opts: { message: string; type?: ToastType }) => void) | null;
+  setToast: (
+    t: ((opts: { message: string; type?: ToastType }) => void) | null
+  ) => void;
+  duplicateTarget: string | null;
+  deleteTarget: string | null;
+  deleteMany: string[] | null;
+  deleteManyAfter: (() => void) | null;
+  setDuplicateTarget: (t: string | null) => void;
+  setDeleteTarget: (t: string | null) => void;
+  setDeleteMany: (names: string[] | null, after?: () => void) => void;
+  openProject: (name: string) => void;
+  duplicateProject: (name: string) => void;
+  deleteProject: (name: string) => void;
+  deleteProjects: (names: string[], after?: () => void) => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -41,7 +57,35 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
   renameTarget: null,
   moveTarget: null,
+  duplicateTarget: null,
+  deleteTarget: null,
+  deleteMany: null,
+  deleteManyAfter: null,
+  setDuplicateTarget: (t) => set({ duplicateTarget: t }),
+  setDeleteTarget: (t) => set({ deleteTarget: t }),
+  setDeleteMany: (names, after) =>
+    set({ deleteMany: names, deleteManyAfter: after ?? null }),
+  toast: null,
+  setToast: (t) => set({ toast: t }),
   openRename: (file) => set({ renameTarget: file }),
   openMove: (file) => set({ moveTarget: file }),
-  closeDialogs: () => set({ renameTarget: null, moveTarget: null }),
+  closeDialogs: () =>
+    set({
+      renameTarget: null,
+      moveTarget: null,
+      duplicateTarget: null,
+      deleteTarget: null,
+      deleteMany: null,
+      deleteManyAfter: null,
+    }),
+  openProject: (name) => {
+    const res = window.electronAPI?.openProject(name);
+    res?.catch?.(() =>
+      get().toast?.({ message: 'Invalid project.json', type: 'error' })
+    );
+  },
+  duplicateProject: (name) => set({ duplicateTarget: name }),
+  deleteProject: (name) => set({ deleteTarget: name }),
+  deleteProjects: (names, after) =>
+    set({ deleteMany: names, deleteManyAfter: after ?? null }),
 }));


### PR DESCRIPTION
## Summary
- implement openProject, duplicateProject and deleteProject directly in the store
- render project action modals based on store state
- connect ProjectManagerView with new store functions
- adjust unit tests for store-driven actions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6854fa51ee348331b410edde5824febe