### PR TITLE
Reorder project sidebar

### DIFF
--- a/__tests__/ProjectManagerView.test.tsx
+++ b/__tests__/ProjectManagerView.test.tsx
@@ -279,4 +279,21 @@ describe('ProjectManagerView', () => {
     fireEvent.click(within(delModal).getByText('Delete'));
     expect(deleteProject).toHaveBeenCalledWith('Alpha');
   });
+
+  it('renders sidebar above the table', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const sidebar = screen.getByTestId('project-sidebar');
+    const table = screen.getByRole('table');
+    const position = sidebar.compareDocumentPosition(table);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('sidebar uses horizontal layout', async () => {
+    render(<ProjectManagerView />);
+    await screen.findAllByRole('button', { name: 'Open' });
+    const sidebar = screen.getByTestId('project-sidebar');
+    expect(sidebar).toHaveClass('flex-row');
+    expect(sidebar).toHaveClass('items-start');
+  });
 });

--- a/src/renderer/components/project/ProjectSidebar.tsx
+++ b/src/renderer/components/project/ProjectSidebar.tsx
@@ -22,7 +22,10 @@ export default function ProjectSidebar({
   }, [project]);
 
   return (
-    <aside data-testid="project-sidebar" className="w-80 p-4 bg-base-200">
+    <aside
+      data-testid="project-sidebar"
+      className="w-full p-4 bg-base-200 flex flex-row gap-4 items-start"
+    >
       {project ? (
         <>
           <h2 className="font-display text-lg mb-2">{project}</h2>

--- a/src/renderer/views/ProjectManagerView.tsx
+++ b/src/renderer/views/ProjectManagerView.tsx
@@ -120,7 +120,7 @@ const ProjectManagerView: React.FC = () => {
   });
 
   return (
-    <section className="flex gap-4 max-w-5xl mx-auto">
+    <section className="flex flex-col gap-4 max-w-5xl mx-auto">
       <div className="flex-1">
         <div className="flex items-center mb-2 gap-2">
           <h2 className="font-display text-xl flex-1">Projects</h2>
@@ -148,6 +148,7 @@ const ProjectManagerView: React.FC = () => {
           onBulkExport={handleBulkExport}
           disableExport={selected.size === 0}
         />
+        <ProjectSidebar project={activeProject} />
         <ProjectTable
           projects={sortedProjects}
           sortKey={sortKey}
@@ -175,7 +176,6 @@ const ProjectManagerView: React.FC = () => {
         )}
         <ProjectModals refresh={refresh} toast={toast} />
       </div>
-      <ProjectSidebar project={activeProject} />
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- arrange sidebar above table in ProjectManagerView
- switch sidebar to horizontal layout
- ensure flex-col container
- cover sidebar order and class expectations with tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6856584ff5188331aeb5517351632f60