### PR TITLE
Fix openProjectFolder path

### DIFF
--- a/__tests__/ProjectContextMenu.test.tsx
+++ b/__tests__/ProjectContextMenu.test.tsx
@@ -1,12 +1,8 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import os from 'os';
-import path from 'path';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import ProjectContextMenu from '../src/renderer/components/project/ProjectContextMenu';
 import { useAppStore } from '../src/renderer/store';
-
-vi.mock('electron', () => ({ app: { getPath: () => os.tmpdir() } }));
 
 describe('ProjectContextMenu', () => {
   it('fires callbacks and renders to overlay root', async () => {
@@ -19,7 +15,7 @@ describe('ProjectContextMenu', () => {
         openProject: open,
         duplicateProject: dup,
         deleteProject: del,
-        openInFolder: reveal,
+        openProjectFolder: reveal,
       } as Window['electronAPI'];
     render(<ProjectContextMenu project="Test" />);
     const root = document.getElementById('overlay-root');
@@ -30,9 +26,7 @@ describe('ProjectContextMenu', () => {
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open' }));
     expect(open).toHaveBeenCalledWith('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Open Folder' }));
-    expect(reveal).toHaveBeenCalledWith(
-      path.join(os.tmpdir(), 'projects', 'Test')
-    );
+    expect(reveal).toHaveBeenCalledWith('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Duplicate' }));
     expect(useAppStore.getState().duplicateTarget).toBe('Test');
     fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));

--- a/src/main/projects/index.ts
+++ b/src/main/projects/index.ts
@@ -2,6 +2,8 @@
  * Aggregates project management utilities and IPC registration helpers.
  */
 import type { IpcMain } from 'electron';
+import { shell } from 'electron';
+import path from 'path';
 import { listPackFormats } from '../assets';
 import { setActiveProject } from '../assets/protocols';
 import { setLastProject } from '../layout';
@@ -57,6 +59,9 @@ export function registerProjectHandlers(
   });
   ipc.handle('delete-project', (_e, name: string) => {
     return deleteProject(baseDir, name);
+  });
+  ipc.handle('open-project-folder', (_e, name: string) => {
+    shell.showItemInFolder(path.join(baseDir, name));
   });
   ipc.handle('import-project', async () => {
     return importProject(baseDir);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -41,6 +41,7 @@ const api = {
     on('project-opened', listener),
   exportProject: (project: string) => invoke('export-project', project),
   exportProjects: (paths: string[]) => invoke('export-projects', paths),
+  openProjectFolder: (name: string) => invoke('open-project-folder', name),
   addTexture: (project: string, name: string) =>
     invoke('add-texture', project, name),
   listTextures: (project: string) => invoke('list-textures', project),

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -1,7 +1,5 @@
 import { create } from 'zustand';
 import type { ToastType } from './components/providers/ToastProvider';
-import path from 'path';
-import { app } from 'electron';
 
 export interface AppState {
   projectPath: string | null;
@@ -88,9 +86,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     );
   },
   openProjectFolder: (name) => {
-    window.electronAPI?.openInFolder(
-      path.join(app.getPath('userData'), 'projects', name)
-    );
+    window.electronAPI?.openProjectFolder(name);
   },
   duplicateProject: (name) => set({ duplicateTarget: name }),
   deleteProject: (name) => set({ deleteTarget: name }),

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -34,6 +34,7 @@ declare global {
       savePackIcon: IpcInvoke<'save-pack-icon'>;
       exportProject: IpcInvoke<'export-project'>;
       exportProjects: IpcInvoke<'export-projects'>;
+      openProjectFolder: IpcInvoke<'open-project-folder'>;
       openInFolder: IpcInvoke<'open-in-folder'>;
       openFile: IpcInvoke<'open-file'>;
       readFile: IpcInvoke<'read-file'>;

--- a/src/shared/ipc/types.ts
+++ b/src/shared/ipc/types.ts
@@ -25,6 +25,7 @@ export interface IpcRequestMap {
   'save-pack-icon': [string, string, string];
   'export-project': [string];
   'export-projects': [string[]];
+  'open-project-folder': [string];
   'open-in-folder': [string];
   'open-file': [string];
   'open-external-editor': [string];
@@ -85,6 +86,7 @@ export interface IpcResponseMap {
   'save-pack-icon': void;
   'export-project': ExportSummary | void;
   'export-projects': void;
+  'open-project-folder': void;
   'open-in-folder': void;
   'open-file': void;
   'open-external-editor': void;


### PR DESCRIPTION
## Summary
- handle project folder reveal in main process via new IPC
- update preload bindings and renderer store
- add unit test expectations for new API

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6855a95671a08331b160e13e7cb49b57