### PR TITLE
Refactor IPC API via mapped types

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -86,7 +86,7 @@ describe('App', () => {
       removeEventListener: vi.fn(),
     });
     interface ElectronAPI {
-      onOpenProject: (cb: (e: unknown, path: string) => void) => void;
+      onProjectOpened: (cb: (e: unknown, path: string) => void) => void;
       exportProject: (path: string) => Promise<{
         fileCount: number;
         totalSize: number;
@@ -99,7 +99,7 @@ describe('App', () => {
       getConfetti: () => Promise<boolean>;
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
-      onOpenProject: (cb) => {
+      onProjectOpened: (cb) => {
         openHandler = cb;
       },
       exportProject,

--- a/__tests__/ProjectManagerView.bulkDeleteConfirm.test.tsx
+++ b/__tests__/ProjectManagerView.bulkDeleteConfirm.test.tsx
@@ -6,7 +6,7 @@ import type { ProjectInfo } from '../src/renderer/components/project/ProjectTabl
 
 describe('ProjectManagerView bulk delete confirm', () => {
   const listProjects = vi.fn();
-  const listPackFormats = vi.fn();
+  const listFormats = vi.fn();
   const deleteProject = vi.fn();
   const getProjectSort = vi.fn();
   const setProjectSort = vi.fn();
@@ -14,7 +14,7 @@ describe('ProjectManagerView bulk delete confirm', () => {
   beforeEach(() => {
     interface API {
       listProjects: () => Promise<ProjectInfo[]>;
-      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      listFormats: () => Promise<{ format: number; label: string }[]>;
       deleteProject: (name: string) => Promise<void>;
       openProject: (name: string) => void;
       createProject: (n: string, v: string) => Promise<void>;
@@ -28,7 +28,7 @@ describe('ProjectManagerView bulk delete confirm', () => {
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       listProjects,
-      listPackFormats,
+      listFormats,
       deleteProject,
       openProject: vi.fn(),
       createProject: vi.fn(),
@@ -42,7 +42,7 @@ describe('ProjectManagerView bulk delete confirm', () => {
       { name: 'Alpha', version: '1.21', assets: 2, lastOpened: 0 },
       { name: 'Beta', version: '1.20', assets: 3, lastOpened: 0 },
     ]);
-    listPackFormats.mockResolvedValue([]);
+    listFormats.mockResolvedValue([]);
     deleteProject.mockResolvedValue(Promise.resolve());
     getProjectSort.mockResolvedValue({ key: 'name', asc: true });
     setProjectSort.mockResolvedValue(Promise.resolve());

--- a/__tests__/ProjectManagerView.bulkExport.test.tsx
+++ b/__tests__/ProjectManagerView.bulkExport.test.tsx
@@ -5,7 +5,7 @@ import ProjectManagerView from '../src/renderer/views/ProjectManagerView';
 
 describe('ProjectManagerView bulk export', () => {
   const listProjects = vi.fn();
-  const listPackFormats = vi.fn();
+  const listFormats = vi.fn();
   const exportProjects = vi.fn();
   const getProjectSort = vi.fn();
   const setProjectSort = vi.fn();
@@ -20,7 +20,7 @@ describe('ProjectManagerView bulk export', () => {
           lastOpened: number;
         }>
       >;
-      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      listFormats: () => Promise<{ format: number; label: string }[]>;
       exportProjects: (paths: string[]) => Promise<void>;
       openProject: (name: string) => void;
       createProject: (name: string, version: string) => Promise<void>;
@@ -34,7 +34,7 @@ describe('ProjectManagerView bulk export', () => {
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       listProjects,
-      listPackFormats,
+      listFormats,
       exportProjects,
       openProject: vi.fn(),
       createProject: vi.fn(),
@@ -48,7 +48,7 @@ describe('ProjectManagerView bulk export', () => {
       { name: 'Alpha', version: '1.21', assets: 2, lastOpened: 0 },
       { name: 'Beta', version: '1.20', assets: 3, lastOpened: 0 },
     ]);
-    listPackFormats.mockResolvedValue([]);
+    listFormats.mockResolvedValue([]);
     exportProjects.mockResolvedValue(undefined);
     getProjectSort.mockResolvedValue({ key: 'name', asc: true });
     setProjectSort.mockResolvedValue(undefined);

--- a/__tests__/ProjectManagerView.helpLink.test.tsx
+++ b/__tests__/ProjectManagerView.helpLink.test.tsx
@@ -13,7 +13,7 @@ describe('ProjectManagerView help link', () => {
   beforeEach(() => {
     interface ElectronAPI {
       listProjects: () => Promise<[]>;
-      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      listFormats: () => Promise<{ format: number; label: string }[]>;
       openProject: (name: string) => void;
       createProject: (n: string, v: string) => Promise<void>;
       importProject: () => Promise<
@@ -26,7 +26,7 @@ describe('ProjectManagerView help link', () => {
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       listProjects: vi.fn().mockResolvedValue([]),
-      listPackFormats: vi.fn().mockResolvedValue([]),
+      listFormats: vi.fn().mockResolvedValue([]),
       openProject: vi.fn(),
       createProject: vi.fn(),
       importProject: vi.fn(),

--- a/__tests__/ProjectManagerView.hotkeys.test.tsx
+++ b/__tests__/ProjectManagerView.hotkeys.test.tsx
@@ -6,7 +6,7 @@ import type { ProjectInfo } from '../src/renderer/components/project/ProjectTabl
 
 describe('ProjectManagerView hotkeys', () => {
   const listProjects = vi.fn();
-  const listPackFormats = vi.fn();
+  const listFormats = vi.fn();
   const openProject = vi.fn();
   const deleteProject = vi.fn();
   const getProjectSort = vi.fn();
@@ -15,7 +15,7 @@ describe('ProjectManagerView hotkeys', () => {
   beforeEach(() => {
     interface API {
       listProjects: () => Promise<ProjectInfo[]>;
-      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      listFormats: () => Promise<{ format: number; label: string }[]>;
       openProject: (name: string) => void;
       deleteProject: (name: string) => Promise<void>;
       createProject: (name: string, version: string) => Promise<void>;
@@ -28,7 +28,7 @@ describe('ProjectManagerView hotkeys', () => {
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       listProjects,
-      listPackFormats,
+      listFormats,
       openProject,
       deleteProject,
       createProject: vi.fn(),
@@ -41,7 +41,7 @@ describe('ProjectManagerView hotkeys', () => {
       { name: 'Alpha', version: '1.20', assets: 2, lastOpened: 0 },
       { name: 'Beta', version: '1.20', assets: 3, lastOpened: 1 },
     ]);
-    listPackFormats.mockResolvedValue([]);
+    listFormats.mockResolvedValue([]);
     deleteProject.mockResolvedValue(Promise.resolve());
     getProjectSort.mockResolvedValue({ key: 'name', asc: true });
     setProjectSort.mockResolvedValue(Promise.resolve());

--- a/__tests__/ProjectManagerView.openError.test.tsx
+++ b/__tests__/ProjectManagerView.openError.test.tsx
@@ -9,7 +9,7 @@ import type { ProjectInfo } from '../src/renderer/components/project/ProjectTabl
 
 describe('ProjectManagerView open error', () => {
   const listProjects = vi.fn();
-  const listPackFormats = vi.fn();
+  const listFormats = vi.fn();
   const openProject = vi.fn();
   const getProjectSort = vi.fn();
   const setProjectSort = vi.fn();
@@ -17,7 +17,7 @@ describe('ProjectManagerView open error', () => {
   beforeEach(() => {
     interface API {
       listProjects: () => Promise<ProjectInfo[]>;
-      listPackFormats: () => Promise<{ format: number; label: string }[]>;
+      listFormats: () => Promise<{ format: number; label: string }[]>;
       openProject: (name: string) => Promise<void>;
       createProject: (n: string, v: string) => Promise<void>;
       importProject: () => Promise<
@@ -30,7 +30,7 @@ describe('ProjectManagerView open error', () => {
     }
     (window as unknown as { electronAPI: API }).electronAPI = {
       listProjects,
-      listPackFormats,
+      listFormats,
       openProject,
       createProject: vi.fn(),
       importProject: vi.fn(),
@@ -42,7 +42,7 @@ describe('ProjectManagerView open error', () => {
     listProjects.mockResolvedValue([
       { name: 'Pack', version: '1.21', assets: 2, lastOpened: 0 },
     ]);
-    listPackFormats.mockResolvedValue([]);
+    listFormats.mockResolvedValue([]);
     openProject.mockRejectedValue(new Error('fail'));
     getProjectSort.mockResolvedValue({ key: 'name', asc: true });
     setProjectSort.mockResolvedValue(undefined);

--- a/__tests__/ProjectManagerView.test.tsx
+++ b/__tests__/ProjectManagerView.test.tsx
@@ -8,7 +8,7 @@ describe('ProjectManagerView', () => {
   const listProjects = vi.fn();
   const openProject = vi.fn();
   const createProject = vi.fn();
-  const listPackFormats = vi.fn();
+  const listFormats = vi.fn();
   const importProject = vi.fn();
   const duplicateProject = vi.fn();
   const deleteProject = vi.fn();
@@ -26,7 +26,7 @@ describe('ProjectManagerView', () => {
           lastOpened: number;
         }>
       >;
-      listPackFormats: () => Promise<
+      listFormats: () => Promise<
         {
           format: number;
           label: string;
@@ -45,7 +45,7 @@ describe('ProjectManagerView', () => {
     }
     (window as unknown as { electronAPI: ElectronAPI }).electronAPI = {
       listProjects,
-      listPackFormats,
+      listFormats,
       openProject,
       createProject,
       importProject,
@@ -63,7 +63,7 @@ describe('ProjectManagerView', () => {
     importProject.mockResolvedValue(undefined);
     duplicateProject.mockResolvedValue(undefined);
     deleteProject.mockResolvedValue(undefined);
-    listPackFormats.mockResolvedValue([
+    listFormats.mockResolvedValue([
       { format: 15, label: '1.20-1.20.1' },
       { format: 34, label: '1.21.1' },
     ]);

--- a/__tests__/ipc.types.test.ts
+++ b/__tests__/ipc.types.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expectTypeOf } from 'vitest';
-import type { IpcRequestMap, IpcResponseMap } from '../src/shared/ipc/types';
+import type {
+  IpcRequestMap,
+  IpcResponseMap,
+  IpcEventMap,
+} from '../src/shared/ipc/types';
+import type { IpcApi } from '../src/shared/ipc/generateApi';
 import type { ProjectInfo } from '../src/main/projects';
 import type { PackMeta } from '../src/shared/project';
 import type { TextureEditOptions } from '../src/shared/texture';
@@ -21,6 +26,17 @@ describe('IPC type mappings', () => {
     expectTypeOf<IpcRequestMap['list-projects']>().toEqualTypeOf<[]>();
     expectTypeOf<IpcResponseMap['list-projects']>().toEqualTypeOf<
       ProjectInfo[]
+    >();
+  });
+
+  it('IpcApi maps requests and events', () => {
+    expectTypeOf<IpcApi['editTexture']>().toEqualTypeOf<
+      (file: string, opts: TextureEditOptions) => Promise<void>
+    >();
+    expectTypeOf<IpcApi['onFileAdded']>().toEqualTypeOf<
+      (
+        listener: (event: unknown, data: IpcEventMap['file-added']) => void
+      ) => () => void
     >();
   });
 });

--- a/__tests__/packFormatsIPC.test.ts
+++ b/__tests__/packFormatsIPC.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { listPackFormats } from '../src/main/assets';
+import { listPackFormats as listFormats } from '../src/main/assets';
 
-describe('listPackFormats', () => {
+describe('listFormats', () => {
   it('returns pack formats', async () => {
-    const list = await listPackFormats();
+    const list = await listFormats();
     expect(list[0]).toHaveProperty('format');
     expect(list[0]).toHaveProperty('label');
   });

--- a/__tests__/useProjectList.test.tsx
+++ b/__tests__/useProjectList.test.tsx
@@ -15,7 +15,7 @@ describe('useProjectList', () => {
         lastOpened: 0,
       } as ProjectInfo,
     ]);
-    (electronAPI.listPackFormats as unknown as vi.Mock).mockResolvedValue([
+    (electronAPI.listFormats as unknown as vi.Mock).mockResolvedValue([
       { format: 1, label: '1.20' },
     ]);
     (electronAPI.getProjectSort as unknown as vi.Mock).mockResolvedValue({

--- a/docs/developer-handbook.md
+++ b/docs/developer-handbook.md
@@ -70,9 +70,9 @@ corresponds to a URL fragment: `#/`, `#/editor`, `#/settings` and `#/about`.
 
 When adding features that need access to Node APIs:
 
-1. Create a function in the `src/main` process and expose it via `ipcMain.handle`.
-2. Declare a matching function in `src/preload/index.ts` using `contextBridge.exposeInMainWorld`.
-3. Call this API from the React renderer via `window.electronAPI.yourApi()`.
+1. Create a function in the `src/main` process and expose it via `ipcMain.handle` or `ipcMain.on`.
+2. Add the request and response (or event) types to `src/shared/ipc/types.ts`.
+3. Call the API from the React renderer via `window.electronAPI.yourApi()`.
 
 Remember that the renderer runs in a browser-like sandbox, so heavy filesystem work belongs in the main process.
 
@@ -94,12 +94,13 @@ duration unless closable.
 ## IPC Pattern
 
 Electron uses a main ↔ preload ↔ renderer pipeline. Functions are implemented in
-`src/main` and registered via `ipcMain.handle`. The preload layer exposes typed
-wrappers with `contextBridge.exposeInMainWorld` so the React renderer can call
-them through `window.electronAPI.*`. Shared helpers and the IPC request/response
-types live under `src/shared`. Node integration is enabled and context
-isolation disabled in `src/main/index.ts` on purpose, so leave these settings
-as they are.
+`src/main` and registered via `ipcMain.handle`. The preload layer now exposes a
+single `electronAPI` object generated via a `Proxy`. Any request or event
+defined in `src/shared/ipc/types.ts` can be called from the renderer in camel
+case (e.g. `window.electronAPI.listProjects()`). Event channels are subscribed
+via `onEventName` helpers such as `window.electronAPI.onProjectOpened(cb)`.
+Node integration is enabled and context isolation disabled in
+`src/main/index.ts` on purpose, so leave these settings as they are.
 
 ## Styling
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -7,6 +7,7 @@ import type {
   IpcResponseMap,
   IpcEventMap,
 } from '../shared/ipc/types';
+import type { IpcApi } from '../shared/ipc/generateApi';
 
 function invoke<C extends keyof IpcRequestMap>(
   channel: C,
@@ -24,98 +25,23 @@ function on<C extends keyof IpcEventMap>(
   return () => ipcRenderer.removeListener(channel, handler);
 }
 
-const api = {
-  log: (level: string, message: string) => invoke('log', level, message),
-  listProjects: () => invoke('list-projects'),
-  listPackFormats: () => invoke('list-formats'),
-  createProject: (name: string, minecraftVersion: string) =>
-    invoke('create-project', name, minecraftVersion),
-  importProject: () => invoke('import-project'),
-  duplicateProject: (name: string, newName: string) =>
-    invoke('duplicate-project', name, newName),
-  renameProject: (name: string, newName: string) =>
-    invoke('rename-project', name, newName),
-  deleteProject: (name: string) => invoke('delete-project', name),
-  openProject: (name: string) => invoke('open-project', name),
-  onOpenProject: (listener: (e: unknown, path: string) => void) =>
-    on('project-opened', listener),
-  exportProject: (project: string) => invoke('export-project', project),
-  exportProjects: (paths: string[]) => invoke('export-projects', paths),
-  openProjectFolder: (name: string) => invoke('open-project-folder', name),
-  addTexture: (project: string, name: string) =>
-    invoke('add-texture', project, name),
-  listTextures: (project: string) => invoke('list-textures', project),
-  getTexturePath: (project: string, name: string) =>
-    invoke('get-texture-path', project, name),
-  getTextureUrl: (project: string, name: string) =>
-    invoke('get-texture-url', project, name),
-  createAtlas: (project: string, files: string[]) =>
-    invoke('create-atlas', project, files),
-  randomizeIcon: (project: string) => invoke('randomize-icon', project),
-  savePackIcon: (project: string, file: string, border: string) =>
-    invoke('save-pack-icon', project, file, border),
-  openInFolder: (file: string) => invoke('open-in-folder', file),
-  openFile: (file: string) => invoke('open-file', file),
-  openExternalEditor: (file: string) => invoke('open-external-editor', file),
-  readFile: (file: string) => invoke('read-file', file),
-  writeFile: (file: string, data: string) => invoke('write-file', file, data),
-  saveRevision: (project: string, rel: string, data: string) =>
-    invoke('save-revision', project, rel, data),
-  listRevisions: (project: string, rel: string) =>
-    invoke('list-revisions', project, rel),
-  restoreRevision: (project: string, rel: string, rev: string) =>
-    invoke('restore-revision', project, rel, rev),
-  renameFile: (oldPath: string, newPath: string) =>
-    invoke('rename-file', oldPath, newPath),
-  deleteFile: (file: string) => invoke('delete-file', file),
-  editTexture: (
-    file: string,
-    opts: import('../shared/texture').TextureEditOptions
-  ) => invoke('edit-texture', file, opts),
-  watchProject: (project: string) => invoke('watch-project', project),
-  unwatchProject: (project: string) => invoke('unwatch-project', project),
-  getNoExport: (project: string) => invoke('get-no-export', project),
-  setNoExport: (project: string, files: string[], flag: boolean) =>
-    invoke('set-no-export', project, files, flag),
-  getEditorLayout: () => invoke('get-editor-layout'),
-  setEditorLayout: (layout: number[]) => invoke('set-editor-layout', layout),
-  getTextureEditor: () => invoke('get-texture-editor'),
-  setTextureEditor: (path: string) => invoke('set-texture-editor', path),
-  getTheme: () => invoke('get-theme'),
-  setTheme: (t: 'light' | 'dark' | 'system') => invoke('set-theme', t),
-  getConfetti: () => invoke('get-confetti'),
-  setConfetti: (c: boolean) => invoke('set-confetti', c),
-  getDefaultExportDir: () => invoke('get-default-export-dir'),
-  setDefaultExportDir: (d: string) => invoke('set-default-export-dir', d),
-  getProjectSort: () => invoke('get-project-sort'),
-  setProjectSort: (
-    k: keyof import('../main/projects').ProjectInfo,
-    asc: boolean
-  ) => invoke('set-project-sort', k, asc),
-  getAssetSearch: () => invoke('get-asset-search'),
-  setAssetSearch: (q: string) => invoke('set-asset-search', q),
-  getAssetFilters: () => invoke('get-asset-filters'),
-  setAssetFilters: (f: string[]) => invoke('set-asset-filters', f),
-  getAssetZoom: () => invoke('get-asset-zoom'),
-  setAssetZoom: (z: number) => invoke('set-asset-zoom', z),
-  getOpenLastProject: () => invoke('get-open-last-project'),
-  setOpenLastProject: (b: boolean) => invoke('set-open-last-project', b),
-  getLastProject: () => invoke('get-last-project'),
-  setLastProject: (n: string) => invoke('set-last-project', n),
-  onFileAdded: (listener: (e: unknown, path: string) => void) =>
-    on('file-added', listener),
-  onFileRemoved: (listener: (e: unknown, path: string) => void) =>
-    on('file-removed', listener),
-  onFileRenamed: (
-    listener: (e: unknown, args: { oldPath: string; newPath: string }) => void
-  ) => on('file-renamed', listener),
-  onFileChanged: (
-    listener: (e: unknown, args: { path: string; stamp: number }) => void
-  ) => on('file-changed', listener),
-  loadPackMeta: (name: string) => invoke('load-pack-meta', name),
-  savePackMeta: (name: string, meta: import('../main/projects').PackMeta) =>
-    invoke('save-pack-meta', name, meta),
-};
+function camelToKebab(name: string) {
+  return name.replace(/([A-Z])/g, '-$1').toLowerCase();
+}
+
+const api: IpcApi = new Proxy({} as IpcApi, {
+  get(_target, prop: string) {
+    if (prop.startsWith('on')) {
+      const event = prop.slice(2);
+      const ch = camelToKebab(event.charAt(0).toLowerCase() + event.slice(1));
+      return (listener: (e: unknown, d: unknown) => void) =>
+        on(ch as keyof IpcEventMap, listener as any);
+    }
+    const channel = camelToKebab(prop);
+    return (...args: unknown[]) =>
+      invoke(channel as keyof IpcRequestMap, ...(args as any));
+  },
+}) as IpcApi;
 
 if (process.contextIsolated) {
   contextBridge.exposeInMainWorld('electronAPI', api);

--- a/src/renderer/components/App.tsx
+++ b/src/renderer/components/App.tsx
@@ -21,7 +21,7 @@ function AppContent() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    window.electronAPI?.onOpenProject((_e, path: string) => {
+    window.electronAPI?.onProjectOpened((_e, path: string) => {
       setProjectPath(path);
       navigate('/editor');
     });

--- a/src/renderer/hooks/useProjectList.ts
+++ b/src/renderer/hooks/useProjectList.ts
@@ -16,7 +16,7 @@ export default function useProjectList() {
 
   useEffect(() => {
     refresh();
-    window.electronAPI?.listPackFormats().then(setFormats);
+    window.electronAPI?.listFormats().then(setFormats);
     window.electronAPI?.getProjectSort().then((s) => {
       if (s) {
         setSortKey(s.key);

--- a/src/shared/global.d.ts
+++ b/src/shared/global.d.ts
@@ -2,83 +2,11 @@
 // Global type declarations used by the renderer process.
 export {};
 
-import type { IpcRequestMap, IpcResponseMap, IpcEventMap } from './ipc/types';
-
-type IpcInvoke<C extends keyof IpcRequestMap> = (
-  ...args: IpcRequestMap[C]
-) => Promise<IpcResponseMap[C]>;
-
-type IpcListener<C extends keyof IpcEventMap> = (
-  listener: (event: unknown, data: IpcEventMap[C]) => void
-) => () => void;
+import type { IpcApi } from './ipc/generateApi';
 
 declare global {
   interface Window {
-    electronAPI?: {
-      listProjects: IpcInvoke<'list-projects'>;
-      listPackFormats: IpcInvoke<'list-formats'>;
-      createProject: IpcInvoke<'create-project'>;
-      importProject: IpcInvoke<'import-project'>;
-      duplicateProject: IpcInvoke<'duplicate-project'>;
-      renameProject: IpcInvoke<'rename-project'>;
-      deleteProject: IpcInvoke<'delete-project'>;
-      openProject: IpcInvoke<'open-project'>;
-      loadPackMeta: IpcInvoke<'load-pack-meta'>;
-      savePackMeta: IpcInvoke<'save-pack-meta'>;
-      addTexture: IpcInvoke<'add-texture'>;
-      listTextures: IpcInvoke<'list-textures'>;
-      getTexturePath: IpcInvoke<'get-texture-path'>;
-      getTextureUrl: IpcInvoke<'get-texture-url'>;
-      createAtlas: IpcInvoke<'create-atlas'>;
-      randomizeIcon: IpcInvoke<'randomize-icon'>;
-      savePackIcon: IpcInvoke<'save-pack-icon'>;
-      exportProject: IpcInvoke<'export-project'>;
-      exportProjects: IpcInvoke<'export-projects'>;
-      openProjectFolder: IpcInvoke<'open-project-folder'>;
-      openInFolder: IpcInvoke<'open-in-folder'>;
-      openFile: IpcInvoke<'open-file'>;
-      readFile: IpcInvoke<'read-file'>;
-      writeFile: IpcInvoke<'write-file'>;
-      saveRevision: IpcInvoke<'save-revision'>;
-      listRevisions: IpcInvoke<'list-revisions'>;
-      restoreRevision: IpcInvoke<'restore-revision'>;
-      renameFile: IpcInvoke<'rename-file'>;
-      deleteFile: IpcInvoke<'delete-file'>;
-      editTexture: IpcInvoke<'edit-texture'>;
-      watchProject: IpcInvoke<'watch-project'>;
-      unwatchProject: IpcInvoke<'unwatch-project'>;
-      getNoExport: IpcInvoke<'get-no-export'>;
-      setNoExport: IpcInvoke<'set-no-export'>;
-      getEditorLayout: IpcInvoke<'get-editor-layout'>;
-      setEditorLayout: IpcInvoke<'set-editor-layout'>;
-      getTextureEditor: IpcInvoke<'get-texture-editor'>;
-      setTextureEditor: IpcInvoke<'set-texture-editor'>;
-      getTheme: IpcInvoke<'get-theme'>;
-      setTheme: IpcInvoke<'set-theme'>;
-      getConfetti: IpcInvoke<'get-confetti'>;
-      setConfetti: IpcInvoke<'set-confetti'>;
-      getDefaultExportDir: IpcInvoke<'get-default-export-dir'>;
-      setDefaultExportDir: IpcInvoke<'set-default-export-dir'>;
-      getProjectSort: IpcInvoke<'get-project-sort'>;
-      setProjectSort: IpcInvoke<'set-project-sort'>;
-      getAssetSearch: IpcInvoke<'get-asset-search'>;
-      setAssetSearch: IpcInvoke<'set-asset-search'>;
-      getAssetFilters: IpcInvoke<'get-asset-filters'>;
-      setAssetFilters: IpcInvoke<'set-asset-filters'>;
-      getAssetZoom: IpcInvoke<'get-asset-zoom'>;
-      setAssetZoom: IpcInvoke<'set-asset-zoom'>;
-      getOpenLastProject: IpcInvoke<'get-open-last-project'>;
-      setOpenLastProject: IpcInvoke<'set-open-last-project'>;
-      getLastProject: IpcInvoke<'get-last-project'>;
-      setLastProject: IpcInvoke<'set-last-project'>;
-      log: IpcInvoke<'log'>;
-      openExternalEditor: IpcInvoke<'open-external-editor'>;
-      onOpenProject: IpcListener<'project-opened'>;
-      onFileAdded: IpcListener<'file-added'>;
-      onFileRemoved: IpcListener<'file-removed'>;
-      onFileRenamed: IpcListener<'file-renamed'>;
-      onFileChanged: IpcListener<'file-changed'>;
-    };
+    electronAPI?: IpcApi;
   }
 }
 /* c8 ignore end */

--- a/src/shared/ipc/generateApi.ts
+++ b/src/shared/ipc/generateApi.ts
@@ -1,0 +1,15 @@
+import type { IpcRequestMap, IpcResponseMap, IpcEventMap } from './types';
+
+type CamelCase<S extends string> = S extends `${infer P}-${infer R}`
+  ? `${P}${Capitalize<CamelCase<R>>}`
+  : S;
+
+export type IpcApi = {
+  [C in keyof IpcRequestMap as CamelCase<C & string>]: (
+    ...args: IpcRequestMap[C]
+  ) => Promise<IpcResponseMap[C]>;
+} & {
+  [E in keyof IpcEventMap as `on${Capitalize<CamelCase<E & string>>}`]: (
+    listener: (event: unknown, data: IpcEventMap[E]) => void
+  ) => () => void;
+};


### PR DESCRIPTION
## Summary
- generate new `IpcApi` mapped type with camel‑case conversion
- expose `IpcApi` in global window typings
- rewrite preload to generate API proxy dynamically
- update renderer and tests to new names
- adjust ipc type tests for the new API

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6855af5cf6848331ae1eceaa0e592dd1