### PR TITLE
Add editor tab wrapper views

### DIFF
--- a/__tests__/editorViews.test.tsx
+++ b/__tests__/editorViews.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SetPath } from './test-utils';
+import BrowserView from '../src/renderer/views/editor/BrowserView';
+import TextureLabView from '../src/renderer/views/editor/TextureLabView';
+import ExporterView from '../src/renderer/views/editor/ExporterView';
+
+vi.mock('../src/renderer/components/editor/AssetBrowserTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="asset-browser-tab" />,
+}));
+vi.mock('../src/renderer/components/editor/TextureLabTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="texture-lab-view" />,
+}));
+vi.mock('../src/renderer/components/editor/ExporterTab', () => ({
+  __esModule: true,
+  default: () => <div data-testid="exporter-tab" />,
+}));
+
+describe('Editor tab views', () => {
+  it('renders AssetBrowserTab', () => {
+    render(
+      <MemoryRouter>
+        <SetPath path="/proj">
+          <BrowserView onExport={() => {}} />
+        </SetPath>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('asset-browser-tab')).toBeInTheDocument();
+  });
+
+  it('renders TextureLabTab', () => {
+    render(
+      <MemoryRouter>
+        <SetPath path="/proj">
+          <TextureLabView />
+        </SetPath>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('texture-lab-view')).toBeInTheDocument();
+  });
+
+  it('renders ExporterTab', () => {
+    render(
+      <MemoryRouter>
+        <SetPath path="/proj">
+          <ExporterView onExport={() => {}} />
+        </SetPath>
+      </MemoryRouter>
+    );
+    expect(screen.getByTestId('exporter-tab')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/views/EditorView.tsx
+++ b/src/renderer/views/EditorView.tsx
@@ -5,11 +5,7 @@ import ExportWizardModal, {
 } from '../components/modals/ExportWizardModal';
 import type { ExportSummary } from '../../main/exporter';
 import { useAppStore } from '../store';
-import {
-  AssetBrowserTab,
-  TextureLabTab,
-  ExporterTab,
-} from '../components/editor';
+import { BrowserView, TextureLabView, ExporterView } from './editor';
 import Tab from '../components/daisy/navigation/Tab';
 
 export default function EditorView() {
@@ -74,9 +70,9 @@ export default function EditorView() {
           Exporter
         </Tab>
       </div>
-      {mode === 'browser' && <AssetBrowserTab onExport={handleExport} />}
-      {mode === 'lab' && <TextureLabTab />}
-      {mode === 'exporter' && <ExporterTab onExport={handleExport} />}
+      {mode === 'browser' && <BrowserView onExport={handleExport} />}
+      {mode === 'lab' && <TextureLabView />}
+      {mode === 'exporter' && <ExporterView onExport={handleExport} />}
       {(progress || summary) && (
         <ExportWizardModal
           progress={progress ?? undefined}

--- a/src/renderer/views/editor/BrowserView.tsx
+++ b/src/renderer/views/editor/BrowserView.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { AssetBrowserTab } from '../../components/editor';
+
+export default function BrowserView({ onExport }: { onExport: () => void }) {
+  return <AssetBrowserTab onExport={onExport} />;
+}

--- a/src/renderer/views/editor/ExporterView.tsx
+++ b/src/renderer/views/editor/ExporterView.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { ExporterTab } from '../../components/editor';
+
+export default function ExporterView({ onExport }: { onExport: () => void }) {
+  return <ExporterTab onExport={onExport} />;
+}

--- a/src/renderer/views/editor/TextureLabView.tsx
+++ b/src/renderer/views/editor/TextureLabView.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { TextureLabTab } from '../../components/editor';
+
+export default function TextureLabView() {
+  return <TextureLabTab />;
+}

--- a/src/renderer/views/editor/index.ts
+++ b/src/renderer/views/editor/index.ts
@@ -1,0 +1,3 @@
+export { default as BrowserView } from './BrowserView';
+export { default as TextureLabView } from './TextureLabView';
+export { default as ExporterView } from './ExporterView';


### PR DESCRIPTION
## Summary
- add BrowserView, TextureLabView and ExporterView under `views/editor`
- update `EditorView` to use new wrapper views
- add tests for the new views

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685656fed7208331a9fec5ac09ca001d