### PR TITLE
Fix image module typing

### DIFF
--- a/src/declaration.d.ts
+++ b/src/declaration.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const value: string;
+  export default value;
+}

--- a/src/renderer/components/project/ProjectInfoPanel.tsx
+++ b/src/renderer/components/project/ProjectInfoPanel.tsx
@@ -4,8 +4,6 @@ import path from 'path';
 import type { PackMeta } from '../../../main/projects';
 import { Button } from '../daisy/actions';
 import { PackMetaForm } from '../modals/PackMetaModal';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - webpack replaces import with URL string
 import defaultIcon from '../../../../resources/default_pack.png';
 
 import { useAppStore } from '../../store';
@@ -55,8 +53,7 @@ export default function ProjectInfoPanel({ onExport }: Props) {
             alt="Pack icon"
             className="w-24 h-24"
             onError={(e) => {
-              (e.currentTarget as HTMLImageElement).src =
-                defaultIcon as unknown as string;
+              (e.currentTarget as HTMLImageElement).src = defaultIcon;
             }}
           />
           <h2 className="card-title text-lg font-display">{name}</h2>

--- a/src/renderer/components/project/ProjectRow.tsx
+++ b/src/renderer/components/project/ProjectRow.tsx
@@ -6,8 +6,6 @@ import {
   DocumentDuplicateIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - webpack replaces import with URL string
 import defaultPack from '../../../../resources/default_pack.png';
 import ProjectContextMenu from './ProjectContextMenu';
 import type { ProjectInfo } from './ProjectTable';
@@ -108,11 +106,7 @@ export default function ProjectRow({
         />
       </td>
       <td className="flex items-center gap-2">
-        <img
-          src={defaultPack as unknown as string}
-          alt="Pack icon"
-          className="w-6 h-6"
-        />
+        <img src={defaultPack} alt="Pack icon" className="w-6 h-6" />
         {project.name}
       </td>
       <td>{project.version}</td>

--- a/src/renderer/views/AboutView.tsx
+++ b/src/renderer/views/AboutView.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import pkg from '../../../package.json';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore - webpack replaces import with URL string
 import iconPath from '../../../resources/icon.png';
 import ExternalLink from '../components/common/ExternalLink';
 export default function AboutView() {
@@ -11,7 +9,7 @@ export default function AboutView() {
       data-testid="about"
     >
       <img
-        src={iconPath as unknown as string}
+        src={iconPath}
         style={{ imageRendering: 'pixelated' }}
         alt="App logo"
         className="w-32 h-32"


### PR DESCRIPTION
## Summary
- add TypeScript declaration for png imports
- use typed image modules in components
- remove cast workarounds

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685640877c9c8331addf153aac12a237