### PR TITLE
Fix zip slip in importer

### DIFF
--- a/__tests__/importZipTraversal.test.ts
+++ b/__tests__/importZipTraversal.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import archiver from 'archiver';
+import { v4 as uuid } from 'uuid';
+
+// eslint-disable-next-line no-var
+var showOpenDialogMock: ReturnType<typeof vi.fn>;
+
+vi.mock('electron', () => {
+  showOpenDialogMock = vi.fn();
+  return {
+    dialog: { showOpenDialog: showOpenDialogMock },
+    app: { getPath: () => os.tmpdir() },
+  };
+});
+
+import { importProject } from '../src/main/projects';
+
+const tmpDir = path.join(os.tmpdir(), `import-${uuid()}`);
+const baseDir = path.join(tmpDir, 'projects');
+const zipPath = path.join(tmpDir, 'pack.zip');
+
+beforeAll(async () => {
+  fs.mkdirSync(baseDir, { recursive: true });
+  await new Promise<void>((resolve, reject) => {
+    const output = fs.createWriteStream(zipPath);
+    const archive = archiver('zip');
+    output.on('close', resolve);
+    archive.on('error', reject);
+    archive.pipe(output);
+    archive.append('safe', { name: 'good.txt' });
+    archive.append('bad', { name: '../evil/steal.txt' });
+    archive.finalize();
+  });
+});
+
+afterAll(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('importProject path traversal', () => {
+  it('ignores paths outside the destination', async () => {
+    showOpenDialogMock.mockResolvedValue({
+      canceled: false,
+      filePaths: [zipPath],
+    });
+    await importProject(baseDir);
+    expect(fs.existsSync(path.join(baseDir, 'pack', 'good.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'evil', 'steal.txt'))).toBe(false);
+  });
+});

--- a/src/main/projects/importer.ts
+++ b/src/main/projects/importer.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { dialog } from 'electron';
 import unzipper from 'unzipper';
+import { pipeline } from 'stream/promises';
 import {
   createDefaultProjectMeta,
   type ProjectMetadata,
@@ -20,29 +21,21 @@ export interface ImportSummary {
 
 async function extractZip(src: string, dest: string): Promise<number> {
   let count = 0;
-  await new Promise<void>((resolve, reject) => {
-    fs.createReadStream(src)
-      .pipe(unzipper.Parse())
-      .on('entry', (entry: unknown) => {
-        const e = entry as {
-          type: string;
-          path: string;
-          autodrain(): void;
-          pipe(dest: fs.WriteStream): void;
-        };
-        const outPath = path.join(dest, e.path);
-        if (e.type === 'Directory') {
-          fs.mkdirSync(outPath, { recursive: true });
-          e.autodrain();
-        } else {
-          fs.mkdirSync(path.dirname(outPath), { recursive: true });
-          e.pipe(fs.createWriteStream(outPath));
-          count++;
-        }
-      })
-      .on('close', resolve)
-      .on('error', reject);
-  });
+  const directory = await unzipper.Open.file(src);
+  for (const e of directory.files) {
+    const outPath = path.resolve(dest, e.path);
+    if (!outPath.startsWith(dest)) {
+      // ignore zip slip entries
+      continue;
+    }
+    if (e.type === 'Directory') {
+      await fs.promises.mkdir(outPath, { recursive: true });
+    } else {
+      await fs.promises.mkdir(path.dirname(outPath), { recursive: true });
+      await pipeline(e.stream(), fs.createWriteStream(outPath));
+      count++;
+    }
+  }
   return count;
 }
 


### PR DESCRIPTION
## Summary
- prevent path traversal when extracting zips
- extract zip entries asynchronously
- add regression test for malicious paths

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run dev:headless` (terminated after startup)

------
https://chatgpt.com/codex/tasks/task_e_68564051c4c083319832426ad2ca9bd5