### PR TITLE
Log errors from main modules

### DIFF
--- a/__tests__/projectMetaSafe.test.ts
+++ b/__tests__/projectMetaSafe.test.ts
@@ -1,15 +1,25 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { v4 as uuid } from 'uuid';
-import { readProjectMetaSafe, writeProjectMeta } from '../src/main/projectMeta';
+
+const errorMock = vi.fn();
+vi.mock('../src/main/logger', () => ({
+  default: { error: errorMock, info: vi.fn() },
+}));
+
+let readProjectMetaSafe: typeof import('../src/main/projectMeta').readProjectMetaSafe;
+let writeProjectMeta: typeof import('../src/main/projectMeta').writeProjectMeta;
 
 const tmpDir = path.join(os.tmpdir(), `meta-${uuid()}`);
 const projDir = path.join(tmpDir, 'proj');
 
-beforeAll(() => {
+beforeAll(async () => {
   fs.mkdirSync(projDir, { recursive: true });
+  ({ readProjectMetaSafe, writeProjectMeta } = await import(
+    '../src/main/projectMeta'
+  ));
 });
 
 afterAll(() => {
@@ -33,5 +43,14 @@ describe('readProjectMetaSafe', () => {
     const meta = await readProjectMetaSafe(projDir);
     expect(meta?.name).toBe('Test');
     expect(meta?.minecraft_version).toBe('1.20');
+  });
+
+  it('logs when metadata is invalid', async () => {
+    fs.writeFileSync(path.join(projDir, 'project.json'), '{ bad');
+    const meta = await readProjectMetaSafe(projDir);
+    expect(meta).toBeUndefined();
+    expect(errorMock).toHaveBeenCalledWith(
+      expect.stringContaining(path.join(projDir, 'project.json'))
+    );
   });
 });

--- a/__tests__/setActiveProject.test.ts
+++ b/__tests__/setActiveProject.test.ts
@@ -3,13 +3,18 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { v4 as uuid } from 'uuid';
-import { setActiveProject } from '../src/main/assets/protocols';
 import * as cache from '../src/main/assets/cache';
+let setActiveProject: typeof import('../src/main/assets/protocols').setActiveProject;
+const errorMock = vi.fn();
+vi.mock('../src/main/logger', () => ({
+  default: { error: errorMock, info: vi.fn() },
+}));
 
 const baseDir = path.join(os.tmpdir(), `active-${uuid()}`);
 
-beforeAll(() => {
+beforeAll(async () => {
   fs.mkdirSync(baseDir, { recursive: true });
+  ({ setActiveProject } = await import('../src/main/assets/protocols'));
 });
 
 afterAll(() => {
@@ -25,5 +30,6 @@ describe('setActiveProject', () => {
     const ok = await setActiveProject(proj);
     expect(ok).toBe(false);
     expect(ensure).not.toHaveBeenCalled();
+    expect(errorMock).toHaveBeenCalledWith(expect.stringContaining(proj));
   });
 });

--- a/src/main/assets/protocols.ts
+++ b/src/main/assets/protocols.ts
@@ -10,6 +10,7 @@ import type { Protocol } from 'electron';
 
 import { readProjectMetaSafe } from '../projectMeta';
 import { ensureAssets } from './cache';
+import logger from '../logger';
 
 let cacheTexturesDir = '';
 let activeProjectDir = '';
@@ -59,7 +60,8 @@ export async function setActiveProject(projectPath: string): Promise<boolean> {
     );
     activeProjectDir = projectPath;
     return true;
-  } catch {
+  } catch (e) {
+    logger.error(`Failed to set active project at ${projectPath}: ${e}`);
     return false;
   }
 }

--- a/src/main/noExport.ts
+++ b/src/main/noExport.ts
@@ -1,12 +1,14 @@
 /* c8 ignore start */
 import type { IpcMain } from 'electron';
 import { readProjectMeta, writeProjectMeta } from './projectMeta';
+import logger from './logger';
 
 export async function getNoExport(projectPath: string): Promise<string[]> {
   try {
     const meta = await readProjectMeta(projectPath);
     return meta.noExport ?? [];
-  } catch {
+  } catch (e) {
+    logger.error(`Failed to read noExport from ${projectPath}: ${e}`);
     return [];
   }
 }

--- a/src/main/projectMeta.ts
+++ b/src/main/projectMeta.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { ProjectMetadata, ProjectMetadataSchema } from '../shared/project';
+import logger from './logger';
 
 /** Read and parse the project.json metadata for a project. */
 export async function readProjectMeta(
@@ -20,7 +21,10 @@ export async function readProjectMetaSafe(
 ): Promise<ProjectMetadata | undefined> {
   try {
     return await readProjectMeta(projectPath);
-  } catch {
+  } catch (e) {
+    logger.error(
+      `Failed to parse ${path.join(projectPath, 'project.json')}: ${e}`
+    );
     return undefined;
   }
 }

--- a/src/main/projects/importer.ts
+++ b/src/main/projects/importer.ts
@@ -11,6 +11,7 @@ import {
 } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
 import { versionForFormat } from '../../shared/packFormat';
+import logger from '../logger';
 
 export interface ImportSummary {
   name: string;
@@ -55,8 +56,8 @@ async function detectVersion(dir: string): Promise<string | null> {
     if (typeof fmt === 'number') {
       return versionForFormat(fmt);
     }
-  } catch {
-    /* ignore */
+  } catch (e) {
+    logger.error(`Failed to parse ${mcmeta}: ${e}`);
   }
   return null;
 }
@@ -81,7 +82,10 @@ export async function importProject(
   if (fs.existsSync(path.join(dest, 'project.json'))) {
     try {
       meta = await readProjectMeta(dest);
-    } catch {
+    } catch (e) {
+      logger.error(
+        `Failed to parse ${path.join(dest, 'project.json')} during import: ${e}`
+      );
       meta = createDefaultProjectMeta(name, version);
     }
   } else {

--- a/src/main/projects/manager.ts
+++ b/src/main/projects/manager.ts
@@ -9,6 +9,7 @@ import {
   type ProjectMetadata,
 } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
+import logger from '../logger';
 
 export interface ProjectInfo {
   name: string;
@@ -54,7 +55,8 @@ export async function listProjects(baseDir: string): Promise<ProjectInfo[]> {
           lastOpened: meta.lastOpened ?? 0,
         });
         continue;
-      } catch {
+      } catch (e) {
+        logger.error(`listProjects failed for ${name}: ${e}`);
         // ignore malformed metadata
       }
     }
@@ -75,7 +77,10 @@ export async function openProject(
       const meta = await readProjectMeta(projectPath);
       meta.lastOpened = Date.now();
       await writeProjectMeta(projectPath, meta);
-    } catch {
+    } catch (e) {
+      logger.error(
+        `Failed to update ${path.join(projectPath, 'project.json')}: ${e}`
+      );
       // ignore corrupted metadata
     }
   }
@@ -95,7 +100,13 @@ export async function duplicateProject(
       const meta = await readProjectMeta(dest);
       meta.name = newName;
       await writeProjectMeta(dest, meta);
-    } catch {
+    } catch (e) {
+      logger.error(
+        `Failed to update duplicated project metadata ${path.join(
+          dest,
+          'project.json'
+        )}: ${e}`
+      );
       // ignore malformed metadata
     }
   }
@@ -114,8 +125,13 @@ export async function renameProject(
       const meta = await readProjectMeta(dest);
       meta.name = newName;
       await writeProjectMeta(dest, meta);
-    } catch {
-      /* ignore */
+    } catch (e) {
+      logger.error(
+        `Failed to update renamed project metadata ${path.join(
+          dest,
+          'project.json'
+        )}: ${e}`
+      );
     }
   }
 }

--- a/src/main/projects/meta.ts
+++ b/src/main/projects/meta.ts
@@ -6,6 +6,7 @@ import path from 'path';
 import type { PackMeta, ProjectMetadata } from '../../shared/project';
 import { PackMetaSchema, createDefaultProjectMeta } from '../../shared/project';
 import { readProjectMeta, writeProjectMeta } from '../projectMeta';
+import logger from '../logger';
 
 export async function loadPackMeta(
   baseDir: string,
@@ -16,7 +17,13 @@ export async function loadPackMeta(
     try {
       const meta = await readProjectMeta(projectPath);
       return PackMetaSchema.parse(meta);
-    } catch {
+    } catch (e) {
+      logger.error(
+        `Failed to load pack metadata from ${path.join(
+          projectPath,
+          'project.json'
+        )}: ${e}`
+      );
       // ignore malformed data
     }
   }
@@ -40,8 +47,13 @@ export async function savePackMeta(
   if (fs.existsSync(path.join(projectPath, 'project.json'))) {
     try {
       data = await readProjectMeta(projectPath);
-    } catch {
-      /* ignore */
+    } catch (e) {
+      logger.error(
+        `Failed to read existing metadata from ${path.join(
+          projectPath,
+          'project.json'
+        )}: ${e}`
+      );
     }
   }
   if (!data) {

--- a/src/main/revision.ts
+++ b/src/main/revision.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import logger from './logger';
 
 /** Save the current version of a file into the project's .history folder */
 export async function saveRevision(
@@ -33,7 +34,8 @@ export async function listRevisions(
   try {
     const list = await fs.promises.readdir(histDir);
     return list.sort().reverse();
-  } catch {
+  } catch (e) {
+    logger.error(`Failed to list revisions in ${histDir}: ${e}`);
     return [];
   }
 }

--- a/src/renderer/components/assets/AssetInfo.tsx
+++ b/src/renderer/components/assets/AssetInfo.tsx
@@ -74,7 +74,8 @@ export default function AssetInfo({ asset, count = 1 }: Props) {
     if (isJson) {
       try {
         JSON.parse(text);
-      } catch {
+      } catch (e) {
+        window.electronAPI?.log('error', `AssetInfo invalid JSON: ${e}`);
         setError('Invalid JSON');
         toast({ message: 'Invalid JSON', type: 'error' });
         return;

--- a/src/renderer/components/assets/MinecraftModelPreview.tsx
+++ b/src/renderer/components/assets/MinecraftModelPreview.tsx
@@ -124,7 +124,8 @@ function useMinecraftModel(
       });
 
       if (!elements.length) throw new Error('No elements array');
-    } catch {
+    } catch (e) {
+      window.electronAPI?.log('error', `Model preview failed: ${e}`);
       const tex = loader.load(getTexture(modelType, ''));
       tex.magFilter = THREE.NearestFilter;
       tex.minFilter = THREE.NearestFilter;

--- a/src/renderer/components/modals/PackMetaModal.tsx
+++ b/src/renderer/components/modals/PackMetaModal.tsx
@@ -58,7 +58,8 @@ export function PackMetaForm({
           };
           const parsed = PackMetaSchema.parse(data);
           onSave({ ...parsed, updated: Date.now() });
-        } catch {
+        } catch (e) {
+          window.electronAPI?.log('error', `PackMetaModal parse failed: ${e}`);
           toast({ message: 'Invalid metadata', type: 'error' });
         }
       }}


### PR DESCRIPTION
## Summary
- reuse `logger` in main modules
- log caught errors with context
- extend tests for metadata reading and active project

## Testing
- `npm run format`
- `npm run lint` (with warnings)
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68564074c51c83319ae7ba048d5fc206