### PR TITLE
Add open folder option to project context menu

### DIFF
--- a/__tests__/ProjectContextMenu.test.tsx
+++ b/__tests__/ProjectContextMenu.test.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProjectContextMenu from '../src/renderer/components/project/ProjectContextMenu';
 import { useAppStore } from '../src/renderer/store';
+
+vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('ProjectContextMenu', () => {
   it('fires callbacks and renders to overlay root', async () => {
     const open = vi.fn();
     const dup = vi.fn();
     const del = vi.fn();
+    const reveal = vi.fn();
     (window as unknown as { electronAPI: Window['electronAPI'] }).electronAPI =
       {
         openProject: open,
         duplicateProject: dup,
         deleteProject: del,
+        openInFolder: reveal,
       } as Window['electronAPI'];
     render(<ProjectContextMenu project="Test" />);
     const root = document.getElementById('overlay-root');
@@ -23,6 +29,10 @@ describe('ProjectContextMenu', () => {
     );
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
     expect(open).toHaveBeenCalledWith('Test');
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Open Folder' }));
+    expect(reveal).toHaveBeenCalledWith(
+      path.join(os.tmpdir(), 'projects', 'Test')
+    );
     fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
     expect(useAppStore.getState().duplicateTarget).toBe('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));

--- a/src/renderer/components/project/ProjectContextMenu.tsx
+++ b/src/renderer/components/project/ProjectContextMenu.tsx
@@ -17,6 +17,7 @@ export default function ProjectContextMenu({
   const openProject = useAppStore((s) => s.openProject);
   const duplicateProject = useAppStore((s) => s.duplicateProject);
   const deleteProject = useAppStore((s) => s.deleteProject);
+  const openProjectFolder = useAppStore((s) => s.openProjectFolder);
   const root = document.getElementById('overlay-root');
   if (!root) return null;
   const fallbackRef = useRef<HTMLButtonElement>(null);
@@ -44,6 +45,11 @@ export default function ProjectContextMenu({
           onClick={() => openProject(project)}
         >
           Open
+        </Button>
+      </li>
+      <li>
+        <Button role="menuitem" onClick={() => openProjectFolder(project)}>
+          Open Folder
         </Button>
       </li>
       <li>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import type { ToastType } from './components/providers/ToastProvider';
+import path from 'path';
+import { app } from 'electron';
 
 export interface AppState {
   projectPath: string | null;
@@ -29,6 +31,7 @@ export interface AppState {
   duplicateProject: (name: string) => void;
   deleteProject: (name: string) => void;
   deleteProjects: (names: string[], after?: () => void) => void;
+  openProjectFolder: (name: string) => void;
 }
 
 export const useAppStore = create<AppState>((set, get) => ({
@@ -82,6 +85,11 @@ export const useAppStore = create<AppState>((set, get) => ({
     const res = window.electronAPI?.openProject(name);
     res?.catch?.(() =>
       get().toast?.({ message: 'Invalid project.json', type: 'error' })
+    );
+  },
+  openProjectFolder: (name) => {
+    window.electronAPI?.openInFolder(
+      path.join(app.getPath('userData'), 'projects', name)
     );
   },
   duplicateProject: (name) => set({ duplicateTarget: name }),


### PR DESCRIPTION
## Summary
- reveal project directory via `Open Folder` in `ProjectContextMenu`
- handle reveal action in zustand store

## Testing
- `npm run format`
- `npm run lint` *(with warnings)*
- `npm run typecheck`
- `npm test`
- `npm run dev:headless` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68550ad790bc8331b62544276c3b20a2