### PR TITLE
Extract BrowserBody component

### DIFF
--- a/__tests__/BrowserBody.test.tsx
+++ b/__tests__/BrowserBody.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import BrowserBody from '../src/renderer/components/assets/BrowserBody';
+import { useAppStore } from '../src/renderer/store';
+
+describe('BrowserBody', () => {
+  it('renders categories and file tree', () => {
+    useAppStore.setState({ selectedAssets: [] });
+    render(
+      <BrowserBody
+        projectPath="/proj"
+        files={[
+          'assets/minecraft/textures/block/stone.png',
+          'lang/en_us.json',
+        ]}
+        versions={{}}
+        zoom={64}
+        onControlsChange={() => {}}
+      />
+    );
+    expect(screen.getByRole('heading', { name: 'blocks' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'lang' })).toBeInTheDocument();
+    expect(screen.getByTestId('file-tree')).toBeInTheDocument();
+  });
+});

--- a/__tests__/BrowserBody.test.tsx
+++ b/__tests__/BrowserBody.test.tsx
@@ -10,10 +10,7 @@ describe('BrowserBody', () => {
     render(
       <BrowserBody
         projectPath="/proj"
-        files={[
-          'assets/minecraft/textures/block/stone.png',
-          'lang/en_us.json',
-        ]}
+        files={['assets/minecraft/textures/block/stone.png', 'lang/en_us.json']}
         versions={{}}
         zoom={64}
         onControlsChange={() => {}}

--- a/__tests__/category.test.ts
+++ b/__tests__/category.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeForCategory,
+  getCategory,
+  groupFilesByCategory,
+} from '../src/renderer/utils/category';
+
+describe('category utils', () => {
+  it('normalizes and categorizes paths', () => {
+    const file = 'assets/minecraft/textures/block/stone.png';
+    const norm = normalizeForCategory(file);
+    expect(getCategory(norm)).toBe('blocks');
+  });
+
+  it('groups files by category', () => {
+    const files = [
+      'assets/minecraft/textures/block/stone.png',
+      'assets/minecraft/textures/item/apple.png',
+      'lang/en_us.json',
+    ];
+    const grouped = groupFilesByCategory(files);
+    expect(grouped.blocks).toEqual([files[0]]);
+    expect(grouped.items).toEqual([files[1]]);
+    expect(grouped.lang).toEqual([files[2]]);
+  });
+});

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -1,108 +1,13 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import path from 'path';
 import RenameModal from '../modals/RenameModal';
 import MoveFileModal from '../modals/MoveFileModal';
 import { useProjectFiles } from '../file/useProjectFiles';
-import FileTree from './FileTree';
 import { useAppStore } from '../../store';
-import AssetBrowserControls, {
-  Filter,
-  ControlsState,
-} from './AssetBrowserControls';
-import AssetCategorySection from './AssetCategorySection';
+import type { Filter, ControlsState } from './AssetBrowserControls';
+import BrowserBody from './BrowserBody';
+import { normalizeForCategory, getCategory } from '../../utils/category';
 
-const normalizeForCategory = (file: string) => {
-  const texIdx = file.indexOf('textures/');
-  if (texIdx >= 0) return file.slice(texIdx + 'textures/'.length);
-  const soundIdx = file.indexOf('sounds/');
-  if (soundIdx >= 0) return file.slice(soundIdx);
-  const soundIdx2 = file.indexOf('sound/');
-  if (soundIdx2 >= 0) return file.slice(soundIdx2);
-  return file;
-};
-
-const getCategory = (name: string): Filter | 'misc' => {
-  if (name.startsWith('block/')) return 'blocks';
-  if (name.startsWith('item/')) return 'items';
-  if (name.startsWith('entity/')) return 'entity';
-  if (
-    name.startsWith('gui/') ||
-    name.startsWith('font/') ||
-    name.startsWith('misc/')
-  )
-    return 'ui';
-  if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
-  if (name.startsWith('lang/')) return 'lang';
-  return 'misc';
-};
-
-const BrowserBody: React.FC<{
-  projectPath: string;
-  visible: string[];
-  versions: Record<string, number>;
-  zoom: number;
-  onControlsChange: (state: ControlsState) => void;
-  categories: Record<Filter | 'misc', string[]>;
-}> = ({
-  projectPath,
-  visible,
-  versions,
-  zoom,
-  onControlsChange,
-  categories,
-}) => {
-  const selected = useAppStore((s) => s.selectedAssets);
-  const deleteFiles = useAppStore((s) => s.deleteFiles);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-
-  const handleDeleteSelected = () => {
-    deleteFiles(selected.map((s) => path.join(projectPath, s)));
-  };
-
-  return (
-    <div
-      data-testid="asset-browser"
-      ref={wrapperRef}
-      className="h-full overflow-y-auto"
-      onKeyDown={(e) => {
-        if (e.key === 'Delete' && selected.length > 0) {
-          e.preventDefault();
-          handleDeleteSelected();
-        }
-      }}
-      tabIndex={0}
-    >
-      <AssetBrowserControls onChange={onControlsChange} />
-      <div className="grid grid-cols-3 gap-4">
-        <div className="col-span-2">
-          {(
-            [
-              'blocks',
-              'items',
-              'entity',
-              'ui',
-              'audio',
-              'lang',
-              'misc',
-            ] as const
-          ).map((key) => (
-            <AssetCategorySection
-              key={key}
-              title={key}
-              files={categories[key]}
-              projectPath={projectPath}
-              versions={versions}
-              zoom={zoom}
-            />
-          ))}
-        </div>
-        <div>
-          <FileTree files={visible} versions={versions} />
-        </div>
-      </div>
-    </div>
-  );
-};
 
 const AssetBrowser: React.FC = () => {
   const projectPath = useAppStore((s) => s.projectPath)!;
@@ -131,23 +36,6 @@ const AssetBrowser: React.FC = () => {
     [files, query, filters]
   );
 
-  const categories = React.useMemo(() => {
-    const out: Record<Filter | 'misc', string[]> = {
-      blocks: [],
-      items: [],
-      entity: [],
-      ui: [],
-      audio: [],
-      lang: [],
-      misc: [],
-    };
-    for (const f of visible) {
-      const cat = getCategory(normalizeForCategory(f));
-      if (out[cat]) out[cat].push(f);
-      else out.misc.push(f);
-    }
-    return out;
-  }, [visible]);
 
   const handleControlsChange = (state: ControlsState) => {
     setQuery(state.query);
@@ -159,11 +47,10 @@ const AssetBrowser: React.FC = () => {
     <>
       <BrowserBody
         projectPath={projectPath}
-        visible={visible}
+        files={visible}
         versions={versions}
         zoom={zoom}
         onControlsChange={handleControlsChange}
-        categories={categories}
       />
       {renameTarget && (
         <RenameModal

--- a/src/renderer/components/assets/AssetBrowser.tsx
+++ b/src/renderer/components/assets/AssetBrowser.tsx
@@ -8,7 +8,6 @@ import type { Filter, ControlsState } from './AssetBrowserControls';
 import BrowserBody from './BrowserBody';
 import { normalizeForCategory, getCategory } from '../../utils/category';
 
-
 const AssetBrowser: React.FC = () => {
   const projectPath = useAppStore((s) => s.projectPath)!;
   const { files, noExport, versions } = useProjectFiles();
@@ -35,7 +34,6 @@ const AssetBrowser: React.FC = () => {
       }),
     [files, query, filters]
   );
-
 
   const handleControlsChange = (state: ControlsState) => {
     setQuery(state.query);

--- a/src/renderer/components/assets/AssetCategoryList.tsx
+++ b/src/renderer/components/assets/AssetCategoryList.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import TextureGrid, { TextureInfo } from './TextureGrid';
 import type { Filter } from './AssetSelectorControls';
+import { getCategory } from '../../utils/category';
 
 export const CATEGORY_KEYS = [
   'blocks',
@@ -11,19 +12,6 @@ export const CATEGORY_KEYS = [
   'misc',
 ] as const;
 
-export const getCategory = (name: string): Filter | 'misc' => {
-  if (name.startsWith('block/')) return 'blocks';
-  if (name.startsWith('item/')) return 'items';
-  if (name.startsWith('entity/')) return 'entity';
-  if (
-    name.startsWith('gui/') ||
-    name.startsWith('font/') ||
-    name.startsWith('misc/')
-  )
-    return 'ui';
-  if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
-  return 'misc';
-};
 
 interface Props {
   textures: TextureInfo[];

--- a/src/renderer/components/assets/AssetCategoryList.tsx
+++ b/src/renderer/components/assets/AssetCategoryList.tsx
@@ -12,7 +12,6 @@ export const CATEGORY_KEYS = [
   'misc',
 ] as const;
 
-
 interface Props {
   textures: TextureInfo[];
   zoom: number;
@@ -38,7 +37,10 @@ export default function AssetCategoryList({
       misc: [],
     };
     for (const tex of textures) {
-      const cat = getCategory(tex.name);
+      const cat = getCategory(tex.name) as Exclude<
+        ReturnType<typeof getCategory>,
+        'lang'
+      >;
       if (out[cat]) out[cat].push(tex);
       else out.misc.push(tex);
     }

--- a/src/renderer/components/assets/AssetSelector.tsx
+++ b/src/renderer/components/assets/AssetSelector.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react';
 import TextureTree from './TextureTree';
 import AssetSelectorControls, { Filter } from './AssetSelectorControls';
-import AssetCategoryList, { getCategory } from './AssetCategoryList';
+import AssetCategoryList from './AssetCategoryList';
+import { getCategory } from '../../utils/category';
 import { TextureInfo } from './TextureGrid';
 import { Button } from '../daisy/actions';
 import { useAppStore } from '../../store';

--- a/src/renderer/components/assets/BrowserBody.tsx
+++ b/src/renderer/components/assets/BrowserBody.tsx
@@ -1,0 +1,82 @@
+import React, { useRef } from 'react';
+import path from 'path';
+import { useAppStore } from '../../store';
+import AssetBrowserControls, { ControlsState } from './AssetBrowserControls';
+import AssetCategorySection from './AssetCategorySection';
+import FileTree from './FileTree';
+import { groupFilesByCategory } from '../../utils/category';
+
+interface Props {
+  projectPath: string;
+  files: string[];
+  versions: Record<string, number>;
+  zoom: number;
+  onControlsChange: (state: ControlsState) => void;
+}
+
+const BrowserBody: React.FC<Props> = ({
+  projectPath,
+  files,
+  versions,
+  zoom,
+  onControlsChange,
+}) => {
+  const selected = useAppStore((s) => s.selectedAssets);
+  const deleteFiles = useAppStore((s) => s.deleteFiles);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const handleDeleteSelected = () => {
+    deleteFiles(selected.map((s) => path.join(projectPath, s)));
+  };
+
+  const categories = React.useMemo(
+    () => groupFilesByCategory(files),
+    [files]
+  );
+
+  return (
+    <div
+      data-testid="asset-browser"
+      ref={wrapperRef}
+      className="h-full overflow-y-auto"
+      onKeyDown={(e) => {
+        if (e.key === 'Delete' && selected.length > 0) {
+          e.preventDefault();
+          handleDeleteSelected();
+        }
+      }}
+      tabIndex={0}
+    >
+      <AssetBrowserControls onChange={onControlsChange} />
+      <div className="grid grid-cols-3 gap-4">
+        <div className="col-span-2">
+          {(
+            [
+              'blocks',
+              'items',
+              'entity',
+              'ui',
+              'audio',
+              'lang',
+              'misc',
+            ] as const
+          ).map((key) => (
+            <AssetCategorySection
+              key={key}
+              title={key}
+              files={categories[key]}
+              projectPath={projectPath}
+              versions={versions}
+              zoom={zoom}
+            />
+          ))}
+        </div>
+        <div>
+          <FileTree files={files} versions={versions} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BrowserBody;

--- a/src/renderer/components/assets/BrowserBody.tsx
+++ b/src/renderer/components/assets/BrowserBody.tsx
@@ -29,10 +29,7 @@ const BrowserBody: React.FC<Props> = ({
     deleteFiles(selected.map((s) => path.join(projectPath, s)));
   };
 
-  const categories = React.useMemo(
-    () => groupFilesByCategory(files),
-    [files]
-  );
+  const categories = React.useMemo(() => groupFilesByCategory(files), [files]);
 
   return (
     <div

--- a/src/renderer/utils/category.ts
+++ b/src/renderer/utils/category.ts
@@ -1,0 +1,49 @@
+import type { Filter } from '../components/assets/AssetBrowserControls';
+
+/** Normalize a file path for category detection. */
+export const normalizeForCategory = (file: string): string => {
+  const texIdx = file.indexOf('textures/');
+  if (texIdx >= 0) return file.slice(texIdx + 'textures/'.length);
+  const soundIdx = file.indexOf('sounds/');
+  if (soundIdx >= 0) return file.slice(soundIdx);
+  const soundIdx2 = file.indexOf('sound/');
+  if (soundIdx2 >= 0) return file.slice(soundIdx2);
+  return file;
+};
+
+/** Determine the asset category from a normalized path. */
+export const getCategory = (name: string): Filter | 'misc' => {
+  if (name.startsWith('block/')) return 'blocks';
+  if (name.startsWith('item/')) return 'items';
+  if (name.startsWith('entity/')) return 'entity';
+  if (
+    name.startsWith('gui/') ||
+    name.startsWith('font/') ||
+    name.startsWith('misc/')
+  )
+    return 'ui';
+  if (name.startsWith('sound/') || name.startsWith('sounds/')) return 'audio';
+  if (name.startsWith('lang/')) return 'lang';
+  return 'misc';
+};
+
+/** Group a list of file paths by category. */
+export const groupFilesByCategory = (
+  files: string[]
+): Record<Filter | 'misc', string[]> => {
+  const out: Record<Filter | 'misc', string[]> = {
+    blocks: [],
+    items: [],
+    entity: [],
+    ui: [],
+    audio: [],
+    lang: [],
+    misc: [],
+  };
+  for (const f of files) {
+    const cat = getCategory(normalizeForCategory(f));
+    if (out[cat]) out[cat].push(f);
+    else out.misc.push(f);
+  }
+  return out;
+};


### PR DESCRIPTION
## Summary
- split inner BrowserBody from `AssetBrowser` into its own file
- centralize category helpers in `utils/category`
- update AssetBrowser, AssetSelector and AssetCategoryList to use new utils
- add unit tests for BrowserBody and category helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685647f83af88331a3f87eefe770aeb4