### PR TITLE
Remove unused AssetBrowser prop

### DIFF
--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -11,10 +11,6 @@ import AssetBrowserControls, {
 } from './AssetBrowserControls';
 import AssetCategorySection from './AssetCategorySection';
 
-interface Props {
-  onSelectionChange?: (sel: string[]) => void;
-}
-
 const normalizeForCategory = (file: string) => {
   const texIdx = file.indexOf('textures/');
   if (texIdx >= 0) return file.slice(texIdx + 'textures/'.length);
@@ -108,7 +104,7 @@ const BrowserBody: React.FC<{
   );
 };
 
-const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
+const AssetBrowser: React.FC = () => {
   const projectPath = useAppStore((s) => s.projectPath)!;
   const { files, noExport, versions } = useProjectFiles();
   React.useEffect(() => {
@@ -116,8 +112,6 @@ const AssetBrowser: React.FC<Props> = ({ onSelectionChange }) => {
   }, [noExport]);
   const renameTarget = useAppStore((s) => s.renameTarget);
   const moveTarget = useAppStore((s) => s.moveTarget);
-  const openRename = useAppStore((s) => s.openRename);
-  const openMove = useAppStore((s) => s.openMove);
   const closeDialogs = useAppStore((s) => s.closeDialogs);
   const [query, setQuery] = useState('');
   const [zoom, setZoom] = useState(64);

--- a/src/renderer/components/editor/AssetBrowserTab.tsx
+++ b/src/renderer/components/editor/AssetBrowserTab.tsx
@@ -23,7 +23,6 @@ interface Props {
 
 export default function AssetBrowserTab({ onExport }: Props) {
   const selected = useAppStore((s) => s.selectedAssets);
-  const setSelected = useAppStore((s) => s.setSelectedAssets);
   const [selectorAsset, setSelectorAsset] = useState<string | null>(null);
   const [layout, setLayout] = useState<number[]>([20, 80]);
   const [selectorOpen, setSelectorOpen] = useState(false);
@@ -85,7 +84,7 @@ export default function AssetBrowserTab({ onExport }: Props) {
           <PanelGroup direction="vertical" className="h-full">
             <Panel defaultSize={70} className="overflow-y-auto">
               <Suspense fallback={<Skeleton width="100%" height="8rem" />}>
-                <AssetBrowser onSelectionChange={setSelected} />
+                <AssetBrowser />
               </Suspense>
             </Panel>
             <PanelResizeHandle className="flex items-center" tagName="div">


### PR DESCRIPTION
## Summary
- remove `onSelectionChange` from `AssetBrowser`
- drop unused `openRename`/`openMove` selectors in `AssetBrowser`
- update `AssetBrowserTab` accordingly

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6856415267548331a16d36e85821a912